### PR TITLE
fix: close live and security integration gaps in platform port

### DIFF
--- a/src/open_range/chart/templates/deployments.yaml
+++ b/src/open_range/chart/templates/deployments.yaml
@@ -53,6 +53,15 @@ spec:
               value: {{ $val | quote }}
             {{- end }}
           {{- end }}
+          {{- if $svc.postStartCommand }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  {{- range $svc.postStartCommand }}
+                  - {{ . | quote }}
+                  {{- end }}
+          {{- end }}
           {{- if $svc.payloads }}
           volumeMounts:
             {{- range $svc.payloads }}

--- a/src/open_range/chart/templates/deployments.yaml
+++ b/src/open_range/chart/templates/deployments.yaml
@@ -70,6 +70,47 @@ spec:
               subPath: {{ .key }}
             {{- end }}
           {{- end }}
+        {{- if $svc.sidecars }}
+        {{- range $sidecar := $svc.sidecars }}
+        - name: {{ $sidecar.name }}
+          image: {{ $sidecar.image }}
+          {{- if $sidecar.command }}
+          command:
+            {{- range $sidecar.command }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if $sidecar.args }}
+          args:
+            {{- range $sidecar.args }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if $sidecar.ports }}
+          ports:
+            {{- range $sidecar.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+              protocol: {{ .protocol | default "TCP" }}
+            {{- end }}
+          {{- end }}
+          {{- if $sidecar.env }}
+          env:
+            {{- range $key, $val := $sidecar.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if $sidecar.payloads }}
+          volumeMounts:
+            {{- range $sidecar.payloads }}
+            - name: payloads
+              mountPath: {{ .mountPath }}
+              subPath: {{ .key }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- end }}
       {{- if $svc.payloads }}
       volumes:
         - name: payloads

--- a/src/open_range/cluster.py
+++ b/src/open_range/cluster.py
@@ -262,6 +262,7 @@ class KindBackend:
         chart_dir = artifacts_dir / "openrange"
         if not chart_dir.exists():
             chart_dir = artifacts_dir
+        self.validate_runtime_env(artifacts_dir)
         self.prepare_images(chart_dir)
         self._helm_install(release_name, chart_dir)
         pod_map = self._discover_pods(release_name)
@@ -312,6 +313,17 @@ class KindBackend:
     def prepare_images(self, chart_dir: Path) -> None:
         for image in self._chart_images(chart_dir):
             self._ensure_image_loaded(image)
+
+    def validate_runtime_env(self, artifacts_dir: Path) -> None:
+        chart_dir = artifacts_dir / "openrange"
+        if not chart_dir.exists():
+            chart_dir = artifacts_dir
+        if self._chart_requires_cilium(chart_dir) and not self._cilium_ready():
+            raise RuntimeError(
+                "rendered chart requires Cilium, but the live cluster does not have "
+                "a ready Cilium installation. Install Cilium first or render with "
+                "the default Kubernetes network-policy backend."
+            )
 
     @staticmethod
     def release_name_for(snapshot_id: str) -> str:
@@ -382,6 +394,48 @@ class KindBackend:
         collect("services")
         collect("sandboxes")
         return images
+
+    @staticmethod
+    def _chart_requires_cilium(chart_dir: Path) -> bool:
+        values_path = chart_dir / "values.yaml"
+        if not values_path.exists():
+            return False
+        values = yaml.safe_load(values_path.read_text(encoding="utf-8")) or {}
+        cilium = values.get("cilium", {})
+        return isinstance(cilium, dict) and bool(cilium.get("enabled"))
+
+    def _cilium_ready(self) -> bool:
+        try:
+            self._run(
+                [
+                    *self.kubectl_cmd,
+                    "get",
+                    "crd",
+                    "ciliumnetworkpolicies.cilium.io",
+                ],
+                timeout=10.0,
+            )
+            daemonset = self._run(
+                [
+                    *self.kubectl_cmd,
+                    "-n",
+                    "kube-system",
+                    "get",
+                    "daemonset",
+                    "cilium",
+                    "-o",
+                    "jsonpath={.status.numberReady}/{.status.desiredNumberScheduled}",
+                ],
+                timeout=10.0,
+            )
+        except RuntimeError:
+            return False
+
+        status = daemonset.stdout.strip()
+        if "/" not in status:
+            return False
+        ready, desired = status.split("/", 1)
+        return desired != "0" and ready == desired
 
     def _ensure_image_loaded(self, image: str) -> None:
         if not image:

--- a/src/open_range/identity_provider.py
+++ b/src/open_range/identity_provider.py
@@ -403,8 +403,8 @@ class SimulatedIdentityProvider:
     def generate_startup_script(self) -> str:
         """Generate a shell script that runs a minimal token endpoint.
 
-        The script is injected into the web/ldap container as a payload.
-        It serves:
+        The script is injected into the runtime as a payload and launched as a
+        dedicated long-running helper process. It serves:
           - ``POST /oauth/token`` (client_credentials grant)
           - ``GET /.well-known/jwks.json``
           - ``POST /oauth/introspect``
@@ -442,12 +442,11 @@ class SimulatedIdentityProvider:
         return textwrap.dedent(f"""\
             #!/bin/bash
             # OpenRange Identity Provider - Auto-generated token endpoint
-            # Launched as a background service inside the range container.
             set -e
 
             echo "[openrange-idp] Starting identity provider on port {port}..."
 
-            python3 /opt/openrange/identity_provider_server.py \\
+            exec python3 /opt/openrange/identity_provider_server.py \\
                 --port {port} \\
                 --issuer '{issuer}' \\
                 --ttl {ttl} \\
@@ -456,10 +455,7 @@ class SimulatedIdentityProvider:
                 --public-key-b64 '{pub_key_b64}' \\
                 --jwks '{jwks_json}' \\
                 --identities '{identities_json}' \\
-                --hmac-secret '{hmac_secret}' \\
-                &
-
-            echo "[openrange-idp] Identity provider started (PID $!)"
+                --hmac-secret '{hmac_secret}'
         """)
 
 

--- a/src/open_range/identity_provider.py
+++ b/src/open_range/identity_provider.py
@@ -10,6 +10,7 @@ This module is entirely optional -- open-range works without it.
 from __future__ import annotations
 
 import base64
+import fnmatch
 import hashlib
 import json
 import logging
@@ -304,6 +305,7 @@ class SimulatedIdentityProvider:
         self,
         token: str,
         expected_audience: str = "range-api",
+        required_scopes: list[str] | None = None,
     ) -> dict[str, Any] | None:
         """Validate a JWT.  Returns claims dict or ``None`` if invalid.
 
@@ -340,6 +342,12 @@ class SimulatedIdentityProvider:
                 if expected_audience:
                     kwargs["audience"] = expected_audience
                 claims = pyjwt.decode(token, key, **kwargs)
+                if (
+                    required_scopes
+                    and "missing_scope_check" not in self.config.weaknesses
+                    and not _scopes_satisfied(dict(claims), required_scopes)
+                ):
+                    continue
                 return dict(claims)
             except pyjwt.InvalidTokenError:
                 continue
@@ -514,3 +522,33 @@ def default_service_identities(
             ],
         ),
     }
+
+
+def _scope_claims(claims: dict[str, Any]) -> set[str]:
+    scopes: set[str] = set()
+
+    scope_claim = claims.get("scope")
+    if isinstance(scope_claim, str):
+        scopes.update(scope_claim.split())
+    elif isinstance(scope_claim, list):
+        scopes.update(str(item) for item in scope_claim)
+
+    scp_claim = claims.get("scp")
+    if isinstance(scp_claim, str):
+        scopes.update(scp_claim.split())
+    elif isinstance(scp_claim, list):
+        scopes.update(str(item) for item in scp_claim)
+
+    return scopes
+
+
+def _scopes_satisfied(claims: dict[str, Any], required_scopes: list[str]) -> bool:
+    granted_scopes = _scope_claims(claims)
+    for required_scope in required_scopes:
+        if not any(
+            granted_scope == required_scope
+            or fnmatch.fnmatchcase(required_scope, granted_scope)
+            for granted_scope in granted_scopes
+        ):
+            return False
+    return True

--- a/src/open_range/k3d_runner.py
+++ b/src/open_range/k3d_runner.py
@@ -73,10 +73,19 @@ class K3dBackend(KindBackend):
         self.k3d_cluster = kind_cluster
         self.k3d_agents = k3d_agents
         self.k3d_subnet = k3d_subnet
+        self.kubectl_cmd = resolve_kubectl_cmd(self.k3d_cluster)
 
     # ------------------------------------------------------------------
     # Cluster lifecycle
     # ------------------------------------------------------------------
+
+    def validate_runtime_env(self, artifacts_dir: Path) -> None:
+        if not self._cilium_ready():
+            raise RuntimeError(
+                "k3d live backend requires Cilium to be installed and ready on the "
+                "target cluster because the rendered k3d cluster disables flannel."
+            )
+        super().validate_runtime_env(artifacts_dir)
 
     def create_cluster(
         self,

--- a/src/open_range/pipeline.py
+++ b/src/open_range/pipeline.py
@@ -17,7 +17,11 @@ from open_range.compiler import EnterpriseSaaSManifestCompiler
 from open_range.k3d_renderer import K3dRenderer
 from open_range.manifest import EnterpriseSaaSManifest, validate_manifest
 from open_range.render import EnterpriseSaaSKindRenderer
-from open_range.security_integrator import SecurityIntegrator, SecurityIntegratorConfig
+from open_range.security_integrator import (
+    SecurityContext,
+    SecurityIntegrator,
+    SecurityIntegratorConfig,
+)
 from open_range.snapshot import KindArtifacts, Snapshot
 from open_range.store import FileSnapshotStore, PoolSplit
 from open_range.synth import EnterpriseSaaSWorldSynthesizer, SynthArtifacts
@@ -148,6 +152,12 @@ class BuildPipeline:
         if not context.generated_files:
             return artifacts
         chart_values = dict(artifacts.chart_values)
+        chart_values["services"] = self._integrate_security_payloads(
+            world,
+            chart_values.get("services", {}),
+            Path(artifacts.render_dir),
+            context,
+        )
         chart_values["security"] = context.model_dump(mode="json")
         return self._sync_artifacts(
             artifacts,
@@ -158,6 +168,139 @@ class BuildPipeline:
                 "security_integration_enabled": True,
             },
         )
+
+    def _integrate_security_payloads(
+        self,
+        world: WorldIR,
+        services: dict[str, Any],
+        render_dir: Path,
+        context: SecurityContext,
+    ) -> dict[str, Any]:
+        next_services = {name: dict(spec) for name, spec in services.items()}
+        security_dir = render_dir / "security"
+
+        idp_targets = [
+            service.id for service in world.services if service.kind == "idp"
+        ]
+        if context.identity_provider and idp_targets:
+            self._append_payloads(
+                next_services,
+                idp_targets[0],
+                [
+                    self._payload_entry(
+                        security_dir / "idp" / "config.json",
+                        "security-idp-config.json",
+                        "/etc/openrange/identity-provider.json",
+                    ),
+                    self._payload_entry(
+                        security_dir / "idp" / "startup.sh",
+                        "security-idp-startup.sh",
+                        "/opt/openrange/start_identity_provider.sh",
+                    ),
+                    self._payload_entry(
+                        security_dir / "idp" / "identity_provider_server.py",
+                        "security-idp-server.py",
+                        "/opt/openrange/identity_provider_server.py",
+                    ),
+                ],
+            )
+            next_services[idp_targets[0]]["postStartCommand"] = [
+                "/bin/sh",
+                "/opt/openrange/start_identity_provider.sh",
+            ]
+            self._append_port(
+                next_services,
+                idp_targets[0],
+                {
+                    "name": "idp-token",
+                    "port": int(
+                        context.identity_provider.get("token_endpoint_port", 8443)
+                    ),
+                },
+            )
+
+        if context.encryption:
+            encryption_payloads = [
+                self._payload_entry(
+                    security_dir / "encryption" / "config.json",
+                    "security-encryption-config.json",
+                    "/etc/openrange/encryption-config.json",
+                ),
+                self._payload_entry(
+                    security_dir / "encryption" / "wrapped_dek.json",
+                    "security-wrapped-dek.json",
+                    "/etc/openrange/wrapped_dek.json",
+                ),
+            ]
+            for service_id in next_services:
+                self._append_payloads(next_services, service_id, encryption_payloads)
+
+        mtls_services = context.mtls.get("mtls_services", [])
+        for service_id in mtls_services:
+            if service_id not in next_services:
+                continue
+            self._append_payloads(
+                next_services,
+                service_id,
+                [
+                    self._payload_entry(
+                        security_dir / "mtls" / service_id / "ca.pem",
+                        "security-mtls-ca.pem",
+                        "/etc/mtls/ca.pem",
+                    ),
+                    self._payload_entry(
+                        security_dir / "mtls" / service_id / "cert.pem",
+                        "security-mtls-cert.pem",
+                        "/etc/mtls/cert.pem",
+                    ),
+                    self._payload_entry(
+                        security_dir / "mtls" / service_id / "key.pem",
+                        "security-mtls-key.pem",
+                        "/etc/mtls/key.pem",
+                    ),
+                ],
+            )
+
+        return next_services
+
+    @staticmethod
+    def _append_payloads(
+        services: dict[str, Any], service_id: str, payloads: list[dict[str, str] | None]
+    ) -> None:
+        service = services.get(service_id)
+        if not isinstance(service, dict):
+            return
+        existing = list(service.get("payloads", []))
+        for payload in payloads:
+            if payload is None:
+                continue
+            existing.append(payload)
+        service["payloads"] = existing
+
+    @staticmethod
+    def _append_port(
+        services: dict[str, Any], service_id: str, port: dict[str, Any]
+    ) -> None:
+        service = services.get(service_id)
+        if not isinstance(service, dict):
+            return
+        existing = list(service.get("ports", []))
+        if any(item.get("port") == port["port"] for item in existing):
+            return
+        existing.append(port)
+        service["ports"] = existing
+
+    @staticmethod
+    def _payload_entry(
+        source_path: Path, key: str, mount_path: str
+    ) -> dict[str, str] | None:
+        if not source_path.exists():
+            return None
+        return {
+            "key": key,
+            "mountPath": mount_path,
+            "content": source_path.read_text(encoding="utf-8"),
+        }
 
     def _integrate_network_policies(
         self,

--- a/src/open_range/pipeline.py
+++ b/src/open_range/pipeline.py
@@ -204,10 +204,6 @@ class BuildPipeline:
                     ),
                 ],
             )
-            next_services[idp_targets[0]]["postStartCommand"] = [
-                "/bin/sh",
-                "/opt/openrange/start_identity_provider.sh",
-            ]
             self._append_port(
                 next_services,
                 idp_targets[0],
@@ -261,6 +257,25 @@ class BuildPipeline:
                 ],
             )
 
+        if context.identity_provider and idp_targets:
+            self._set_sidecars(
+                next_services,
+                idp_targets[0],
+                [
+                    {
+                        "name": "idp-helper",
+                        "image": next_services[idp_targets[0]].get("image"),
+                        "command": [
+                            "/bin/sh",
+                            "/opt/openrange/start_identity_provider.sh",
+                        ],
+                        "payloads": list(
+                            next_services[idp_targets[0]].get("payloads", [])
+                        ),
+                    }
+                ],
+            )
+
         return next_services
 
     @staticmethod
@@ -289,6 +304,15 @@ class BuildPipeline:
             return
         existing.append(port)
         service["ports"] = existing
+
+    @staticmethod
+    def _set_sidecars(
+        services: dict[str, Any], service_id: str, sidecars: list[dict[str, Any]]
+    ) -> None:
+        service = services.get(service_id)
+        if not isinstance(service, dict):
+            return
+        service["sidecars"] = sidecars
 
     @staticmethod
     def _payload_entry(

--- a/src/open_range/templates/identity_provider_server.py.tpl
+++ b/src/open_range/templates/identity_provider_server.py.tpl
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import fnmatch
 import hashlib
 import hmac
 import json
@@ -211,7 +212,41 @@ def issue_token(
     return _manual_jwt_hs256(claims, CONFIG["hmac_secret"], kid=kid)
 
 
-def validate_token(token: str, expected_audience: str = "range-api") -> dict[str, Any] | None:
+def _scope_claims(claims: dict[str, Any]) -> set[str]:
+    scopes: set[str] = set()
+
+    scope_claim = claims.get("scope")
+    if isinstance(scope_claim, str):
+        scopes.update(scope_claim.split())
+    elif isinstance(scope_claim, list):
+        scopes.update(str(item) for item in scope_claim)
+
+    scp_claim = claims.get("scp")
+    if isinstance(scp_claim, str):
+        scopes.update(scp_claim.split())
+    elif isinstance(scp_claim, list):
+        scopes.update(str(item) for item in scp_claim)
+
+    return scopes
+
+
+def _scopes_satisfied(claims: dict[str, Any], required_scopes: list[str]) -> bool:
+    granted_scopes = _scope_claims(claims)
+    for required_scope in required_scopes:
+        if not any(
+            granted_scope == required_scope
+            or fnmatch.fnmatchcase(required_scope, granted_scope)
+            for granted_scope in granted_scopes
+        ):
+            return False
+    return True
+
+
+def validate_token(
+    token: str,
+    expected_audience: str = "range-api",
+    required_scopes: list[str] | None = None,
+) -> dict[str, Any] | None:
     """Validate a JWT and return claims or None."""
     weaknesses = CONFIG["weaknesses"]
 
@@ -234,7 +269,14 @@ def validate_token(token: str, expected_audience: str = "range-api") -> dict[str
                 kwargs: dict[str, Any] = {"algorithms": algs, "options": options}
                 if expected_audience:
                     kwargs["audience"] = expected_audience
-                return dict(pyjwt.decode(token, key, **kwargs))
+                claims = dict(pyjwt.decode(token, key, **kwargs))
+                if (
+                    required_scopes
+                    and "missing_scope_check" not in weaknesses
+                    and not _scopes_satisfied(claims, required_scopes)
+                ):
+                    continue
+                return claims
             except Exception:
                 continue
         return None
@@ -256,6 +298,13 @@ def validate_token(token: str, expected_audience: str = "range-api") -> dict[str
             return None
         if isinstance(aud, list) and expected_audience not in aud:
             return None
+
+    if (
+        required_scopes
+        and "missing_scope_check" not in weaknesses
+        and not _scopes_satisfied(claims, required_scopes)
+    ):
+        return None
 
     return claims
 
@@ -405,13 +454,15 @@ class TokenHandler(BaseHTTPRequestHandler):
         body = self._read_body()
         params = dict(urllib.parse.parse_qsl(body.decode("utf-8", errors="replace")))
         token_str = params.get("token", "")
+        scope_str = params.get("scope", "")
+        required_scopes = scope_str.split() if scope_str else None
 
         if not token_str:
             self._send_json(400, {"error": "invalid_request",
                                   "detail": "missing token parameter"})
             return
 
-        claims = validate_token(token_str)
+        claims = validate_token(token_str, required_scopes=required_scopes)
         if claims is None:
             self._send_json(200, {"active": False})
             return

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from subprocess import CompletedProcess
+from pathlib import Path
 
 from open_range.async_utils import run_async
 from open_range.cluster import KindBackend, PodSet
 import open_range.cluster as cluster_mod
+import open_range.k3d_runner as k3d_mod
+from open_range.k3d_runner import K3dBackend
+import pytest
 
 
 class _FakeProc:
@@ -63,3 +67,83 @@ def test_kind_backend_discovers_pods_from_service_label(monkeypatch) -> None:
     }
     assert "labels['openrange/service']" in captured["args"][-1]
     assert captured["timeout"] == 30.0
+
+
+def test_kind_backend_requires_cilium_when_chart_requests_it(
+    tmp_path: Path, monkeypatch
+) -> None:
+    chart_dir = tmp_path / "openrange"
+    chart_dir.mkdir()
+    (chart_dir / "values.yaml").write_text(
+        "cilium:\n  enabled: true\n", encoding="utf-8"
+    )
+
+    backend = KindBackend()
+    monkeypatch.setattr(KindBackend, "_cilium_ready", lambda self: False)
+
+    with pytest.raises(RuntimeError, match="requires Cilium"):
+        backend.validate_runtime_env(tmp_path)
+
+
+def test_kind_backend_boot_validates_runtime_env_before_install(
+    tmp_path: Path, monkeypatch
+) -> None:
+    chart_dir = tmp_path / "openrange"
+    chart_dir.mkdir()
+    calls: list[tuple[str, object]] = []
+    backend = KindBackend()
+
+    monkeypatch.setattr(
+        KindBackend,
+        "validate_runtime_env",
+        lambda self, artifacts_dir: calls.append(("validate", artifacts_dir)),
+    )
+    monkeypatch.setattr(
+        KindBackend,
+        "prepare_images",
+        lambda self, live_chart_dir: calls.append(("prepare", live_chart_dir)),
+    )
+    monkeypatch.setattr(
+        KindBackend,
+        "_helm_install",
+        lambda self, release_name, live_chart_dir: calls.append(
+            ("helm", (release_name, live_chart_dir))
+        ),
+    )
+    monkeypatch.setattr(
+        KindBackend,
+        "_discover_pods",
+        lambda self, release_name: {"svc-web": "ns/svc-web-pod"},
+    )
+    monkeypatch.setattr(
+        KindBackend,
+        "wait_until_healthy",
+        lambda self, release, services: calls.append(("wait", tuple(services))),
+    )
+
+    backend.boot(snapshot_id="demo", artifacts_dir=tmp_path)
+
+    assert calls[0] == ("validate", tmp_path)
+    assert calls[1] == ("prepare", chart_dir)
+
+
+def test_k3d_backend_requires_ready_cilium_even_without_cilium_chart(
+    tmp_path: Path, monkeypatch
+) -> None:
+    chart_dir = tmp_path / "openrange"
+    chart_dir.mkdir()
+    (chart_dir / "values.yaml").write_text("services: {}\n", encoding="utf-8")
+
+    backend = K3dBackend()
+    monkeypatch.setattr(K3dBackend, "_cilium_ready", lambda self: False)
+
+    with pytest.raises(RuntimeError, match="requires Cilium"):
+        backend.validate_runtime_env(tmp_path)
+
+
+def test_k3d_backend_uses_k3d_context_when_kubectl_is_available(monkeypatch) -> None:
+    monkeypatch.setattr(k3d_mod.shutil, "which", lambda name: "/usr/bin/kubectl")
+
+    backend = K3dBackend(kind_cluster="openrange")
+
+    assert backend.kubectl_cmd == ("kubectl", "--context", "k3d-openrange")

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
+import subprocess
 
 from open_range._runtime_store import hydrate_runtime_snapshot
 import pytest
@@ -96,6 +98,59 @@ def test_build_config_can_enable_security_integration(tmp_path: Path):
         path.endswith("security/security-context.json")
         for path in candidate.artifacts.rendered_files
     )
+    idp_payloads = candidate.artifacts.chart_values["services"]["svc-idp"]["payloads"]
+    db_payloads = candidate.artifacts.chart_values["services"]["svc-db"]["payloads"]
+    idp_post_start = candidate.artifacts.chart_values["services"]["svc-idp"][
+        "postStartCommand"
+    ]
+
+    assert any(
+        payload["mountPath"] == "/opt/openrange/identity_provider_server.py"
+        for payload in idp_payloads
+    )
+    assert idp_post_start == ["/bin/sh", "/opt/openrange/start_identity_provider.sh"]
+    assert any(
+        port["port"] == 8443
+        for port in candidate.artifacts.chart_values["services"]["svc-idp"]["ports"]
+    )
+    assert any(
+        payload["mountPath"] == "/etc/openrange/wrapped_dek.json"
+        for payload in db_payloads
+    )
+    assert any(payload["mountPath"] == "/etc/mtls/cert.pem" for payload in db_payloads)
+
+
+def test_security_integration_renders_idp_runtime_hooks_with_helm(tmp_path: Path):
+    if shutil.which("helm") is None:
+        pytest.skip("helm is required for chart rendering checks")
+
+    pipeline = BuildPipeline(store=FileSnapshotStore(tmp_path / "snapshots"))
+    candidate = pipeline.build(
+        _manifest_payload(),
+        tmp_path / "rendered-security-template",
+        BuildConfig(
+            validation_profile="graph_only",
+            security_integration_enabled=True,
+            security_tier=3,
+        ),
+    )
+
+    rendered = subprocess.run(
+        [
+            "helm",
+            "template",
+            "or-demo",
+            candidate.artifacts.chart_dir,
+            "--values",
+            candidate.artifacts.values_path,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+    assert "containerPort: 8443" in rendered
+    assert "/opt/openrange/start_identity_provider.sh" in rendered
 
 
 def test_build_config_can_select_k3d_and_cilium_outputs(tmp_path: Path):

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -98,21 +98,25 @@ def test_build_config_can_enable_security_integration(tmp_path: Path):
         path.endswith("security/security-context.json")
         for path in candidate.artifacts.rendered_files
     )
-    idp_payloads = candidate.artifacts.chart_values["services"]["svc-idp"]["payloads"]
+    idp_service = candidate.artifacts.chart_values["services"]["svc-idp"]
+    idp_payloads = idp_service["payloads"]
     db_payloads = candidate.artifacts.chart_values["services"]["svc-db"]["payloads"]
-    idp_post_start = candidate.artifacts.chart_values["services"]["svc-idp"][
-        "postStartCommand"
-    ]
+    idp_sidecar = idp_service["sidecars"][0]
 
     assert any(
         payload["mountPath"] == "/opt/openrange/identity_provider_server.py"
         for payload in idp_payloads
     )
-    assert idp_post_start == ["/bin/sh", "/opt/openrange/start_identity_provider.sh"]
+    assert idp_sidecar["name"] == "idp-helper"
+    assert idp_sidecar["command"] == [
+        "/bin/sh",
+        "/opt/openrange/start_identity_provider.sh",
+    ]
     assert any(
-        port["port"] == 8443
-        for port in candidate.artifacts.chart_values["services"]["svc-idp"]["ports"]
+        payload["mountPath"] == "/opt/openrange/start_identity_provider.sh"
+        for payload in idp_sidecar["payloads"]
     )
+    assert any(port["port"] == 8443 for port in idp_service["ports"])
     assert any(
         payload["mountPath"] == "/etc/openrange/wrapped_dek.json"
         for payload in db_payloads
@@ -151,6 +155,7 @@ def test_security_integration_renders_idp_runtime_hooks_with_helm(tmp_path: Path
 
     assert "containerPort: 8443" in rendered
     assert "/opt/openrange/start_identity_provider.sh" in rendered
+    assert "name: idp-helper" in rendered
 
 
 def test_build_config_can_select_k3d_and_cilium_outputs(tmp_path: Path):

--- a/tests/test_identity_provider.py
+++ b/tests/test_identity_provider.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from open_range.identity_provider import (
+    IdentityProviderConfig,
+    ServiceIdentity,
+    SimulatedIdentityProvider,
+)
+
+
+def _idp(*, weaknesses: list[str] | None = None) -> SimulatedIdentityProvider:
+    return SimulatedIdentityProvider(
+        IdentityProviderConfig(
+            enabled=True,
+            weaknesses=[] if weaknesses is None else weaknesses,
+            service_identities={
+                "svc-web": ServiceIdentity(
+                    identity_uri="spiffe://range.local/ns/dmz/sa/svc-web",
+                    allowed_scopes=["data:read:patients/*"],
+                )
+            },
+        )
+    )
+
+
+def test_validate_token_accepts_required_scopes() -> None:
+    idp = _idp()
+
+    token = idp.issue_token(
+        "spiffe://range.local/ns/dmz/sa/svc-web",
+        ["data:read:patients/*"],
+    )
+
+    claims = idp.validate_token(
+        token,
+        required_scopes=["data:read:patients/42"],
+    )
+
+    assert claims is not None
+
+
+def test_validate_token_rejects_missing_required_scopes() -> None:
+    idp = _idp()
+
+    token = idp.issue_token(
+        "spiffe://range.local/ns/dmz/sa/svc-web",
+        ["data:read:patients/*"],
+    )
+
+    claims = idp.validate_token(
+        token,
+        required_scopes=["admin:write:*"],
+    )
+
+    assert claims is None
+
+
+def test_missing_scope_check_weakness_bypasses_scope_validation() -> None:
+    idp = _idp(weaknesses=["missing_scope_check"])
+
+    token = idp.issue_token(
+        "spiffe://range.local/ns/dmz/sa/svc-web",
+        ["data:read:patients/*"],
+    )
+
+    claims = idp.validate_token(
+        token,
+        required_scopes=["admin:write:*"],
+    )
+
+    assert claims is not None


### PR DESCRIPTION
## Summary

Tighten the v1-alignment stack with three small follow-up fixes:

- fail fast before live boot when the selected backend is missing required cluster prerequisites
- wire the generated security artifacts into rendered services so the IdP helper is actually mounted and started, and its port is exposed
- enforce required identity scopes during token validation unless the `missing_scope_check` weakness is explicitly enabled

## Why

The original port plus the alignment pass were close, but a few important edges were still soft:

- k3d/Cilium assumptions could fail late during live boot instead of surfacing as an explicit preflight error
- security artifacts were generated, but not fully connected to the rendered runtime surface
- the identity validator modeled `missing_scope_check` as a weakness, but the default path was already skipping scope enforcement

## Testing

Verified locally with the targeted slices that cover cluster preflight, config/render/admission wiring, rendered chart output, service reset, security integrator behavior, and identity scope validation.

Also compiled the embedded identity-provider server template to catch syntax drift.

## Review Notes

This is a follow-up hardening pass on top of `feat/k3s-platform-integration`, not a deeper redesign of the long-term security runtime model.
