### PR TITLE
[codex] Fix packaged docs and bundled quickstart

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include docs *.md

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ training-data generation.
 The fastest way to experience OpenRange locally is directly through the PyPI package. This requires no external dependencies and runs the engine fully offline over a synthetic simulation plane.
 
 ```bash
-pip install openenv-open-range
-openrange admit -m manifests/tier1_basic.yaml -o /tmp/openrange-build --validation-profile graph_only
+pip install open-range
+openrange admit -m tier1_basic.yaml -o /tmp/openrange-build --store-dir /tmp/openrange-snapshots --validation-profile graph_only
 ```
 
-This deterministic pipeline will immediately compile a tier-1 enterprise environment, synthesize internal vulnerabilities, and freeze it into an immutable snapshot. You can then trace an episode by instantly invoking `openrange reset`.
+This deterministic pipeline will immediately compile a tier-1 enterprise environment, synthesize internal vulnerabilities, and freeze it into an immutable snapshot. You can then trace an episode by invoking `openrange reset --store-dir /tmp/openrange-snapshots --sample-seed 7`.
 
 ## Offline Exploration vs Live Ranges
 
@@ -248,4 +248,3 @@ uv run pre-commit run --all-files
 ## License
 
 Apache 2.0
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ Homepage = "https://github.com/venca-labs/open-range"
 "Bug Tracker" = "https://github.com/venca-labs/open-range/issues"
 
 [project.optional-dependencies]
+npc = []
 training = [
     "torch>=2.10",
     "transformers>=5.2",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+from shutil import copy2
+
+from setuptools import setup
+from setuptools.command.build_py import build_py as _build_py
+
+
+class build_py(_build_py):
+    def run(self) -> None:
+        super().run()
+        root = Path(__file__).resolve().parent
+        source_dir = root / "docs"
+        target_dir = Path(self.build_lib) / "open_range" / "_resources" / "docs"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        source_docs = {path.name: path for path in source_dir.glob("*.md")}
+        for path in target_dir.glob("*.md"):
+            if path.name not in source_docs:
+                path.unlink()
+        for name, source_path in source_docs.items():
+            copy2(source_path, target_dir / name)
+
+
+setup(cmdclass={"build_py": build_py})

--- a/src/open_range/cli.py
+++ b/src/open_range/cli.py
@@ -16,6 +16,7 @@ import yaml
 from open_range.build_config import BuildConfig
 from open_range.episode_config import EpisodeConfig
 from open_range.pipeline import BuildPipeline
+from open_range.resources import load_bundled_manifest
 from open_range.service import OpenRange
 from open_range.store import FileSnapshotStore
 from open_range.tracegen import generate_trace_dataset
@@ -34,11 +35,15 @@ def _configure_logging(verbose: bool) -> None:
     )
 
 
-def _load_manifest(path: str) -> dict[str, Any]:
-    manifest_path = Path(path)
-    if not manifest_path.exists():
-        raise click.ClickException(f"manifest not found: {manifest_path}")
-    payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+def _load_manifest(source: str) -> dict[str, Any]:
+    manifest_path = Path(source)
+    if manifest_path.exists():
+        payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    else:
+        try:
+            payload = load_bundled_manifest(source)
+        except FileNotFoundError as exc:
+            raise click.ClickException(f"manifest not found: {source}") from exc
     if not isinstance(payload, dict):
         raise click.ClickException(
             f"manifest must be a YAML mapping, got {type(payload).__name__}"
@@ -113,8 +118,8 @@ def cli(
     "-m",
     "--manifest",
     required=True,
-    type=click.Path(exists=True),
-    help="Path to manifest YAML.",
+    type=str,
+    help="Path to manifest YAML or bundled manifest name.",
 )
 @click.option(
     "-o",
@@ -143,8 +148,8 @@ def build_cmd(manifest: str, output: str) -> None:
     "-m",
     "--manifest",
     required=True,
-    type=click.Path(exists=True),
-    help="Path to manifest YAML.",
+    type=str,
+    help="Path to manifest YAML or bundled manifest name.",
 )
 @click.option(
     "-o",
@@ -264,8 +269,8 @@ def reset_cmd(
     "-m",
     "--manifest",
     required=True,
-    type=click.Path(exists=True),
-    help="Path to manifest YAML.",
+    type=str,
+    help="Path to manifest YAML or bundled manifest name.",
 )
 @click.option(
     "-o",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,6 +73,30 @@ def test_admit_command_persists_snapshot(tmp_path: Path):
     assert "Admitted snapshot written to" in result.output
 
 
+def test_admit_command_accepts_bundled_manifest_name(tmp_path: Path):
+    store_dir = tmp_path / "snapshots"
+    render_dir = tmp_path / "rendered"
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "admit",
+            "--manifest",
+            "tier1_basic.yaml",
+            "--output",
+            str(render_dir),
+            "--store-dir",
+            str(store_dir),
+            "--validation-profile",
+            "graph_only",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    snapshot_dirs = [path for path in store_dir.iterdir() if path.is_dir()]
+    assert len(snapshot_dirs) == 1
+
+
 def test_reset_command_loads_snapshot_from_store(tmp_path: Path):
     manifest_path = _write_manifest(tmp_path)
     store_dir = tmp_path / "snapshots"

--- a/uv.lock
+++ b/uv.lock
@@ -1149,7 +1149,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'training'", specifier = ">=5.2" },
     { name = "trl", marker = "extra == 'training'", specifier = ">=0.24" },
 ]
-provides-extras = ["training"]
+provides-extras = ["npc", "training"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Tightens the new PyPI/onboarding path without backing out the branch direction:
- restore wheel-safe docs packaging so `load_bundled_doc()` works from built artifacts again
- allow `openrange` CLI commands to accept bundled manifest names like `tier1_basic.yaml`
- fix the README quickstart to use the published package name and a manifest form that works outside a repo checkout
- add a placeholder `npc` extra so that surface can exist cleanly while it fills in later

## Why

The current branch introduced a PyPI-first quickstart, but two pieces were still repo-checkout dependent:
- built wheels no longer carried the top-level docs markdown files that `load_bundled_doc()` expects
- the CLI quickstart still referenced `manifests/tier1_basic.yaml`, which is only present in a source checkout

This keeps the existing onboarding direction and makes the packaged flow behave the way the README now describes.

## Testing

```bash
uv build
uv run --isolated --python 3.14 --with /tmp/open-range-pr156-fix/dist/open_range-0.1.0-py3-none-any.whl python - <<'PY'
from open_range.resources import load_bundled_doc
text = load_bundled_doc('architecture.md')
print('loaded', 'Python control plane' in text, len(text))
PY
uv run --isolated --python 3.14 --with /tmp/open-range-pr156-fix/dist/open_range-0.1.0-py3-none-any.whl openrange admit -m tier1_basic.yaml -o /tmp/or-build --store-dir /tmp/or-snaps --validation-profile graph_only
```

## Review Notes

This stays intentionally narrow and does not remove the new `npc` surface; it just makes that extra valid as an empty placeholder for now.
