### PR TITLE
Refactor security runtime into the world model

### DIFF
--- a/src/open_range/k3d_renderer.py
+++ b/src/open_range/k3d_renderer.py
@@ -15,6 +15,7 @@ from typing import Any
 import yaml
 
 from open_range.render import EnterpriseSaaSKindRenderer
+from open_range.runtime_extensions import RenderExtensions
 from open_range.snapshot import KindArtifacts
 from open_range.synth import SynthArtifacts
 from open_range.world_ir import ServiceSpec, WorldIR
@@ -59,14 +60,19 @@ class K3dRenderer(EnterpriseSaaSKindRenderer):
         self.wait_timeout = wait_timeout
 
     def render(
-        self, world: WorldIR, synth: SynthArtifacts, outdir: Path
+        self,
+        world: WorldIR,
+        synth: SynthArtifacts,
+        outdir: Path,
+        *,
+        extensions: RenderExtensions | None = None,
     ) -> KindArtifacts:
         """Render the Helm chart and k3d config to *outdir*.
 
         Delegates most work to ``EnterpriseSaaSKindRenderer.render()``
         then replaces the Kind config with a k3d config.
         """
-        artifacts = super().render(world, synth, outdir)
+        artifacts = super().render(world, synth, outdir, extensions=extensions)
 
         # Replace kind-config.yaml with k3d-config.yaml
         kind_config_path = Path(artifacts.kind_config_path)

--- a/src/open_range/mtls_sim.py
+++ b/src/open_range/mtls_sim.py
@@ -109,15 +109,15 @@ _SERVICE_TLS_ENV: dict[str, dict[str, str]] = {
         "ssl_client_certificate": "/etc/mtls/ca.pem",
     },
     "ldap": {
-        "LDAP_TLS_CRT_FILENAME": "/etc/mtls/cert.pem",
-        "LDAP_TLS_KEY_FILENAME": "/etc/mtls/key.pem",
-        "LDAP_TLS_CA_FILE": "/etc/mtls/ca.pem",
+        "LDAP_TLS_CRT_FILENAME": "ldap.crt",
+        "LDAP_TLS_KEY_FILENAME": "ldap.key",
+        "LDAP_TLS_CA_CRT_FILENAME": "ca.crt",
         "LDAP_TLS_VERIFY_CLIENT": "demand",
     },
     "openldap": {
-        "LDAP_TLS_CRT_FILENAME": "/etc/mtls/cert.pem",
-        "LDAP_TLS_KEY_FILENAME": "/etc/mtls/key.pem",
-        "LDAP_TLS_CA_FILE": "/etc/mtls/ca.pem",
+        "LDAP_TLS_CRT_FILENAME": "ldap.crt",
+        "LDAP_TLS_KEY_FILENAME": "ldap.key",
+        "LDAP_TLS_CA_CRT_FILENAME": "ca.crt",
         "LDAP_TLS_VERIFY_CLIENT": "demand",
     },
 }
@@ -482,7 +482,8 @@ class MTLSSimulator:
 
         - **MySQL / db** : ``SSL_CERT``, ``SSL_KEY``, ``SSL_CA``, ``require_secure_transport``
         - **nginx / web** : ``ssl_certificate``, ``ssl_certificate_key``, ``ssl_client_certificate``
-        - **LDAP / openldap** : ``LDAP_TLS_CRT_FILENAME``, ``LDAP_TLS_KEY_FILENAME``, etc.
+        - **LDAP / openldap** : image-native TLS filenames such as
+          ``LDAP_TLS_CRT_FILENAME`` and ``LDAP_TLS_CA_CRT_FILENAME``
 
         Returns an empty dict for unknown services.
         """

--- a/src/open_range/pipeline.py
+++ b/src/open_range/pipeline.py
@@ -17,11 +17,8 @@ from open_range.compiler import EnterpriseSaaSManifestCompiler
 from open_range.k3d_renderer import K3dRenderer
 from open_range.manifest import EnterpriseSaaSManifest, validate_manifest
 from open_range.render import EnterpriseSaaSKindRenderer
-from open_range.security_integrator import (
-    SecurityContext,
-    SecurityIntegrator,
-    SecurityIntegratorConfig,
-)
+from open_range.security_runtime import SecurityRuntimeSpec
+from open_range.security_integrator import SecurityIntegrator, SecurityIntegratorConfig
 from open_range.snapshot import KindArtifacts, Snapshot
 from open_range.store import FileSnapshotStore, PoolSplit
 from open_range.synth import EnterpriseSaaSWorldSynthesizer, SynthArtifacts
@@ -68,17 +65,7 @@ class BuildPipeline:
     ) -> CandidateWorld:
         world = self._prepare_world(source, build_config)
         synth = self.synthesizer.synthesize(world, Path(outdir) / "synth")
-        security_context = self._security_context(world, Path(outdir), build_config)
-        artifacts = self._renderer_for(build_config).render(
-            world,
-            synth,
-            Path(outdir),
-            extensions=(
-                security_context.render_extensions()
-                if security_context is not None
-                else None
-            ),
-        )
+        artifacts = self._renderer_for(build_config).render(world, synth, Path(outdir))
         artifacts = self._integrate_network_policies(artifacts, build_config)
         return CandidateWorld(
             world=world, synth=synth, artifacts=artifacts, build_config=build_config
@@ -121,14 +108,15 @@ class BuildPipeline:
         build_config: BuildConfig,
     ) -> WorldIR:
         if isinstance(source, WorldIR):
-            return source if source.weaknesses else self.seeder.apply(source)
+            world = source if source.weaknesses else self.seeder.apply(source)
+            return self._attach_security_runtime(world, build_config)
         parsed = (
             source
             if isinstance(source, EnterpriseSaaSManifest)
             else validate_manifest(source)
         )
         world = self.compiler.compile(parsed, build_config)
-        return self.seeder.apply(world)
+        return self._attach_security_runtime(self.seeder.apply(world), build_config)
 
     def _renderer_for(self, build_config: BuildConfig) -> EnterpriseSaaSKindRenderer:
         if self.renderer is not None and not isinstance(
@@ -142,23 +130,18 @@ class BuildPipeline:
             )
         return self.renderer
 
-    def _security_context(
+    def _attach_security_runtime(
         self,
         world: WorldIR,
-        outdir: Path,
         build_config: BuildConfig,
-    ) -> SecurityContext | None:
+    ) -> WorldIR:
         if not build_config.security_enabled:
-            return None
+            return world.model_copy(update={"security_runtime": SecurityRuntimeSpec()})
         integrator = self.security_integrator or SecurityIntegrator(
             SecurityIntegratorConfig(enabled=True)
         )
-        context = integrator.integrate(
-            world,
-            render_dir=outdir,
-            tier=build_config.security_tier,
-        )
-        return context if context.generated_files else None
+        runtime = integrator.plan(world, tier=build_config.security_tier)
+        return world.model_copy(update={"security_runtime": runtime})
 
     def _integrate_network_policies(
         self,

--- a/src/open_range/pipeline.py
+++ b/src/open_range/pipeline.py
@@ -18,11 +18,9 @@ from open_range.k3d_renderer import K3dRenderer
 from open_range.manifest import EnterpriseSaaSManifest, validate_manifest
 from open_range.render import EnterpriseSaaSKindRenderer
 from open_range.security_integrator import (
-    PayloadPatch,
     SecurityContext,
     SecurityIntegrator,
     SecurityIntegratorConfig,
-    SidecarPatch,
 )
 from open_range.snapshot import KindArtifacts, Snapshot
 from open_range.store import FileSnapshotStore, PoolSplit
@@ -70,8 +68,17 @@ class BuildPipeline:
     ) -> CandidateWorld:
         world = self._prepare_world(source, build_config)
         synth = self.synthesizer.synthesize(world, Path(outdir) / "synth")
-        artifacts = self._renderer_for(build_config).render(world, synth, Path(outdir))
-        artifacts = self._integrate_security(world, artifacts, build_config)
+        security_context = self._security_context(world, Path(outdir), build_config)
+        artifacts = self._renderer_for(build_config).render(
+            world,
+            synth,
+            Path(outdir),
+            extensions=(
+                security_context.render_extensions()
+                if security_context is not None
+                else None
+            ),
+        )
         artifacts = self._integrate_network_policies(artifacts, build_config)
         return CandidateWorld(
             world=world, synth=synth, artifacts=artifacts, build_config=build_config
@@ -135,145 +142,23 @@ class BuildPipeline:
             )
         return self.renderer
 
-    def _integrate_security(
+    def _security_context(
         self,
         world: WorldIR,
-        artifacts: KindArtifacts,
+        outdir: Path,
         build_config: BuildConfig,
-    ) -> KindArtifacts:
+    ) -> SecurityContext | None:
         if not build_config.security_enabled:
-            return artifacts
+            return None
         integrator = self.security_integrator or SecurityIntegrator(
             SecurityIntegratorConfig(enabled=True)
         )
         context = integrator.integrate(
             world,
-            render_dir=Path(artifacts.render_dir),
+            render_dir=outdir,
             tier=build_config.security_tier,
         )
-        if not context.generated_files:
-            return artifacts
-        chart_values = dict(artifacts.chart_values)
-        chart_values["services"] = self._integrate_security_payloads(
-            world,
-            chart_values.get("services", {}),
-            context,
-        )
-        chart_values["security"] = context.model_dump(mode="json")
-        return self._sync_artifacts(
-            artifacts,
-            chart_values=chart_values,
-            rendered_files=context.generated_files,
-            summary_updates={
-                "security_tier": build_config.security_tier,
-                "security_integration_enabled": True,
-            },
-        )
-
-    def _integrate_security_payloads(
-        self,
-        world: WorldIR,
-        services: dict[str, Any],
-        context: SecurityContext,
-    ) -> dict[str, Any]:
-        next_services = {name: dict(spec) for name, spec in services.items()}
-
-        for service_id, patch in context.service_patches.items():
-            if service_id not in next_services:
-                continue
-            if patch.payloads:
-                self._append_payloads(next_services, service_id, patch.payloads)
-            if patch.ports:
-                for port in patch.ports:
-                    self._append_port(next_services, service_id, port)
-            if patch.sidecars:
-                resolved_sidecars = [
-                    self._resolve_sidecar_patch(
-                        next_services[service_id], service_id, sidecar
-                    )
-                    for sidecar in patch.sidecars
-                ]
-                self._set_sidecars(next_services, service_id, resolved_sidecars)
-
-        return next_services
-
-    @staticmethod
-    def _append_payloads(
-        services: dict[str, Any], service_id: str, payloads: list[PayloadPatch | None]
-    ) -> None:
-        service = services.get(service_id)
-        if not isinstance(service, dict):
-            return
-        existing = list(service.get("payloads", []))
-        for payload in payloads:
-            if payload is None:
-                continue
-            existing.append(payload.model_dump(mode="json"))
-        service["payloads"] = existing
-
-    @staticmethod
-    def _append_port(
-        services: dict[str, Any], service_id: str, port: dict[str, Any]
-    ) -> None:
-        service = services.get(service_id)
-        if not isinstance(service, dict):
-            return
-        existing = list(service.get("ports", []))
-        if any(item.get("port") == port["port"] for item in existing):
-            return
-        existing.append(port)
-        service["ports"] = existing
-
-    @staticmethod
-    def _set_sidecars(
-        services: dict[str, Any], service_id: str, sidecars: list[dict[str, Any]]
-    ) -> None:
-        service = services.get(service_id)
-        if not isinstance(service, dict):
-            return
-        service["sidecars"] = sidecars
-
-    @staticmethod
-    def _resolve_sidecar_patch(
-        service: dict[str, Any],
-        service_id: str,
-        sidecar: SidecarPatch,
-    ) -> dict[str, Any]:
-        image = sidecar.image
-        if sidecar.inherit_image_from_service:
-            image = service.get("image", image)
-        if image is None:
-            raise ValueError(
-                f"sidecar {sidecar.name!r} for service {service_id!r} has no image"
-            )
-
-        payloads = [payload.model_dump(mode="json") for payload in sidecar.payloads]
-        if sidecar.inherit_payloads_from_service:
-            payloads = list(service.get("payloads", [])) + payloads
-
-        resolved = sidecar.model_dump(
-            mode="json",
-            exclude={
-                "inherit_image_from_service",
-                "inherit_payloads_from_service",
-            },
-            exclude_none=True,
-        )
-        resolved["image"] = image
-        resolved["payloads"] = payloads
-        return resolved
-
-    @staticmethod
-    def _payload_entry(
-        source_path: Path, key: str, mount_path: str
-    ) -> dict[str, str] | None:
-        if not source_path.exists():
-            return None
-        return {
-            "key": key,
-            "mountPath": mount_path,
-            "content": source_path.read_text(encoding="utf-8"),
-        }
+        return context if context.generated_files else None
 
     def _integrate_network_policies(
         self,

--- a/src/open_range/render.py
+++ b/src/open_range/render.py
@@ -13,7 +13,9 @@ import yaml
 from open_range.runtime_extensions import (
     RenderExtensions,
     apply_service_runtime_extensions,
+    merge_render_extensions,
 )
+from open_range.security_runtime import materialize_security_runtime
 from open_range.snapshot import KindArtifacts
 from open_range.synth import SynthArtifacts
 from open_range.world_ir import GreenPersona, ServiceSpec, WorldIR
@@ -72,12 +74,18 @@ class EnterpriseSaaSKindRenderer:
             shutil.rmtree(chart_out)
         shutil.copytree(self.chart_dir, chart_out)
 
-        values = self._build_values(world, synth, extensions=extensions)
+        combined_extensions = merge_render_extensions(
+            materialize_security_runtime(world, outdir),
+            extensions,
+        )
+        values = self._build_values(world, synth, extensions=combined_extensions)
         kind_config = self._build_kind_config(world)
         summary = self._build_summary(
             world,
             values,
-            summary_updates=extensions.summary_updates if extensions else None,
+            summary_updates=(
+                combined_extensions.summary_updates if combined_extensions else None
+            ),
         )
 
         values_path = chart_out / "values.yaml"
@@ -110,7 +118,11 @@ class EnterpriseSaaSKindRenderer:
                     str(kind_config_path),
                     str(summary_path),
                     *synth.generated_files,
-                    *(extensions.rendered_files if extensions else ()),
+                    *(
+                        combined_extensions.rendered_files
+                        if combined_extensions
+                        else ()
+                    ),
                 ]
             ),
             chart_values=values,

--- a/src/open_range/render.py
+++ b/src/open_range/render.py
@@ -10,6 +10,10 @@ from typing import Any, Protocol
 
 import yaml
 
+from open_range.runtime_extensions import (
+    RenderExtensions,
+    apply_service_runtime_extensions,
+)
 from open_range.snapshot import KindArtifacts
 from open_range.synth import SynthArtifacts
 from open_range.world_ir import GreenPersona, ServiceSpec, WorldIR
@@ -37,7 +41,12 @@ _SANDBOX_IMAGE_BY_ROLE = {
 
 class KindRenderer(Protocol):
     def render(
-        self, world: WorldIR, synth: SynthArtifacts, outdir: Path
+        self,
+        world: WorldIR,
+        synth: SynthArtifacts,
+        outdir: Path,
+        *,
+        extensions: RenderExtensions | None = None,
     ) -> KindArtifacts: ...
 
 
@@ -48,7 +57,12 @@ class EnterpriseSaaSKindRenderer:
         self.chart_dir = chart_dir or _CHART_DIR
 
     def render(
-        self, world: WorldIR, synth: SynthArtifacts, outdir: Path
+        self,
+        world: WorldIR,
+        synth: SynthArtifacts,
+        outdir: Path,
+        *,
+        extensions: RenderExtensions | None = None,
     ) -> KindArtifacts:
         outdir = Path(outdir)
         outdir.mkdir(parents=True, exist_ok=True)
@@ -58,9 +72,13 @@ class EnterpriseSaaSKindRenderer:
             shutil.rmtree(chart_out)
         shutil.copytree(self.chart_dir, chart_out)
 
-        values = self._build_values(world, synth)
+        values = self._build_values(world, synth, extensions=extensions)
         kind_config = self._build_kind_config(world)
-        summary = self._build_summary(world, values)
+        summary = self._build_summary(
+            world,
+            values,
+            summary_updates=extensions.summary_updates if extensions else None,
+        )
 
         values_path = chart_out / "values.yaml"
         values_path.write_text(
@@ -92,6 +110,7 @@ class EnterpriseSaaSKindRenderer:
                     str(kind_config_path),
                     str(summary_path),
                     *synth.generated_files,
+                    *(extensions.rendered_files if extensions else ()),
                 ]
             ),
             chart_values=values,
@@ -99,7 +118,12 @@ class EnterpriseSaaSKindRenderer:
         )
 
     @staticmethod
-    def _build_values(world: WorldIR, synth: SynthArtifacts) -> dict[str, Any]:
+    def _build_values(
+        world: WorldIR,
+        synth: SynthArtifacts,
+        *,
+        extensions: RenderExtensions | None = None,
+    ) -> dict[str, Any]:
         host_by_id = {host.id: host for host in world.hosts}
         service_by_id = {service.id: service for service in world.services}
         zones: dict[str, dict[str, Any]] = {}
@@ -162,7 +186,7 @@ class EnterpriseSaaSKindRenderer:
             for user in world.users
         ]
 
-        return {
+        values = {
             "global": {
                 "namePrefix": _name_prefix(world.world_id),
                 "snapshotId": world.world_id,
@@ -190,6 +214,13 @@ class EnterpriseSaaSKindRenderer:
                 edge.model_dump(mode="json") for edge in world.telemetry_edges
             ],
         }
+        if extensions is not None:
+            values["services"] = apply_service_runtime_extensions(
+                values["services"],
+                extensions.services,
+            )
+            values.update(extensions.values)
+        return values
 
     @staticmethod
     def _build_kind_config(world: WorldIR) -> dict[str, Any]:
@@ -209,8 +240,13 @@ class EnterpriseSaaSKindRenderer:
         }
 
     @staticmethod
-    def _build_summary(world: WorldIR, values: dict[str, Any]) -> dict[str, Any]:
-        return {
+    def _build_summary(
+        world: WorldIR,
+        values: dict[str, Any],
+        *,
+        summary_updates: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        summary = {
             "world_id": world.world_id,
             "service_count": len(world.services),
             "zone_count": len(world.zones),
@@ -223,6 +259,9 @@ class EnterpriseSaaSKindRenderer:
                 )
             ).hexdigest(),
         }
+        if summary_updates:
+            summary.update(summary_updates)
+        return summary
 
     @staticmethod
     def _image_digest_for(kind: str) -> str:

--- a/src/open_range/render.py
+++ b/src/open_range/render.py
@@ -309,6 +309,10 @@ def _service_env(service: ServiceSpec) -> dict[str, str]:
 
 
 def _service_command(service: ServiceSpec) -> list[str]:
+    if service.kind == "idp":
+        # The osixia/openldap image expects mounted certs to be copied into a
+        # writable service directory before startup mutates ownership.
+        return ["/container/tool/run", "--copy-service"]
     if service.kind == "siem":
         return [
             "/bin/sh",

--- a/src/open_range/runtime_extensions.py
+++ b/src/open_range/runtime_extensions.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field
 class RuntimePayload(BaseModel):
     """Mountable content added to a rendered service."""
 
-    model_config = ConfigDict(extra="forbid", frozen=True)
+    model_config = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
 
     key: str
     mount_path: str = Field(alias="mountPath")
@@ -109,6 +109,47 @@ class RenderExtensions(BaseModel):
     values: dict[str, Any] = Field(default_factory=dict)
     summary_updates: dict[str, Any] = Field(default_factory=dict)
     rendered_files: tuple[str, ...] = Field(default_factory=tuple)
+
+
+def merge_render_extensions(
+    base: RenderExtensions | None,
+    extra: RenderExtensions | None,
+) -> RenderExtensions | None:
+    """Merge two render extension bundles."""
+
+    if base is None:
+        return extra
+    if extra is None:
+        return base
+
+    services: dict[str, ServiceRuntimeExtension] = {
+        service_id: ServiceRuntimeExtension.model_validate(
+            extension.model_dump(by_alias=True)
+        )
+        for service_id, extension in base.services.items()
+    }
+    for service_id, extension in extra.services.items():
+        if service_id not in services:
+            services[service_id] = ServiceRuntimeExtension.model_validate(
+                extension.model_dump(by_alias=True)
+            )
+            continue
+        merged = services[service_id]
+        merged.payloads.extend(extension.payloads)
+        merged.ports.extend(extension.ports)
+        merged.sidecars.extend(extension.sidecars)
+
+    values = dict(base.values)
+    values.update(extra.values)
+    summary_updates = dict(base.summary_updates)
+    summary_updates.update(extra.summary_updates)
+    rendered_files = tuple(dict.fromkeys((*base.rendered_files, *extra.rendered_files)))
+    return RenderExtensions(
+        services=services,
+        values=values,
+        summary_updates=summary_updates,
+        rendered_files=rendered_files,
+    )
 
 
 def apply_service_runtime_extensions(

--- a/src/open_range/runtime_extensions.py
+++ b/src/open_range/runtime_extensions.py
@@ -1,0 +1,144 @@
+"""Typed runtime extensions applied during render."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RuntimePayload(BaseModel):
+    """Mountable content added to a rendered service."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    key: str
+    mount_path: str = Field(alias="mountPath")
+    content: str
+
+    def as_chart_value(self) -> dict[str, str]:
+        return {
+            "key": self.key,
+            "mountPath": self.mount_path,
+            "content": self.content,
+        }
+
+
+class RuntimePort(BaseModel):
+    """Port exposed by a rendered service or sidecar."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str
+    port: int
+    protocol: str = "TCP"
+
+    def as_chart_value(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "port": self.port,
+            "protocol": self.protocol,
+        }
+
+
+class RuntimeSidecar(BaseModel):
+    """Sidecar attached to a rendered service."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str
+    image: str | None = None
+    image_source: Literal["explicit", "service"] = "explicit"
+    command: tuple[str, ...] = Field(default_factory=tuple)
+    args: tuple[str, ...] = Field(default_factory=tuple)
+    ports: tuple[RuntimePort, ...] = Field(default_factory=tuple)
+    env: dict[str, str] = Field(default_factory=dict)
+    payloads: tuple[RuntimePayload, ...] = Field(default_factory=tuple)
+    include_service_payloads: bool = False
+
+    def as_chart_value(
+        self,
+        service: dict[str, Any],
+        *,
+        service_id: str,
+    ) -> dict[str, Any]:
+        if self.image_source == "service":
+            image = str(service.get("image", "")).strip()
+        else:
+            image = (self.image or "").strip()
+        if not image:
+            raise ValueError(
+                f"sidecar {self.name!r} for service {service_id!r} has no image"
+            )
+
+        payloads: list[dict[str, str]] = []
+        if self.include_service_payloads:
+            payloads.extend(list(service.get("payloads", [])))
+        payloads.extend(payload.as_chart_value() for payload in self.payloads)
+
+        resolved: dict[str, Any] = {"name": self.name, "image": image}
+        if self.command:
+            resolved["command"] = list(self.command)
+        if self.args:
+            resolved["args"] = list(self.args)
+        if self.ports:
+            resolved["ports"] = [port.as_chart_value() for port in self.ports]
+        if self.env:
+            resolved["env"] = dict(self.env)
+        if payloads:
+            resolved["payloads"] = payloads
+        return resolved
+
+
+class ServiceRuntimeExtension(BaseModel):
+    """Runtime additions attached to a rendered service."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    payloads: list[RuntimePayload] = Field(default_factory=list)
+    ports: list[RuntimePort] = Field(default_factory=list)
+    sidecars: list[RuntimeSidecar] = Field(default_factory=list)
+
+
+class RenderExtensions(BaseModel):
+    """Additional render-time inputs layered onto the base world render."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    services: dict[str, ServiceRuntimeExtension] = Field(default_factory=dict)
+    values: dict[str, Any] = Field(default_factory=dict)
+    summary_updates: dict[str, Any] = Field(default_factory=dict)
+    rendered_files: tuple[str, ...] = Field(default_factory=tuple)
+
+
+def apply_service_runtime_extensions(
+    services: dict[str, dict[str, Any]],
+    extensions: dict[str, ServiceRuntimeExtension],
+) -> dict[str, dict[str, Any]]:
+    """Merge typed runtime extensions into rendered service values."""
+
+    next_services = {name: dict(spec) for name, spec in services.items()}
+    for service_id, extension in extensions.items():
+        service = next_services.get(service_id)
+        if not isinstance(service, dict):
+            continue
+        if extension.payloads:
+            service["payloads"] = list(service.get("payloads", [])) + [
+                payload.as_chart_value() for payload in extension.payloads
+            ]
+        if extension.ports:
+            existing = list(service.get("ports", []))
+            for port in extension.ports:
+                rendered = port.as_chart_value()
+                if any(item.get("port") == rendered["port"] for item in existing):
+                    continue
+                existing.append(rendered)
+            service["ports"] = existing
+        if extension.sidecars:
+            existing_sidecars = list(service.get("sidecars", []))
+            existing_sidecars.extend(
+                sidecar.as_chart_value(service, service_id=service_id)
+                for sidecar in extension.sidecars
+            )
+            service["sidecars"] = existing_sidecars
+    return next_services

--- a/src/open_range/runtime_extensions.py
+++ b/src/open_range/runtime_extensions.py
@@ -95,6 +95,7 @@ class ServiceRuntimeExtension(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    env: dict[str, str] = Field(default_factory=dict)
     payloads: list[RuntimePayload] = Field(default_factory=list)
     ports: list[RuntimePort] = Field(default_factory=list)
     sidecars: list[RuntimeSidecar] = Field(default_factory=list)
@@ -135,6 +136,7 @@ def merge_render_extensions(
             )
             continue
         merged = services[service_id]
+        merged.env.update(extension.env)
         merged.payloads.extend(extension.payloads)
         merged.ports.extend(extension.ports)
         merged.sidecars.extend(extension.sidecars)
@@ -163,6 +165,10 @@ def apply_service_runtime_extensions(
         service = next_services.get(service_id)
         if not isinstance(service, dict):
             continue
+        if extension.env:
+            merged_env = dict(service.get("env", {}))
+            merged_env.update(extension.env)
+            service["env"] = merged_env
         if extension.payloads:
             service["payloads"] = list(service.get("payloads", [])) + [
                 payload.as_chart_value() for payload in extension.payloads

--- a/src/open_range/security_integrator.py
+++ b/src/open_range/security_integrator.py
@@ -1,4 +1,4 @@
-"""Wire security training modules into the v1 build pipeline.
+"""Plan security runtime intent for the v1 build pipeline.
 
 The ``SecurityIntegrator`` orchestrates the four training-layer modules
 (Identity Provider, Envelope Encryption, mTLS Simulation, NPC Credential
@@ -12,10 +12,9 @@ Tier mapping (configurable):
 - **Tier 3+**: Full stack -- identity + encryption + mTLS + NPC credential
   lifecycle with authorization policies.
 
-The integrator builds a deterministic security runtime plan from the
-``WorldIR`` and build tier. It generates the needed artefacts on disk and
-describes the runtime components that render should materialize directly
-into the chart values.
+The integrator builds a security runtime plan from the ``WorldIR`` and build
+tier. The plan is stored on ``WorldIR`` as source-of-truth intent, and render
+later materializes the concrete files and runtime components from that plan.
 
 Ported from k3s-istio-vault-platform's orchestration patterns:
 - App-of-apps component ordering (root-chart)
@@ -25,23 +24,24 @@ Ported from k3s-istio-vault-platform's orchestration patterns:
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import random
 from copy import deepcopy
-from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, Field
 
 from open_range.runtime_extensions import (
-    RenderExtensions,
-    RuntimePayload,
     RuntimePort,
     RuntimeSidecar,
-    ServiceRuntimeExtension,
+)
+from open_range.security_runtime import (
+    SecurityPayloadSpec,
+    SecurityRuntimeSpec,
+    SecurityServiceRuntimeSpec,
+    materialize_security_runtime,
 )
 from open_range.world_ir import WorldIR
 
@@ -138,25 +138,38 @@ class SecurityIntegratorConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Security context returned by the integrator
+# Mutable planning context
 # ---------------------------------------------------------------------------
 
 
+class SecurityServiceRuntimeBuilder(BaseModel):
+    """Mutable runtime builder before freezing onto ``WorldIR``."""
+
+    payloads: list[SecurityPayloadSpec] = Field(default_factory=list)
+    ports: list[RuntimePort] = Field(default_factory=list)
+    sidecars: list[RuntimeSidecar] = Field(default_factory=list)
+
+
 class SecurityContext(BaseModel):
-    """Result of a security integration pass."""
+    """Mutable planner context before freezing onto ``WorldIR``."""
 
     tier: int = 1
     identity_provider: dict[str, Any] = Field(default_factory=dict)
     encryption: dict[str, Any] = Field(default_factory=dict)
     mtls: dict[str, Any] = Field(default_factory=dict)
     npc_credential_lifecycle: dict[str, Any] = Field(default_factory=dict)
-    generated_files: list[str] = Field(default_factory=list)
-    service_runtime: dict[str, ServiceRuntimeExtension] = Field(default_factory=dict)
+    service_runtime: dict[str, SecurityServiceRuntimeBuilder] = Field(
+        default_factory=dict
+    )
 
-    def service_extension(self, service_id: str) -> ServiceRuntimeExtension:
-        return self.service_runtime.setdefault(service_id, ServiceRuntimeExtension())
+    def service_extension(self, service_id: str) -> SecurityServiceRuntimeBuilder:
+        return self.service_runtime.setdefault(
+            service_id, SecurityServiceRuntimeBuilder()
+        )
 
-    def append_payload(self, service_id: str, payload: RuntimePayload | None) -> None:
+    def append_payload(
+        self, service_id: str, payload: SecurityPayloadSpec | None
+    ) -> None:
         if payload is not None:
             self.service_extension(service_id).payloads.append(payload)
 
@@ -166,29 +179,34 @@ class SecurityContext(BaseModel):
     def append_sidecar(self, service_id: str, sidecar: RuntimeSidecar) -> None:
         self.service_extension(service_id).sidecars.append(sidecar)
 
+    @staticmethod
     def runtime_payload(
-        self, source_path: Path, key: str, mount_path: str
-    ) -> RuntimePayload | None:
-        if not source_path.exists():
-            return None
-        return RuntimePayload(
+        *,
+        key: str,
+        mount_path: str,
+        source_path: str,
+    ) -> SecurityPayloadSpec:
+        return SecurityPayloadSpec(
             key=key,
             mountPath=mount_path,
-            content=source_path.read_text(encoding="utf-8"),
+            source_path=source_path,
         )
 
-    def summary(self) -> dict[str, Any]:
-        return self.model_dump(mode="json", exclude={"service_runtime"})
-
-    def render_extensions(self) -> RenderExtensions:
-        return RenderExtensions(
-            services=self.service_runtime,
-            values={"security": self.summary()},
-            summary_updates={
-                "security_tier": self.tier,
-                "security_integration_enabled": True,
+    def build(self) -> SecurityRuntimeSpec:
+        return SecurityRuntimeSpec(
+            tier=self.tier,
+            identity_provider=self.identity_provider,
+            encryption=self.encryption,
+            mtls=self.mtls,
+            npc_credential_lifecycle=self.npc_credential_lifecycle,
+            service_runtime={
+                service_id: SecurityServiceRuntimeSpec(
+                    payloads=tuple(extension.payloads),
+                    ports=tuple(extension.ports),
+                    sidecars=tuple(extension.sidecars),
+                )
+                for service_id, extension in self.service_runtime.items()
             },
-            rendered_files=tuple(self.generated_files),
         )
 
 
@@ -198,33 +216,28 @@ class SecurityContext(BaseModel):
 
 
 class SecurityIntegrator:
-    """Orchestrate security module integration into rendered snapshots.
+    """Build security runtime intent from a world and security tier.
 
     Usage::
 
         integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
-        ctx = integrator.integrate(world, render_dir=Path("/tmp/render"), tier=2)
+        runtime = integrator.plan(world, tier=2)
     """
 
     def __init__(self, config: SecurityIntegratorConfig | None = None) -> None:
         self.config = config or SecurityIntegratorConfig()
 
-    def integrate(
+    def plan(
         self,
         world: WorldIR,
         *,
-        render_dir: Path,
         tier: int = 1,
-    ) -> SecurityContext:
-        """Enrich rendered artifacts with security infrastructure.
-
-        Writes security config and artefact files into *render_dir*.
-        Returns a ``SecurityContext`` summarising what was generated.
-        """
+    ) -> SecurityRuntimeSpec:
+        """Build a security runtime plan that can be attached to ``WorldIR``."""
         ctx = SecurityContext(tier=tier)
 
         if not self.config.enabled:
-            return ctx
+            return ctx.build()
 
         rng = random.Random(f"{world.world_id}:{world.seed}:{tier}")
         tier_cfg = self.config.tier_map.get(
@@ -240,38 +253,43 @@ class SecurityIntegrator:
             services[svc.id] = zone
 
         domain = "range.local"
-        security_dir = render_dir / "security"
-        security_dir.mkdir(parents=True, exist_ok=True)
 
         if tier_cfg.identity_provider:
-            self._integrate_identity(ctx, world, services, domain, security_dir)
+            self._integrate_identity(ctx, world, services, domain)
 
         if tier_cfg.envelope_encryption:
-            self._integrate_encryption(ctx, world, services, security_dir, rng)
+            self._integrate_encryption(ctx, world, services, rng)
 
         if tier_cfg.mtls:
-            self._integrate_mtls(ctx, services, domain, security_dir, rng)
+            self._integrate_mtls(ctx, services, domain, rng)
 
         if tier_cfg.npc_credential_lifecycle:
-            self._integrate_npc_lifecycle(ctx, security_dir)
-
-        # Write the security context summary
-        ctx_path = security_dir / "security-context.json"
-        ctx_path.write_text(
-            json.dumps(ctx.model_dump(), indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        ctx.generated_files.append(str(ctx_path))
+            self._integrate_npc_lifecycle(ctx)
 
         logger.info(
-            "SecurityIntegrator: enriched render (tier=%d, idp=%s, enc=%s, mtls=%s, npc=%s)",
+            "SecurityIntegrator: planned security runtime (tier=%d, idp=%s, enc=%s, mtls=%s, npc=%s)",
             tier,
             tier_cfg.identity_provider,
             tier_cfg.envelope_encryption,
             tier_cfg.mtls,
             tier_cfg.npc_credential_lifecycle,
         )
-        return ctx
+        return ctx.build()
+
+    def integrate(
+        self,
+        world: WorldIR,
+        *,
+        tier: int = 1,
+        render_dir: object | None = None,
+    ) -> SecurityRuntimeSpec:
+        """Backward-compatible helper for callers still expecting file output."""
+
+        runtime = self.plan(world, tier=tier)
+        if render_dir is not None:
+            render_world = world.model_copy(update={"security_runtime": runtime})
+            materialize_security_runtime(render_world, Path(render_dir))
+        return runtime
 
     # ------------------------------------------------------------------
     # Identity Provider
@@ -283,14 +301,12 @@ class SecurityIntegrator:
         world: WorldIR,
         services: dict[str, str],
         domain: str,
-        security_dir: Path,
     ) -> None:
-        """Generate identity provider config and tokens."""
+        """Declare identity provider runtime intent."""
         try:
             from open_range.identity_provider import (
                 IdentityProviderConfig,
                 ServiceIdentity,
-                SimulatedIdentityProvider,
                 build_spiffe_id,
             )
         except ImportError:
@@ -320,35 +336,6 @@ class SecurityIntegrator:
 
         ctx.identity_provider = idp_config.model_dump()
 
-        # Generate startup script
-        idp = SimulatedIdentityProvider(idp_config)
-        startup_script = idp.generate_startup_script()
-        server_template = (
-            files("open_range")
-            .joinpath("templates")
-            .joinpath("identity_provider_server.py.tpl")
-            .read_text(encoding="utf-8")
-        )
-
-        # Write IdP artifacts
-        idp_dir = security_dir / "idp"
-        idp_dir.mkdir(parents=True, exist_ok=True)
-        (idp_dir / "config.json").write_text(
-            json.dumps(idp_config.model_dump(), indent=2) + "\n", encoding="utf-8"
-        )
-        (idp_dir / "startup.sh").write_text(startup_script, encoding="utf-8")
-        (idp_dir / "identity_provider_server.py").write_text(
-            server_template,
-            encoding="utf-8",
-        )
-        ctx.generated_files.extend(
-            [
-                str(idp_dir / "config.json"),
-                str(idp_dir / "startup.sh"),
-                str(idp_dir / "identity_provider_server.py"),
-            ]
-        )
-
         idp_targets = [
             service.id for service in world.services if service.kind == "idp"
         ]
@@ -357,25 +344,25 @@ class SecurityIntegrator:
             ctx.append_payload(
                 idp_id,
                 ctx.runtime_payload(
-                    idp_dir / "config.json",
-                    "security-idp-config.json",
-                    "/etc/openrange/identity-provider.json",
+                    key="security-idp-config.json",
+                    mount_path="/etc/openrange/identity-provider.json",
+                    source_path="security/idp/config.json",
                 ),
             )
             ctx.append_payload(
                 idp_id,
                 ctx.runtime_payload(
-                    idp_dir / "startup.sh",
-                    "security-idp-startup.sh",
-                    "/opt/openrange/start_identity_provider.sh",
+                    key="security-idp-startup.sh",
+                    mount_path="/opt/openrange/start_identity_provider.sh",
+                    source_path="security/idp/startup.sh",
                 ),
             )
             ctx.append_payload(
                 idp_id,
                 ctx.runtime_payload(
-                    idp_dir / "identity_provider_server.py",
-                    "security-idp-server.py",
-                    "/opt/openrange/identity_provider_server.py",
+                    key="security-idp-server.py",
+                    mount_path="/opt/openrange/identity_provider_server.py",
+                    source_path="security/idp/identity_provider_server.py",
                 ),
             )
             ctx.append_port(
@@ -412,15 +399,11 @@ class SecurityIntegrator:
         ctx: SecurityContext,
         world: WorldIR,
         services: dict[str, str],
-        security_dir: Path,
         rng: random.Random,
     ) -> None:
-        """Generate envelope encryption config for credential secrets."""
+        """Declare envelope encryption runtime intent."""
         try:
-            from open_range.envelope_crypto import (
-                EncryptionConfig,
-                EnvelopeCrypto,
-            )
+            from open_range.envelope_crypto import EncryptionConfig
         except ImportError:
             logger.warning(
                 "envelope_crypto module not available; skipping encryption integration"
@@ -442,34 +425,11 @@ class SecurityIntegrator:
             min(n_encrypt, len(credentials)),
         )
 
-        master_key = EnvelopeCrypto.generate_master_key()
-        import base64
-
-        master_key_b64 = base64.b64encode(master_key).decode()
-
         encrypted_refs: list[str] = []
-        dek_metadata: dict[str, Any] = {}
-
-        prev_env = os.environ.get("OPENRANGE_MASTER_KEY")
-        os.environ["OPENRANGE_MASTER_KEY"] = master_key_b64
-        try:
-            crypto = EnvelopeCrypto(master_key)
-            for idx in indices:
-                cred = credentials[idx]
-                aad = f"openrange:range:{cred.subject}:{cred.id}"
-                bundle = crypto.encrypt(cred.secret_ref, aad=aad)
-                encrypted_refs.append(cred.id)
-                dek_metadata[cred.id] = bundle.model_dump()
-        finally:
-            if prev_env is None:
-                os.environ.pop("OPENRANGE_MASTER_KEY", None)
-            else:
-                os.environ["OPENRANGE_MASTER_KEY"] = prev_env
+        for idx in indices:
+            encrypted_refs.append(credentials[idx].id)
 
         if encrypted_refs:
-            enc_dir = security_dir / "encryption"
-            enc_dir.mkdir(parents=True, exist_ok=True)
-
             enc_config = EncryptionConfig(
                 enabled=True,
                 encrypted_paths=encrypted_refs,
@@ -478,34 +438,21 @@ class SecurityIntegrator:
             )
             ctx.encryption = enc_config.model_dump()
 
-            (enc_dir / "config.json").write_text(
-                json.dumps(enc_config.model_dump(), indent=2) + "\n", encoding="utf-8"
-            )
-            (enc_dir / "wrapped_dek.json").write_text(
-                json.dumps(dek_metadata, indent=2) + "\n", encoding="utf-8"
-            )
-            ctx.generated_files.extend(
-                [
-                    str(enc_dir / "config.json"),
-                    str(enc_dir / "wrapped_dek.json"),
-                ]
-            )
-
             for svc_name in services:
                 ctx.append_payload(
                     svc_name,
                     ctx.runtime_payload(
-                        enc_dir / "config.json",
-                        "security-encryption-config.json",
-                        "/etc/openrange/encryption-config.json",
+                        key="security-encryption-config.json",
+                        mount_path="/etc/openrange/encryption-config.json",
+                        source_path="security/encryption/config.json",
                     ),
                 )
                 ctx.append_payload(
                     svc_name,
                     ctx.runtime_payload(
-                        enc_dir / "wrapped_dek.json",
-                        "security-wrapped-dek.json",
-                        "/etc/openrange/wrapped_dek.json",
+                        key="security-wrapped-dek.json",
+                        mount_path="/etc/openrange/wrapped_dek.json",
+                        source_path="security/encryption/wrapped_dek.json",
                     ),
                 )
 
@@ -522,12 +469,11 @@ class SecurityIntegrator:
         ctx: SecurityContext,
         services: dict[str, str],
         domain: str,
-        security_dir: Path,
         rng: random.Random,
     ) -> None:
-        """Generate TLS certificates for service-to-service mTLS."""
+        """Declare TLS runtime intent for service-to-service mTLS."""
         try:
-            from open_range.mtls_sim import MTLSConfig, MTLSSimulator
+            from open_range.mtls_sim import MTLSConfig
         except ImportError:
             logger.warning("mtls_sim module not available; skipping mTLS integration")
             return
@@ -547,60 +493,38 @@ class SecurityIntegrator:
             mtls_services=mtls_services,
             weaknesses=weaknesses,
         )
-
-        sim = MTLSSimulator(mtls_config)
-        # Build zones dict from services mapping
-        zones_dict: dict[str, list[str]] = {}
-        for svc_name, zone in services.items():
-            zones_dict.setdefault(zone, []).append(svc_name)
-
-        bundles = sim.generate_all_certs(services, zones_dict)
-
-        mtls_dir = security_dir / "mtls"
-        mtls_dir.mkdir(parents=True, exist_ok=True)
-
-        for svc_name, bundle in bundles.items():
-            svc_dir = mtls_dir / svc_name
-            svc_dir.mkdir(parents=True, exist_ok=True)
-            for payload in sim.get_payload_files(bundle):
-                fname = payload["mountPath"].rsplit("/", 1)[-1]
-                (svc_dir / fname).write_text(payload["content"], encoding="utf-8")
-                ctx.generated_files.append(str(svc_dir / fname))
-
+        for svc_name in mtls_services:
             ctx.append_payload(
                 svc_name,
                 ctx.runtime_payload(
-                    svc_dir / "ca.pem",
-                    "security-mtls-ca.pem",
-                    "/etc/mtls/ca.pem",
+                    key="security-mtls-ca.pem",
+                    mount_path="/etc/mtls/ca.pem",
+                    source_path=f"security/mtls/{svc_name}/ca.pem",
                 ),
             )
             ctx.append_payload(
                 svc_name,
                 ctx.runtime_payload(
-                    svc_dir / "cert.pem",
-                    "security-mtls-cert.pem",
-                    "/etc/mtls/cert.pem",
+                    key="security-mtls-cert.pem",
+                    mount_path="/etc/mtls/cert.pem",
+                    source_path=f"security/mtls/{svc_name}/cert.pem",
                 ),
             )
             ctx.append_payload(
                 svc_name,
                 ctx.runtime_payload(
-                    svc_dir / "key.pem",
-                    "security-mtls-key.pem",
-                    "/etc/mtls/key.pem",
+                    key="security-mtls-key.pem",
+                    mount_path="/etc/mtls/key.pem",
+                    source_path=f"security/mtls/{svc_name}/key.pem",
                 ),
             )
 
         ctx.mtls = mtls_config.model_dump()
 
-        (mtls_dir / "config.json").write_text(
-            json.dumps(mtls_config.model_dump(), indent=2) + "\n", encoding="utf-8"
-        )
-        ctx.generated_files.append(str(mtls_dir / "config.json"))
-
         logger.debug(
-            "mTLS integrated: %d services, weaknesses=%s", len(bundles), weaknesses
+            "mTLS integrated: %d services, weaknesses=%s",
+            len(mtls_services),
+            weaknesses,
         )
 
     # ------------------------------------------------------------------
@@ -610,9 +534,8 @@ class SecurityIntegrator:
     def _integrate_npc_lifecycle(
         self,
         ctx: SecurityContext,
-        security_dir: Path,
     ) -> None:
-        """Configure NPC credential lifecycle."""
+        """Declare NPC credential lifecycle runtime intent."""
         try:
             from open_range.credential_lifecycle import CredentialLifecycleConfig
         except ImportError:
@@ -629,13 +552,6 @@ class SecurityIntegrator:
         )
 
         ctx.npc_credential_lifecycle = lifecycle_config.model_dump()
-
-        npc_dir = security_dir / "npc"
-        npc_dir.mkdir(parents=True, exist_ok=True)
-        (npc_dir / "config.json").write_text(
-            json.dumps(lifecycle_config.model_dump(), indent=2) + "\n", encoding="utf-8"
-        )
-        ctx.generated_files.append(str(npc_dir / "config.json"))
 
         logger.debug(
             "NPC credential lifecycle integrated: weaknesses=%s",

--- a/src/open_range/security_integrator.py
+++ b/src/open_range/security_integrator.py
@@ -145,6 +145,7 @@ class SecurityIntegratorConfig(BaseModel):
 class SecurityServiceRuntimeBuilder(BaseModel):
     """Mutable runtime builder before freezing onto ``WorldIR``."""
 
+    env: dict[str, str] = Field(default_factory=dict)
     payloads: list[SecurityPayloadSpec] = Field(default_factory=list)
     ports: list[RuntimePort] = Field(default_factory=list)
     sidecars: list[RuntimeSidecar] = Field(default_factory=list)
@@ -179,6 +180,10 @@ class SecurityContext(BaseModel):
     def append_sidecar(self, service_id: str, sidecar: RuntimeSidecar) -> None:
         self.service_extension(service_id).sidecars.append(sidecar)
 
+    def extend_env(self, service_id: str, env: dict[str, str]) -> None:
+        if env:
+            self.service_extension(service_id).env.update(env)
+
     @staticmethod
     def runtime_payload(
         *,
@@ -201,6 +206,7 @@ class SecurityContext(BaseModel):
             npc_credential_lifecycle=self.npc_credential_lifecycle,
             service_runtime={
                 service_id: SecurityServiceRuntimeSpec(
+                    env=dict(extension.env),
                     payloads=tuple(extension.payloads),
                     ports=tuple(extension.ports),
                     sidecars=tuple(extension.sidecars),
@@ -247,10 +253,12 @@ class SecurityIntegrator:
 
         # Build service→zone mapping from WorldIR
         services: dict[str, str] = {}
+        service_kinds: dict[str, str] = {}
         host_by_id = {h.id: h for h in world.hosts}
         for svc in world.services:
             zone = host_by_id[svc.host].zone if svc.host in host_by_id else "default"
             services[svc.id] = zone
+            service_kinds[svc.id] = svc.kind
 
         domain = "range.local"
 
@@ -261,7 +269,7 @@ class SecurityIntegrator:
             self._integrate_encryption(ctx, world, services, rng)
 
         if tier_cfg.mtls:
-            self._integrate_mtls(ctx, services, domain, rng)
+            self._integrate_mtls(ctx, services, service_kinds, domain, rng)
 
         if tier_cfg.npc_credential_lifecycle:
             self._integrate_npc_lifecycle(ctx)
@@ -468,12 +476,13 @@ class SecurityIntegrator:
         self,
         ctx: SecurityContext,
         services: dict[str, str],
+        service_kinds: dict[str, str],
         domain: str,
         rng: random.Random,
     ) -> None:
-        """Declare TLS runtime intent for service-to-service mTLS."""
+        """Declare mTLS artifacts plus supported runtime hooks for services."""
         try:
-            from open_range.mtls_sim import MTLSConfig
+            from open_range.mtls_sim import MTLSConfig, MTLSSimulator
         except ImportError:
             logger.warning("mtls_sim module not available; skipping mTLS integration")
             return
@@ -518,6 +527,43 @@ class SecurityIntegrator:
                     source_path=f"security/mtls/{svc_name}/key.pem",
                 ),
             )
+            service_kind = service_kinds.get(svc_name, "")
+            if service_kind == "idp":
+                ctx.extend_env(svc_name, MTLSSimulator.get_service_tls_env("openldap"))
+                ctx.append_payload(
+                    svc_name,
+                    ctx.runtime_payload(
+                        key="security-mtls-openldap-ca.crt",
+                        mount_path="/container/service/slapd/assets/certs/ca.crt",
+                        source_path=f"security/mtls/{svc_name}/ca.pem",
+                    ),
+                )
+                ctx.append_payload(
+                    svc_name,
+                    ctx.runtime_payload(
+                        key="security-mtls-openldap-ldap.crt",
+                        mount_path="/container/service/slapd/assets/certs/ldap.crt",
+                        source_path=f"security/mtls/{svc_name}/cert.pem",
+                    ),
+                )
+                ctx.append_payload(
+                    svc_name,
+                    ctx.runtime_payload(
+                        key="security-mtls-openldap-ldap.key",
+                        mount_path="/container/service/slapd/assets/certs/ldap.key",
+                        source_path=f"security/mtls/{svc_name}/key.pem",
+                    ),
+                )
+                ctx.append_port(svc_name, RuntimePort(name="ldaps", port=636))
+            if service_kind == "db":
+                ctx.append_payload(
+                    svc_name,
+                    ctx.runtime_payload(
+                        key="security-mtls-mysql.cnf",
+                        mount_path="/etc/mysql/conf.d/openrange-mtls.cnf",
+                        source_path=f"security/mtls/{svc_name}/mysql.cnf",
+                    ),
+                )
 
         ctx.mtls = mtls_config.model_dump()
 

--- a/src/open_range/security_integrator.py
+++ b/src/open_range/security_integrator.py
@@ -12,9 +12,10 @@ Tier mapping (configurable):
 - **Tier 3+**: Full stack -- identity + encryption + mTLS + NPC credential
   lifecycle with authorization policies.
 
-The integrator runs as a post-render enrichment step.  It reads the
-``WorldIR``, generates security artefacts, and writes them as JSON
-config files alongside the rendered Kind/Helm artifacts.
+The integrator builds a deterministic security runtime plan from the
+``WorldIR`` and build tier. It generates the needed artefacts on disk and
+describes the runtime components that render should materialize directly
+into the chart values.
 
 Ported from k3s-istio-vault-platform's orchestration patterns:
 - App-of-apps component ordering (root-chart)
@@ -31,10 +32,17 @@ import random
 from copy import deepcopy
 from importlib.resources import files
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
+from open_range.runtime_extensions import (
+    RenderExtensions,
+    RuntimePayload,
+    RuntimePort,
+    RuntimeSidecar,
+    ServiceRuntimeExtension,
+)
 from open_range.world_ir import WorldIR
 
 logger = logging.getLogger(__name__)
@@ -143,64 +151,45 @@ class SecurityContext(BaseModel):
     mtls: dict[str, Any] = Field(default_factory=dict)
     npc_credential_lifecycle: dict[str, Any] = Field(default_factory=dict)
     generated_files: list[str] = Field(default_factory=list)
-    service_patches: dict[str, "ServicePatch"] = Field(default_factory=dict)
+    service_runtime: dict[str, ServiceRuntimeExtension] = Field(default_factory=dict)
 
-    def append_patch(
-        self,
-        service_id: str,
-        patch_type: Literal["payloads", "ports", "sidecars"],
-        item: Any,
-    ) -> None:
-        patch = self.service_patches.setdefault(service_id, ServicePatch())
-        if item is not None:
-            getattr(patch, patch_type).append(item)
+    def service_extension(self, service_id: str) -> ServiceRuntimeExtension:
+        return self.service_runtime.setdefault(service_id, ServiceRuntimeExtension())
 
-    def payload_patch(
+    def append_payload(self, service_id: str, payload: RuntimePayload | None) -> None:
+        if payload is not None:
+            self.service_extension(service_id).payloads.append(payload)
+
+    def append_port(self, service_id: str, port: RuntimePort) -> None:
+        self.service_extension(service_id).ports.append(port)
+
+    def append_sidecar(self, service_id: str, sidecar: RuntimeSidecar) -> None:
+        self.service_extension(service_id).sidecars.append(sidecar)
+
+    def runtime_payload(
         self, source_path: Path, key: str, mount_path: str
-    ) -> PayloadPatch | None:
+    ) -> RuntimePayload | None:
         if not source_path.exists():
             return None
-        return PayloadPatch(
+        return RuntimePayload(
             key=key,
             mountPath=mount_path,
             content=source_path.read_text(encoding="utf-8"),
         )
 
+    def summary(self) -> dict[str, Any]:
+        return self.model_dump(mode="json", exclude={"service_runtime"})
 
-class PayloadPatch(BaseModel):
-    """Mountable content to inject into a service."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    key: str
-    mountPath: str
-    content: str
-
-
-class SidecarPatch(BaseModel):
-    """Additional container attached to a rendered service."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    name: str
-    image: str | None = None
-    command: list[str] = Field(default_factory=list)
-    args: list[str] = Field(default_factory=list)
-    ports: list[dict[str, Any]] = Field(default_factory=list)
-    env: dict[str, str] = Field(default_factory=dict)
-    payloads: list[PayloadPatch] = Field(default_factory=list)
-    inherit_image_from_service: bool = False
-    inherit_payloads_from_service: bool = False
-
-
-class ServicePatch(BaseModel):
-    """Rendered-service mutations produced by an integration pass."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    payloads: list[PayloadPatch] = Field(default_factory=list)
-    ports: list[dict[str, Any]] = Field(default_factory=list)
-    sidecars: list[SidecarPatch] = Field(default_factory=list)
+    def render_extensions(self) -> RenderExtensions:
+        return RenderExtensions(
+            services=self.service_runtime,
+            values={"security": self.summary()},
+            summary_updates={
+                "security_tier": self.tier,
+                "security_integration_enabled": True,
+            },
+            rendered_files=tuple(self.generated_files),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -365,53 +354,48 @@ class SecurityIntegrator:
         ]
         if idp_targets:
             idp_id = idp_targets[0]
-            ctx.append_patch(
+            ctx.append_payload(
                 idp_id,
-                "payloads",
-                ctx.payload_patch(
+                ctx.runtime_payload(
                     idp_dir / "config.json",
                     "security-idp-config.json",
                     "/etc/openrange/identity-provider.json",
                 ),
             )
-            ctx.append_patch(
+            ctx.append_payload(
                 idp_id,
-                "payloads",
-                ctx.payload_patch(
+                ctx.runtime_payload(
                     idp_dir / "startup.sh",
                     "security-idp-startup.sh",
                     "/opt/openrange/start_identity_provider.sh",
                 ),
             )
-            ctx.append_patch(
+            ctx.append_payload(
                 idp_id,
-                "payloads",
-                ctx.payload_patch(
+                ctx.runtime_payload(
                     idp_dir / "identity_provider_server.py",
                     "security-idp-server.py",
                     "/opt/openrange/identity_provider_server.py",
                 ),
             )
-            ctx.append_patch(
+            ctx.append_port(
                 idp_id,
-                "ports",
-                {
-                    "name": "idp-token",
-                    "port": int(
+                RuntimePort(
+                    name="idp-token",
+                    port=int(
                         idp_config.token_endpoint_port
                         if hasattr(idp_config, "token_endpoint_port")
                         else 8443
                     ),
-                },
+                ),
             )
-            ctx.append_patch(
+            ctx.append_sidecar(
                 idp_id,
-                "sidecars",
-                SidecarPatch(
+                RuntimeSidecar(
                     name="idp-helper",
-                    command=["/bin/sh", "/opt/openrange/start_identity_provider.sh"],
-                    inherit_image_from_service=True,
-                    inherit_payloads_from_service=True,
+                    image_source="service",
+                    command=("/bin/sh", "/opt/openrange/start_identity_provider.sh"),
+                    include_service_payloads=True,
                 ),
             )
 
@@ -508,19 +492,17 @@ class SecurityIntegrator:
             )
 
             for svc_name in services:
-                ctx.append_patch(
+                ctx.append_payload(
                     svc_name,
-                    "payloads",
-                    ctx.payload_patch(
+                    ctx.runtime_payload(
                         enc_dir / "config.json",
                         "security-encryption-config.json",
                         "/etc/openrange/encryption-config.json",
                     ),
                 )
-                ctx.append_patch(
+                ctx.append_payload(
                     svc_name,
-                    "payloads",
-                    ctx.payload_patch(
+                    ctx.runtime_payload(
                         enc_dir / "wrapped_dek.json",
                         "security-wrapped-dek.json",
                         "/etc/openrange/wrapped_dek.json",
@@ -585,28 +567,25 @@ class SecurityIntegrator:
                 (svc_dir / fname).write_text(payload["content"], encoding="utf-8")
                 ctx.generated_files.append(str(svc_dir / fname))
 
-            ctx.append_patch(
+            ctx.append_payload(
                 svc_name,
-                "payloads",
-                ctx.payload_patch(
+                ctx.runtime_payload(
                     svc_dir / "ca.pem",
                     "security-mtls-ca.pem",
                     "/etc/mtls/ca.pem",
                 ),
             )
-            ctx.append_patch(
+            ctx.append_payload(
                 svc_name,
-                "payloads",
-                ctx.payload_patch(
+                ctx.runtime_payload(
                     svc_dir / "cert.pem",
                     "security-mtls-cert.pem",
                     "/etc/mtls/cert.pem",
                 ),
             )
-            ctx.append_patch(
+            ctx.append_payload(
                 svc_name,
-                "payloads",
-                ctx.payload_patch(
+                ctx.runtime_payload(
                     svc_dir / "key.pem",
                     "security-mtls-key.pem",
                     "/etc/mtls/key.pem",

--- a/src/open_range/security_runtime.py
+++ b/src/open_range/security_runtime.py
@@ -24,6 +24,10 @@ if TYPE_CHECKING:
     from open_range.world_ir import WorldIR
 
 
+_DETERMINISTIC_CERT_EPOCH = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+_MIN_RENDER_CERT_VALIDITY_DAYS = 3650
+
+
 _STATIC_CA_PRIVATE_KEY_PEM = """-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAuhvpIJGaPyUf0YjDUbgPX9tj6kBbvQDuDZ7JbVOoV2/8haNi
 gdZCKTLZWDkeCtXKFDitAW4LTSy0kNfQOEMyfG6O1fcDI2+D7GjHtG5EVg+yxGFl
@@ -380,7 +384,11 @@ def _mtls_files(
         return {}
 
     services, _ = _service_zone_layout(world)
-    now = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+    now = _DETERMINISTIC_CERT_EPOCH
+    # Keep deterministic render-time certs valid across calendar time.
+    # The explicit expired_cert weakness remains the supported way to
+    # materialize an actually expired certificate.
+    validity_days = max(config.cert_validity_days, _MIN_RENDER_CERT_VALIDITY_DAYS)
 
     def load_key(pem: str) -> rsa.RSAPrivateKey:
         return serialization.load_pem_private_key(pem.encode("utf-8"), password=None)
@@ -410,7 +418,7 @@ def _mtls_files(
         .public_key(ca_key.public_key())
         .serial_number(_serial_number(world, security_runtime, "mtls-ca"))
         .not_valid_before(now)
-        .not_valid_after(now + datetime.timedelta(days=config.cert_validity_days * 2))
+        .not_valid_after(now + datetime.timedelta(days=validity_days * 2))
         .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
         .sign(ca_key, hashes.SHA256())
     )
@@ -421,13 +429,15 @@ def _mtls_files(
         .public_key(rogue_ca_key.public_key())
         .serial_number(_serial_number(world, security_runtime, "mtls-rogue-ca"))
         .not_valid_before(now)
-        .not_valid_after(now + datetime.timedelta(days=365))
+        .not_valid_after(now + datetime.timedelta(days=validity_days))
         .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
         .sign(rogue_ca_key, hashes.SHA256())
     )
 
+    rendered_config = config.model_copy(update={"cert_validity_days": validity_days})
     file_contents = {
-        "security/mtls/config.json": json.dumps(config.model_dump(), indent=2) + "\n"
+        "security/mtls/config.json": json.dumps(rendered_config.model_dump(), indent=2)
+        + "\n"
     }
     for service_id in config.mtls_services:
         weakness = next(iter(config.weaknesses.get(service_id, ())), None)
@@ -441,11 +451,9 @@ def _mtls_files(
             sans = [x509.DNSName(f"wrong-{service_id}.{zone}.svc.cluster.local")]
 
         not_valid_before = now
-        not_valid_after = now + datetime.timedelta(days=config.cert_validity_days)
+        not_valid_after = now + datetime.timedelta(days=validity_days)
         if weakness == "expired_cert":
-            not_valid_before = now - datetime.timedelta(
-                days=config.cert_validity_days + 30
-            )
+            not_valid_before = now - datetime.timedelta(days=validity_days + 30)
             not_valid_after = now - datetime.timedelta(days=1)
 
         signer_key = ca_key

--- a/src/open_range/security_runtime.py
+++ b/src/open_range/security_runtime.py
@@ -1,0 +1,579 @@
+"""Canonical security runtime plan stored on ``WorldIR``."""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import hashlib
+import json
+from importlib.resources import files
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from open_range.runtime_extensions import (
+    RenderExtensions,
+    RuntimePayload,
+    RuntimePort,
+    RuntimeSidecar,
+    ServiceRuntimeExtension,
+)
+
+if TYPE_CHECKING:
+    from open_range.world_ir import WorldIR
+
+
+_STATIC_CA_PRIVATE_KEY_PEM = """-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAuhvpIJGaPyUf0YjDUbgPX9tj6kBbvQDuDZ7JbVOoV2/8haNi
+gdZCKTLZWDkeCtXKFDitAW4LTSy0kNfQOEMyfG6O1fcDI2+D7GjHtG5EVg+yxGFl
+nZq2+IZ0fcrLDdUEfGaQRzUACmqfd+fddYsGfNjP8PHtc8EwUgzlCUn6uXOiJ7mp
+Iy+A6pnY4ANL01AmFVXVYA8KR1YGNJew9eDvwFiImnRILTqcnoHew9i9YRnsL2jf
+9kSD8Aka0K+9CR3NrGAQvmFoM58uXtYcAcOr8rR/qO5cUuu0QXHYmqJWbp2y83M3
+zrPWNeFGbxsiabKxD7vjZGPlofUyZV5Tctk7cQIDAQABAoIBAA8T4su6MBpsigri
+Pxy4QjqcXhhk1WnXEPI2ipAaZnmK/5TeG0V0k9Cdp4Efw4DSODhyLQYAIddDR2+y
+pFJik00EcfsAs5bj2nbFOGS0SEIGrI9/aomdtrQkxHxKeS/qMZ5YetjiANpXMAs5
+VDZJKKHluNcG6ptlq+IB3G5nuXHbumocUypsiuUfxrZ6z+vJPJd/G4oIYMdxcbru
+oigNv/3Aje53aY686GKX1IuP6QdMbwnDwoRrtEL/KsIxawDCAN2+e52Zl2XfafQU
+hEI30HNQgNN8X/EZ2m3CRMY0RHU7Lw61KtDqTiYlBxrjuf72sq73BBggS5xoHVsD
+Xa+5S6kCgYEA7U5UwInUCKtg/q9+Sv5AEpNT0b5CX0qRcspApvh6V2uzbVdxpS0B
+lwPQ6Y9ZxSIqH+XbCpqjMfL5iTftQHTtyowZyKicrO4pdCbD3VPV/BI0A7rXhD/D
+AdJTXMmFyCLA87Ike/+SQ2CvyyPA1eNAFgd6BnONk/sWdpfc0cLC1SUCgYEAyMUb
+p+4cK+nx3Oa/qYJjyL0P7DFK7d7vk1+FrubdUs3Iupa4SY3PIoJnhN5Dx+ZXtc8x
+ZAr6p5wH14o9BEwCOcQwtkDc9bv7iKE03w6Mef1u83TqAdSiJnu3yHsRrOnJA1cv
+wQlYcI3TbOHE3FGR8ETzcBA7E+0iGiFRWpStiV0CgYEAuw7f59W9egf9sUUMvHim
+cP4JOHBNSWgyNtYPGI8NgRO4oBwpzRYpBq1PZIxHKwm/Qt2hSD6VHa513SBkuEZz
+mxHM0Ut4FSi3LIPSKQkIyGZg8f+6GtlYEnuEksOX3SboCjEGaWgQF2SDrhFE1FUK
+E1NZcPRtSZTHJDyZKA/qHLECgYEAvixm+/TB3p7lKPexyODnn/fmIza14QfxK0mq
+GXg5YPvoDUZDHfkjoW6gm+zli26W2nJ+OGNl9moHy5T4Ix/UY9+AvMJICsSbiFoa
++MaRLeRvulCecEl3prg957sbjQyOCYoGg/VUPpk5EcPxczgY4tyNMzNMop1WViYF
+J6X5k0kCgYBy3WJ8MqAWlPoNsCdO0/cQQfNT081tnsQJ0K+8aheQ9qFuaWBKrMjE
+eQiXyT00vpKnD8rLgUEanB+Eqh5k6vu6CmLii+fXKYIdvV9gSjmxzXKZG5nW5YE7
+CbgHRVlOObXl83/998EyIUDoyYHIzDpVEvzNek7CUCLH7uRHMsMDpA==
+-----END RSA PRIVATE KEY-----
+"""
+
+_STATIC_SERVICE_PRIVATE_KEY_PEM = """-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEA3SOUMMd9y7fvn2anLAVq8k0sl36PJhLqv9X9bDvZ3zMRFvxJ
+81Urvb2vVENsV3Wl8Stx/q4N+02hgTmbkmgH/B291Hj9KH1PcekIljHnWPY9nzTt
+VLyMQk9vNkxoPuhhJ95FQDQjYGjVkijlen9utuhdnv2OchtkrMW6d04Za/Em1TRF
+eSr6U+0zQEqRbKvlpGuLVQHgeylZ1zjShefqZSWYe50M+OBkS7GRMf06LQjMAfVL
+ifJIzk8JI/HJhEWbnvC9nR6tmw55IpGvUxnj4GIi1jG7vtWVvIG0Mf1RuAqKBxAA
+tb4Wdmoy10lHhzWZp7gCuiLqG/QVNGh2hpW0SQIDAQABAoIBAA9dJbJW5ddFxfzv
+45z0GmhPstGqrhTh2xPtcOA4b0xpzp3ndNbWW8XgvCHxVkFkT91n3JFqc9e6Hsas
+4zFij211focYydPqkt6x51ISEQX2A7WANp38xIzl2m7uE48NU5SyxWJuzOdpmS8A
+ruLaIC3OipSdfqxQWWgEi842q577XtEmp7Wi/n/Xa+q2dyWNPQUi/54zjH3BxIik
+x4q/6IV/gvcqRo912/p06X0RqIvsZx3EHtxm0H4p6RqLE2s+wtl0J1/jrzvGE05z
+EMglicmY2xZ7j20qDAuoesVbGprFXvwQ16VaTPGkmTiNfqLIlDUzpaASN5iJuzxs
+Q2l7c1UCgYEA+r2z42aMMdUIGYLIekOBp+c93vPGedkevKVUYtSPnxjEj1qxf8c5
+FODVISyo9Z5+hfZATtwapYgTcvQZUUKOIbBALYaxAWmsHWzXnomuygnj/g/9RwVU
+s4Vu+h4SWR5eVwB0Iv5nbD4By+VL3hWN5m/8sZYJVKSgeiC25NDSIV0CgYEA4cbv
+RyOomcFJDTHiLzk5KhwjlLn/62p2xZi1J+hcynQHY6N8Xuw40f4zfSLTANhO7Wnw
+PVIlWD7GRnNNxLBMYQ4wU5avZB3bdZXa8YAggo+LaoO9hSSx+Bav3Jgid0sIAxlI
+6Qxdmx0J4kb5SGzSY2gXlu4pir2+BYcQf3c5E90CgYEA5SewmtgisnxGbcI35H2D
+pmbRBcz3DG8hBzl2GOi45acmJPm3FNeHVIxyXGJLfEbAzT+T4D6KX9QwKjPqW3if
+GyzQSos5g9gGw9GwcaTVSLKnWo9UY678jSEanp4TGL2HbK3udfjZnnRBAg5qOuqq
+B/s7DzXXCzN1sofpfs9V68UCgYEA3XzvF3bf25ZGN++L2I/miGz6atjdOvFCey4H
+6ZKGFQYmiZTEWcqbI0ag9E3Jeba6FyYqS73ebOeIU2yiCiZ5h20H87iLb0frFztf
+gjMTsYFoX6HFtmv9O0fmVh3ZEfZFceTIJfe/jH+8RoMh4e7/pg1jtukFT9o8I+gQ
+QzuOfvECgYEA5c7pHZpLwjwlmOkjtXBCnw9U12COr0YRwrckB+H0ZScoyS7/qt2m
+HqyEnhav+a2Otlaxf8ndXWRiB0jGf8409vDz7X/aNoDYO2K3PWs92JalQQVmVW9X
+LCdu8t3Lwq9yUmUyC7o3oLt5nLeUnalktCI9QJiktIFr/ZEElb9ByDM=
+-----END RSA PRIVATE KEY-----
+"""
+
+_STATIC_WEAK_SERVICE_PRIVATE_KEY_PEM = """-----BEGIN RSA PRIVATE KEY-----
+MIICXgIBAAKBgQDWfURggCroy92zjPDiPb1teW7DXB38A06J1l4gzpcNU3tbXX8K
+mFXL23ZzxJvZPGur7A/j3lSOS1q8qahIBPKeoe8KZs7QAvOlcaOJ/q+Wg7x8Z5TF
+Co5IlfWobhnYRUxd2J9Er8VMsphb9+JQQyg0imsMQc2NfUkalBl5YM8IrwIDAQAB
+AoGAcXl0Y1lrWh4A/KzkA82GGhTUdKaXdmyJcILo6ZJid7pi2MNuIrzVJzTERhsO
+GK/OhvYssfE96soTBxz62p9De5EAmgJaZ2uDjkcy3nxoJtBQAkPnerMz4Wqiukxv
+R1m7BAp6ggHiLv8dqzED9YjPFcNDgr3a+MF6Cz0kIj+xjgECQQD3dLZAFFdySR+S
+wPKHunkXkwjV6aMFO0FgKngyybfhPfcz47LqDJ9VgSUj5bLncbZXjRcHV1PJdJwX
+CJL2roKfAkEA3eUpAovadLR9/ol5syhcrkR8SDv6P5NgxJbRX/uDcK3miznh5R1S
+gfk/7yoMbf1iiaDWYobVbna397IKp2lP8QJBAMFoqHXHMF30B0h1pFovhivF0VcY
+aEFTghJ+vzm67gyPmSImaxWBzhtPeE7pXn6FIyak8QXc3HENwl5CZlOGLDMCQQDS
+XrFrtZWuMXSGPmYAAdMkcM93WE2fuqTynJ3yJqztxiEdfAn7Qrp3eQwxPac9HA4w
+tyipjnWI3cr6bXSGVWSxAkEAzXjLbr3niEjP/HydSjlPn2Jc2z8ngIO4l3hFueg1
+8QkOdg7aSr+kVlma516waQDhVRpkQrZZV+5rbMqhkzgCUg==
+-----END RSA PRIVATE KEY-----
+"""
+
+_STATIC_ROGUE_CA_PRIVATE_KEY_PEM = """-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAjFt8OCHngxHGq2+nW/i/Tmnw6XSYhvY/K74gwiiHs4CfX+1m
+mhJ3rTuMMb6ttDp9b025fKor0XWda5R7CmGsALAEvDusL1mImhl+30g3+F7b+VqL
+SNQyOvZSfEGa84ff7TeFdupvUr9ZzUhpTrF8L3EWiLX8T0qK3REH4oV8BAvhMSlC
+VXZ2gT3dFcTwW/Cyziz6FCT1eUtwf0B5ustQa7WewDOtJPUaO2/eO7u2EZbF0aJn
+4SmxwBIT9US4SEf3/XKqfUzDmZWzfBqC9LP0dfLQY/xARS7yFeolGEqVcFk2EHf5
+cSkBYDPzHRGmsEAxM9p87po56LaiBmW4We0F8QIDAQABAoIBAAoZVQ1G5z0HjOdt
+77lO4xj1x3dMw+LGGhKAKiQ+PVFdmloRH1ZLqN/GjpZPtXjn0nmtOoDtT5zRHSQN
++XJsR69++sA+fOulQg5wcjAHprtQu/wrlyUE255hddrp74fBSYvseEZvpNXr3b7H
+DIi0fY5+URRCH+bmoqo4XPxgBWXXB7QvTD+8T5F47ELcXAMAcxAehXcROHVPnpKJ
+LwFl1fjgnZKQv4nFKBrpJI2uPB4B0K3EGPgDhupf17Q6WtCxW4xTEoPYUWI00rn4
+BhSe3SwCmUSBTF4kWq125KwiQ3mRRfw6lpNiM+HcPt/dGxfgDSj5Glr+nMZ+FT6u
+2xwx3D8CgYEAvoY54ChfzWUOa6T5fwXh/Leyp30sN7TFhcNXIQpvs59nSeKeMBmZ
+jUdQuPlsBi5gO/mzt1UFezqoSpaV0zbCAv0bVYkq+THdIPugiXH09j/pV0SF/4vj
+A/orEbNC+21INGLEfct4kqllia8z131TcupiWY2KpL6mcRqRozG/hb8CgYEAvJe3
+eClP60XoLRNGd/eK1vTCfs2oZGEIwoZJhGoP6dmMOUbjJLAdQryf8sCuNxvCPcDD
+Wq7p8AFJbRMcEVatmiODjxoI6fIeo6siUoKBOS0CpRByinqNtgmjHAZvO8Z+V4Jm
+z3GjVZobizfZk8Dh/f5tc9t8Aqjc7eoBGXhdQE8CgYAk372b0LSaABEGbGuNVgoi
+6zq8h9FjBq2j8eaPEoID9bn75sxO6uV5HnBVHJD3sUoW0YEi3mWtL/EaXoKo2lQ6
+V9pOd7nFeQ0fMRQlBdUvQ7dZmH2GtAA/6M8lIdi46LGs0eDNp++yEu7/8tTJxAu+
+lfZq9qX6tJtqEIZXW22B6QKBgQCP3AuQFbNo/QKGn9V5XdMC9eIHaEmziHFuMZGS
++HT7JX/ZkUFjkxQ+/DPmsSQz1XDuOkTKv/Kjqdeg5JrcfwoeMkkAuBNkodTNdJXR
+6ss4GiWSVGGLUMEYw3Ewx5fCOT/W8RoL09uMSOoJ4KiQFOpPHe3QGvUV8knVElOU
+YkR/8QKBgE2cw9ydqMfD+dZhq5dWvrq511D6R/ZCE7dt/GGoXehfkdtSPLv3/Usd
+l3epP2A/aRLuFFSp3bPwEDqxelrex4Z4VxOQYNxZH/llggt8ayjlsJnnYiQV19NV
+HoPJtsmDPERc0rzWK2lXQLpw20VDrQR7H1Pux2HiFql/h6MJT1sm
+-----END RSA PRIVATE KEY-----
+"""
+
+
+class SecurityPayloadSpec(BaseModel):
+    """Declarative payload mount generated from a security artifact."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
+
+    key: str
+    mount_path: str = Field(alias="mountPath")
+    source_path: str
+
+
+class SecurityServiceRuntimeSpec(BaseModel):
+    """Declarative runtime additions owned by the security plan."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    payloads: tuple[SecurityPayloadSpec, ...] = Field(default_factory=tuple)
+    ports: tuple[RuntimePort, ...] = Field(default_factory=tuple)
+    sidecars: tuple[RuntimeSidecar, ...] = Field(default_factory=tuple)
+
+
+class SecurityRuntimeSpec(BaseModel):
+    """Security runtime intent for a world.
+
+    Concrete files and payload contents are derived during render so the
+    canonical world model only carries the declared security plan.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    tier: int = 1
+    identity_provider: dict[str, Any] = Field(default_factory=dict)
+    encryption: dict[str, Any] = Field(default_factory=dict)
+    mtls: dict[str, Any] = Field(default_factory=dict)
+    npc_credential_lifecycle: dict[str, Any] = Field(default_factory=dict)
+    service_runtime: dict[str, SecurityServiceRuntimeSpec] = Field(default_factory=dict)
+
+    @property
+    def enabled(self) -> bool:
+        return self.tier > 1
+
+    def summary(self) -> dict[str, Any]:
+        return self.model_dump(
+            mode="json",
+            exclude={"service_runtime"},
+        )
+
+
+def materialize_security_runtime(
+    world: WorldIR,
+    render_dir: Path,
+) -> RenderExtensions:
+    """Materialize the security plan into render-time files and extensions."""
+
+    security_runtime = world.security_runtime
+    if not security_runtime.enabled:
+        return RenderExtensions()
+
+    file_contents = _build_security_file_contents(world, security_runtime)
+    written_paths: list[str] = []
+    for relative_path, content in file_contents.items():
+        path = render_dir / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        written_paths.append(str(path))
+
+    services: dict[str, ServiceRuntimeExtension] = {}
+    for service_id, extension in security_runtime.service_runtime.items():
+        payloads = [
+            RuntimePayload(
+                key=payload.key,
+                mountPath=payload.mount_path,
+                content=_required_file_content(file_contents, payload.source_path),
+            )
+            for payload in extension.payloads
+        ]
+        services[service_id] = ServiceRuntimeExtension(
+            payloads=payloads,
+            ports=list(extension.ports),
+            sidecars=list(extension.sidecars),
+        )
+
+    return RenderExtensions(
+        services=services,
+        values={"security": security_runtime.summary()},
+        summary_updates={
+            "security_tier": security_runtime.tier,
+            "security_integration_enabled": True,
+        },
+        rendered_files=tuple(written_paths),
+    )
+
+
+def _required_file_content(
+    file_contents: dict[str, str],
+    relative_path: str,
+) -> str:
+    try:
+        return file_contents[relative_path]
+    except KeyError as exc:  # pragma: no cover - defensive, validated by tests
+        raise ValueError(
+            f"security runtime references missing artifact {relative_path!r}"
+        ) from exc
+
+
+def _build_security_file_contents(
+    world: WorldIR,
+    security_runtime: SecurityRuntimeSpec,
+) -> dict[str, str]:
+    file_contents: dict[str, str] = {}
+    file_contents.update(_identity_provider_files(security_runtime))
+    file_contents.update(_encryption_files(world, security_runtime))
+    file_contents.update(_mtls_files(world, security_runtime))
+    file_contents.update(_npc_files(security_runtime))
+    file_contents["security/security-context.json"] = (
+        json.dumps(security_runtime.summary(), indent=2, sort_keys=True) + "\n"
+    )
+    return file_contents
+
+
+def _identity_provider_files(
+    security_runtime: SecurityRuntimeSpec,
+) -> dict[str, str]:
+    if not security_runtime.identity_provider:
+        return {}
+    try:
+        from open_range.identity_provider import (
+            IdentityProviderConfig,
+            SimulatedIdentityProvider,
+        )
+    except ImportError:  # pragma: no cover - optional dependency
+        return {}
+
+    idp_config = IdentityProviderConfig.model_validate(
+        security_runtime.identity_provider
+    )
+    idp = SimulatedIdentityProvider(idp_config)
+    server_template = (
+        files("open_range")
+        .joinpath("templates")
+        .joinpath("identity_provider_server.py.tpl")
+        .read_text(encoding="utf-8")
+    )
+    return {
+        "security/idp/config.json": json.dumps(idp_config.model_dump(), indent=2)
+        + "\n",
+        "security/idp/startup.sh": idp.generate_startup_script(),
+        "security/idp/identity_provider_server.py": server_template,
+    }
+
+
+def _encryption_files(
+    world: WorldIR,
+    security_runtime: SecurityRuntimeSpec,
+) -> dict[str, str]:
+    if not security_runtime.encryption:
+        return {}
+    try:
+        from open_range.envelope_crypto import (
+            EncryptedBundle,
+            EncryptionConfig,
+            _aes_gcm_encrypt,
+        )
+    except ImportError:  # pragma: no cover - optional dependency
+        return {}
+
+    config = EncryptionConfig.model_validate(security_runtime.encryption)
+    if not config.enabled or not config.encrypted_paths:
+        return {}
+
+    credentials = {cred.id: cred for cred in world.credentials}
+    master_key = _derive_bytes(
+        world,
+        security_runtime,
+        label="encryption-master-key",
+        length=32,
+    )
+    dek_metadata: dict[str, Any] = {}
+
+    for credential_id in config.encrypted_paths:
+        credential = credentials.get(credential_id)
+        if credential is None:
+            raise ValueError(
+                f"security runtime references unknown credential {credential_id!r}"
+            )
+        aad = f"openrange:range:{credential.subject}:{credential.id}"
+        dek = _derive_bytes(
+            world,
+            security_runtime,
+            label="encryption-dek",
+            item=credential.id,
+            length=32,
+        )
+        nonce = _derive_bytes(
+            world,
+            security_runtime,
+            label="encryption-nonce",
+            item=credential.id,
+            length=12,
+        )
+        wrap_nonce = _derive_bytes(
+            world,
+            security_runtime,
+            label="encryption-wrap-nonce",
+            item=credential.id,
+            length=12,
+        )
+        ciphertext = _aes_gcm_encrypt(
+            dek,
+            nonce,
+            credential.secret_ref.encode("utf-8"),
+            aad.encode("utf-8"),
+        )
+        wrapped_ct = _aes_gcm_encrypt(master_key, wrap_nonce, dek, b"dek-wrap")
+        bundle = EncryptedBundle(
+            ciphertext=base64.b64encode(ciphertext).decode(),
+            nonce=base64.b64encode(nonce).decode(),
+            wrapped_dek=base64.b64encode(wrap_nonce + wrapped_ct).decode(),
+            aad=aad,
+            key_version=1,
+        )
+        dek_metadata[credential.id] = bundle.model_dump()
+
+    return {
+        "security/encryption/config.json": json.dumps(config.model_dump(), indent=2)
+        + "\n",
+        "security/encryption/wrapped_dek.json": json.dumps(dek_metadata, indent=2)
+        + "\n",
+    }
+
+
+def _mtls_files(
+    world: WorldIR,
+    security_runtime: SecurityRuntimeSpec,
+) -> dict[str, str]:
+    if not security_runtime.mtls:
+        return {}
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+        from open_range.mtls_sim import MTLSConfig
+    except ImportError:  # pragma: no cover - optional dependency
+        return {}
+
+    config = MTLSConfig.model_validate(security_runtime.mtls)
+    if not config.enabled or not config.mtls_services:
+        return {}
+
+    services, _ = _service_zone_layout(world)
+    now = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+
+    def load_key(pem: str) -> rsa.RSAPrivateKey:
+        return serialization.load_pem_private_key(pem.encode("utf-8"), password=None)
+
+    ca_key = load_key(_STATIC_CA_PRIVATE_KEY_PEM)
+    rogue_ca_key = load_key(_STATIC_ROGUE_CA_PRIVATE_KEY_PEM)
+    strong_service_key = load_key(_STATIC_SERVICE_PRIVATE_KEY_PEM)
+    weak_service_key = load_key(_STATIC_WEAK_SERVICE_PRIVATE_KEY_PEM)
+
+    ca_subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, config.ca_common_name),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "OpenRange"),
+        ]
+    )
+    rogue_subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, "Rogue CA"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Untrusted"),
+        ]
+    )
+
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_subject)
+        .issuer_name(ca_subject)
+        .public_key(ca_key.public_key())
+        .serial_number(_serial_number(world, security_runtime, "mtls-ca"))
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=config.cert_validity_days * 2))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    rogue_ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(rogue_subject)
+        .issuer_name(rogue_subject)
+        .public_key(rogue_ca_key.public_key())
+        .serial_number(_serial_number(world, security_runtime, "mtls-rogue-ca"))
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(rogue_ca_key, hashes.SHA256())
+    )
+
+    file_contents = {
+        "security/mtls/config.json": json.dumps(config.model_dump(), indent=2) + "\n"
+    }
+    for service_id in config.mtls_services:
+        weakness = next(iter(config.weaknesses.get(service_id, ())), None)
+        zone = services.get(service_id, "default")
+        fqdn = f"{service_id}.{zone}.svc.cluster.local"
+        sans = [
+            x509.DNSName(fqdn),
+            x509.DNSName(f"{service_id}.{zone}"),
+        ]
+        if weakness == "wrong_san":
+            sans = [x509.DNSName(f"wrong-{service_id}.{zone}.svc.cluster.local")]
+
+        not_valid_before = now
+        not_valid_after = now + datetime.timedelta(days=config.cert_validity_days)
+        if weakness == "expired_cert":
+            not_valid_before = now - datetime.timedelta(
+                days=config.cert_validity_days + 30
+            )
+            not_valid_after = now - datetime.timedelta(days=1)
+
+        signer_key = ca_key
+        signer_subject = ca_subject
+        ca_pem = ca_cert.public_bytes(serialization.Encoding.PEM).decode()
+        if weakness == "self_signed":
+            signer_key = rogue_ca_key
+            signer_subject = rogue_subject
+            ca_pem = rogue_ca_cert.public_bytes(serialization.Encoding.PEM).decode()
+
+        service_key = (
+            weak_service_key if weakness == "weak_key_1024" else strong_service_key
+        )
+        eku = [ExtendedKeyUsageOID.SERVER_AUTH]
+        if weakness != "no_client_verify":
+            eku.append(ExtendedKeyUsageOID.CLIENT_AUTH)
+
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(
+                x509.Name(
+                    [
+                        x509.NameAttribute(
+                            NameOID.COMMON_NAME, f"{service_id}.range.local"
+                        ),
+                        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "OpenRange"),
+                    ]
+                )
+            )
+            .issuer_name(signer_subject)
+            .public_key(service_key.public_key())
+            .serial_number(
+                _serial_number(world, security_runtime, "mtls-service", service_id)
+            )
+            .not_valid_before(not_valid_before)
+            .not_valid_after(not_valid_after)
+            .add_extension(x509.SubjectAlternativeName(sans), critical=False)
+            .add_extension(x509.ExtendedKeyUsage(eku), critical=False)
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None), critical=True
+            )
+            .sign(signer_key, hashes.SHA256())
+        )
+
+        file_contents[f"security/mtls/{service_id}/ca.pem"] = ca_pem
+        file_contents[f"security/mtls/{service_id}/cert.pem"] = cert.public_bytes(
+            serialization.Encoding.PEM
+        ).decode()
+        file_contents[f"security/mtls/{service_id}/key.pem"] = (
+            service_key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption(),
+            ).decode()
+        )
+
+    return file_contents
+
+
+def _npc_files(
+    security_runtime: SecurityRuntimeSpec,
+) -> dict[str, str]:
+    if not security_runtime.npc_credential_lifecycle:
+        return {}
+    return {
+        "security/npc/config.json": json.dumps(
+            security_runtime.npc_credential_lifecycle,
+            indent=2,
+        )
+        + "\n"
+    }
+
+
+def _service_zone_layout(
+    world: WorldIR,
+) -> tuple[dict[str, str], dict[str, list[str]]]:
+    host_by_id = {host.id: host for host in world.hosts}
+    services: dict[str, str] = {}
+    zones_dict: dict[str, list[str]] = {}
+    for service in world.services:
+        zone = (
+            host_by_id[service.host].zone if service.host in host_by_id else "default"
+        )
+        services[service.id] = zone
+        zones_dict.setdefault(zone, []).append(service.id)
+    return services, zones_dict
+
+
+def _derive_bytes(
+    world: WorldIR,
+    security_runtime: SecurityRuntimeSpec,
+    *,
+    label: str,
+    item: str = "",
+    length: int,
+) -> bytes:
+    seed = json.dumps(
+        {
+            "world_id": world.world_id,
+            "seed": world.seed,
+            "label": label,
+            "item": item,
+            "summary": security_runtime.summary(),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    output = bytearray()
+    counter = 0
+    while len(output) < length:
+        counter_bytes = counter.to_bytes(4, byteorder="big")
+        output.extend(hashlib.sha256(seed + counter_bytes).digest())
+        counter += 1
+    return bytes(output[:length])
+
+
+def _serial_number(
+    world: WorldIR,
+    security_runtime: SecurityRuntimeSpec,
+    label: str,
+    item: str = "",
+) -> int:
+    raw = _derive_bytes(
+        world,
+        security_runtime,
+        label=label,
+        item=item,
+        length=20,
+    )
+    serial = int.from_bytes(raw, byteorder="big") >> 1
+    return serial or 1

--- a/src/open_range/security_runtime.py
+++ b/src/open_range/security_runtime.py
@@ -148,6 +148,7 @@ class SecurityServiceRuntimeSpec(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
+    env: dict[str, str] = Field(default_factory=dict)
     payloads: tuple[SecurityPayloadSpec, ...] = Field(default_factory=tuple)
     ports: tuple[RuntimePort, ...] = Field(default_factory=tuple)
     sidecars: tuple[RuntimeSidecar, ...] = Field(default_factory=tuple)
@@ -209,6 +210,7 @@ def materialize_security_runtime(
             for payload in extension.payloads
         ]
         services[service_id] = ServiceRuntimeExtension(
+            env=dict(extension.env),
             payloads=payloads,
             ports=list(extension.ports),
             sidecars=list(extension.sidecars),
@@ -384,6 +386,7 @@ def _mtls_files(
         return {}
 
     services, _ = _service_zone_layout(world)
+    service_kinds = {service.id: service.kind for service in world.services}
     now = _DETERMINISTIC_CERT_EPOCH
     # Keep deterministic render-time certs valid across calendar time.
     # The explicit expired_cert weakness remains the supported way to
@@ -509,6 +512,14 @@ def _mtls_files(
                 serialization.NoEncryption(),
             ).decode()
         )
+        if service_kinds.get(service_id) == "db":
+            file_contents[f"security/mtls/{service_id}/mysql.cnf"] = (
+                "[mysqld]\n"
+                "ssl-ca=/etc/mtls/ca.pem\n"
+                "ssl-cert=/etc/mtls/cert.pem\n"
+                "ssl-key=/etc/mtls/key.pem\n"
+                "require_secure_transport=ON\n"
+            )
 
     return file_contents
 

--- a/src/open_range/world_ir.py
+++ b/src/open_range/world_ir.py
@@ -16,6 +16,7 @@ from open_range.manifest import (
     WeaknessTargetKind,
 )
 from open_range.objectives import StandardAttackObjective
+from open_range.security_runtime import SecurityRuntimeSpec
 
 
 class _StrictModel(BaseModel):
@@ -199,6 +200,7 @@ class WorldIR(_StrictModel):
     blue_objectives: tuple[ObjectiveSpec, ...] = Field(default_factory=tuple)
     green_personas: tuple[GreenPersona, ...] = Field(default_factory=tuple)
     green_workload: GreenWorkloadSpec
+    security_runtime: SecurityRuntimeSpec = Field(default_factory=SecurityRuntimeSpec)
     mutation_bounds: MutationBoundsSpec = Field(default_factory=MutationBoundsSpec)
     lineage: LineageSpec
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -227,6 +227,45 @@ def test_security_runtime_materialization_is_deterministic(tmp_path: Path):
         ).read_text(encoding="utf-8")
 
 
+def test_security_runtime_mtls_cert_window_stays_long_lived(tmp_path: Path):
+    cryptography = pytest.importorskip("cryptography.x509")
+
+    pipeline = BuildPipeline(store=FileSnapshotStore(tmp_path / "snapshots"))
+    pipeline.build(
+        _manifest_payload(),
+        tmp_path / "rendered-security-window",
+        BuildConfig(
+            validation_profile="graph_only",
+            security_integration_enabled=True,
+            security_tier=3,
+        ),
+    )
+
+    ca_cert = cryptography.load_pem_x509_certificate(
+        (
+            tmp_path
+            / "rendered-security-window"
+            / "security"
+            / "mtls"
+            / "svc-db"
+            / "ca.pem"
+        ).read_bytes()
+    )
+    svc_cert = cryptography.load_pem_x509_certificate(
+        (
+            tmp_path
+            / "rendered-security-window"
+            / "security"
+            / "mtls"
+            / "svc-db"
+            / "cert.pem"
+        ).read_bytes()
+    )
+
+    assert ca_cert.not_valid_after_utc.year >= 2033
+    assert svc_cert.not_valid_after_utc.year >= 2033
+
+
 def test_renderer_applies_runtime_extensions_during_render(tmp_path: Path):
     manifest = validate_manifest(_manifest_payload())
     build_config = BuildConfig(validation_profile="graph_only")

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -23,6 +23,7 @@ from open_range.runtime_extensions import (
 from open_range.store import FileSnapshotStore
 from open_range.synth import EnterpriseSaaSWorldSynthesizer
 from open_range.weaknesses import CatalogWeaknessSeeder
+from open_range.world_ir import WorldIR
 from tests.support import manifest_payload
 
 
@@ -87,6 +88,7 @@ def test_build_config_can_filter_services_without_touching_manifest_schema(
     )
 
     assert candidate.world.allowed_service_kinds == ("web_app", "idp", "siem")
+    assert candidate.world.security_runtime.tier == 1
 
 
 def test_build_config_can_enable_security_integration(tmp_path: Path):
@@ -104,6 +106,12 @@ def test_build_config_can_enable_security_integration(tmp_path: Path):
     )
 
     assert candidate.build_config == build_config
+    assert candidate.world.security_runtime.tier == 3
+    idp_payload_spec = candidate.world.security_runtime.service_runtime[
+        "svc-idp"
+    ].payloads[0]
+    assert idp_payload_spec.source_path.startswith("security/idp/")
+    assert "content" not in idp_payload_spec.model_dump(by_alias=True)
     assert candidate.artifacts.chart_values["security"]["tier"] == 3
     assert any(
         path.endswith("security/security-context.json")
@@ -170,6 +178,53 @@ def test_security_integration_renders_idp_runtime_hooks_with_helm(tmp_path: Path
     assert "containerPort: 8443" in rendered
     assert "/opt/openrange/start_identity_provider.sh" in rendered
     assert "name: idp-helper" in rendered
+
+
+def test_security_runtime_round_trips_through_world_ir_json(tmp_path: Path):
+    pipeline = BuildPipeline(store=FileSnapshotStore(tmp_path / "snapshots"))
+    candidate = pipeline.build(
+        _manifest_payload(),
+        tmp_path / "rendered-security-roundtrip",
+        BuildConfig(
+            validation_profile="graph_only",
+            security_integration_enabled=True,
+            security_tier=3,
+        ),
+    )
+
+    round_tripped = WorldIR.model_validate_json(candidate.world.model_dump_json())
+
+    assert round_tripped.security_runtime.tier == 3
+    payload = round_tripped.security_runtime.service_runtime["svc-idp"].payloads[0]
+    assert payload.key
+    assert payload.source_path.startswith("security/idp/")
+    assert "content" not in payload.model_dump(by_alias=True)
+
+
+def test_security_runtime_materialization_is_deterministic(tmp_path: Path):
+    pipeline = BuildPipeline(store=FileSnapshotStore(tmp_path / "snapshots"))
+    candidate = pipeline.build(
+        _manifest_payload(),
+        tmp_path / "rendered-security-deterministic",
+        BuildConfig(
+            validation_profile="graph_only",
+            security_integration_enabled=True,
+            security_tier=3,
+        ),
+    )
+
+    renderer = EnterpriseSaaSKindRenderer()
+    renderer.render(candidate.world, candidate.synth, tmp_path / "render-a")
+    renderer.render(candidate.world, candidate.synth, tmp_path / "render-b")
+
+    for relative_path in (
+        "security/encryption/wrapped_dek.json",
+        "security/mtls/svc-db/key.pem",
+        "security/security-context.json",
+    ):
+        assert (tmp_path / "render-a" / relative_path).read_text(encoding="utf-8") == (
+            tmp_path / "render-b" / relative_path
+        ).read_text(encoding="utf-8")
 
 
 def test_renderer_applies_runtime_extensions_during_render(tmp_path: Path):

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -8,10 +8,21 @@ from open_range._runtime_store import hydrate_runtime_snapshot
 import pytest
 
 from open_range.build_config import BuildConfig
+from open_range.compiler import EnterpriseSaaSManifestCompiler
 from open_range.episode_config import EpisodeConfig
 from open_range.manifest import validate_manifest
 from open_range.pipeline import BuildPipeline
+from open_range.render import EnterpriseSaaSKindRenderer
+from open_range.runtime_extensions import (
+    RenderExtensions,
+    RuntimePayload,
+    RuntimePort,
+    RuntimeSidecar,
+    ServiceRuntimeExtension,
+)
 from open_range.store import FileSnapshotStore
+from open_range.synth import EnterpriseSaaSWorldSynthesizer
+from open_range.weaknesses import CatalogWeaknessSeeder
 from tests.support import manifest_payload
 
 
@@ -159,6 +170,63 @@ def test_security_integration_renders_idp_runtime_hooks_with_helm(tmp_path: Path
     assert "containerPort: 8443" in rendered
     assert "/opt/openrange/start_identity_provider.sh" in rendered
     assert "name: idp-helper" in rendered
+
+
+def test_renderer_applies_runtime_extensions_during_render(tmp_path: Path):
+    manifest = validate_manifest(_manifest_payload())
+    build_config = BuildConfig(validation_profile="graph_only")
+    world = CatalogWeaknessSeeder().apply(
+        EnterpriseSaaSManifestCompiler().compile(manifest, build_config)
+    )
+    synth = EnterpriseSaaSWorldSynthesizer().synthesize(world, tmp_path / "synth")
+    extensions = RenderExtensions(
+        services={
+            "svc-idp": ServiceRuntimeExtension(
+                payloads=[
+                    RuntimePayload(
+                        key="runtime-helper.sh",
+                        mountPath="/opt/openrange/runtime-helper.sh",
+                        content="#!/bin/sh\nexit 0\n",
+                    )
+                ],
+                ports=[RuntimePort(name="runtime-helper", port=8443)],
+                sidecars=[
+                    RuntimeSidecar(
+                        name="runtime-helper",
+                        image_source="service",
+                        include_service_payloads=True,
+                        command=("/bin/sh", "/opt/openrange/runtime-helper.sh"),
+                    )
+                ],
+            )
+        },
+        values={"security": {"tier": 3}},
+        summary_updates={"security_tier": 3},
+        rendered_files=(str(tmp_path / "security-context.json"),),
+    )
+
+    artifacts = EnterpriseSaaSKindRenderer().render(
+        world,
+        synth,
+        tmp_path / "rendered-with-extensions",
+        extensions=extensions,
+    )
+
+    idp_service = artifacts.chart_values["services"]["svc-idp"]
+    sidecar = idp_service["sidecars"][0]
+
+    assert artifacts.chart_values["security"]["tier"] == 3
+    assert any(
+        payload["mountPath"] == "/opt/openrange/runtime-helper.sh"
+        for payload in idp_service["payloads"]
+    )
+    assert any(port["port"] == 8443 for port in idp_service["ports"])
+    assert sidecar["image"] == idp_service["image"]
+    assert any(
+        payload["mountPath"] == "/opt/openrange/runtime-helper.sh"
+        for payload in sidecar["payloads"]
+    )
+    assert str(tmp_path / "security-context.json") in artifacts.rendered_files
 
 
 def test_build_config_can_select_k3d_and_cilium_outputs(tmp_path: Path):

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -118,14 +118,17 @@ def test_build_config_can_enable_security_integration(tmp_path: Path):
         for path in candidate.artifacts.rendered_files
     )
     idp_service = candidate.artifacts.chart_values["services"]["svc-idp"]
+    idp_env = idp_service["env"]
     idp_payloads = idp_service["payloads"]
-    db_payloads = candidate.artifacts.chart_values["services"]["svc-db"]["payloads"]
+    db_service = candidate.artifacts.chart_values["services"]["svc-db"]
+    db_payloads = db_service["payloads"]
     idp_sidecar = idp_service["sidecars"][0]
 
     assert any(
         payload["mountPath"] == "/opt/openrange/identity_provider_server.py"
         for payload in idp_payloads
     )
+    assert idp_service["command"] == ["/container/tool/run", "--copy-service"]
     assert idp_sidecar["name"] == "idp-helper"
     assert idp_sidecar["command"] == [
         "/bin/sh",
@@ -139,11 +142,30 @@ def test_build_config_can_enable_security_integration(tmp_path: Path):
         for payload in idp_sidecar["payloads"]
     )
     assert any(port["port"] == 8443 for port in idp_service["ports"])
+    assert any(port["port"] == 636 for port in idp_service["ports"])
+    assert idp_env["LDAP_TLS_CRT_FILENAME"] == "ldap.crt"
+    assert idp_env["LDAP_TLS_CA_CRT_FILENAME"] == "ca.crt"
+    assert idp_env["LDAP_TLS_VERIFY_CLIENT"] == "demand"
+    assert any(
+        payload["mountPath"] == "/container/service/slapd/assets/certs/ldap.crt"
+        for payload in idp_payloads
+    )
     assert any(
         payload["mountPath"] == "/etc/openrange/wrapped_dek.json"
         for payload in db_payloads
     )
     assert any(payload["mountPath"] == "/etc/mtls/cert.pem" for payload in db_payloads)
+    assert any(
+        payload["mountPath"] == "/etc/mysql/conf.d/openrange-mtls.cnf"
+        for payload in db_payloads
+    )
+    mysql_tls_config = next(
+        payload["content"]
+        for payload in db_service["payloads"]
+        if payload["mountPath"] == "/etc/mysql/conf.d/openrange-mtls.cnf"
+    )
+    assert "require_secure_transport=ON" in mysql_tls_config
+    assert "ssl-cert=/etc/mtls/cert.pem" in mysql_tls_config
 
 
 def test_security_integration_renders_idp_runtime_hooks_with_helm(tmp_path: Path):

--- a/tests/test_mtls_sim.py
+++ b/tests/test_mtls_sim.py
@@ -403,7 +403,8 @@ class TestServiceTLSEnv:
 
     def test_ldap_env(self):
         env = MTLSSimulator.get_service_tls_env("ldap")
-        assert env["LDAP_TLS_CRT_FILENAME"] == "/etc/mtls/cert.pem"
+        assert env["LDAP_TLS_CRT_FILENAME"] == "ldap.crt"
+        assert env["LDAP_TLS_CA_CRT_FILENAME"] == "ca.crt"
         assert env["LDAP_TLS_VERIFY_CLIENT"] == "demand"
 
     def test_unknown_service_returns_empty(self):

--- a/tests/test_security_integrator.py
+++ b/tests/test_security_integrator.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from open_range.security_runtime import materialize_security_runtime
 from open_range.security_integrator import (
     DEFAULT_TIER_MAP,
     SecurityIntegrator,
@@ -104,7 +105,7 @@ class TestIntegratorDisabled:
         assert ctx.tier == 3
         assert not ctx.identity_provider
         assert not ctx.encryption
-        assert not ctx.generated_files
+        assert not ctx.service_runtime
 
     def test_noop_for_tier1(self, sample_world, render_dir):
         integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
@@ -135,9 +136,11 @@ class TestIdentityIntegration:
         integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
         integrator.integrate(sample_world, render_dir=render_dir, tier=2)
 
-        idp_config_path = render_dir / "security" / "idp" / "config.json"
-        assert idp_config_path.exists()
-        data = json.loads(idp_config_path.read_text())
+        data = json.loads(
+            (render_dir / "security" / "idp" / "config.json").read_text(
+                encoding="utf-8"
+            )
+        )
         assert data["enabled"] is True
 
     def test_idp_runtime_files_written(self, sample_world, render_dir):
@@ -166,7 +169,8 @@ class TestIdentityIntegration:
     ):
         integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
         ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=2)
-        extensions = ctx.render_extensions()
+        render_world = sample_world.model_copy(update={"security_runtime": ctx})
+        extensions = materialize_security_runtime(render_world, render_dir)
 
         assert "svc-idp" in extensions.services
         assert extensions.values["security"]["tier"] == 2
@@ -208,9 +212,11 @@ class TestEncryptionIntegration:
         )
         integrator.integrate(sample_world, render_dir=render_dir, tier=2)
 
-        dek_path = render_dir / "security" / "encryption" / "wrapped_dek.json"
-        assert dek_path.exists()
-        data = json.loads(dek_path.read_text())
+        data = json.loads(
+            (render_dir / "security" / "encryption" / "wrapped_dek.json").read_text(
+                encoding="utf-8"
+            )
+        )
         assert isinstance(data, dict)
         assert len(data) >= 1
 
@@ -230,10 +236,7 @@ class TestMTLSIntegration:
 
         assert ctx.mtls
         assert ctx.mtls["enabled"] is True
-        # Cert files should exist
-        mtls_dir = render_dir / "security" / "mtls"
-        assert mtls_dir.exists()
-        cert_files = list(mtls_dir.rglob("*.pem"))
+        cert_files = list((render_dir / "security" / "mtls").glob("*/*.pem"))
         assert len(cert_files) >= 3
 
     @pytest.mark.skipif(
@@ -306,6 +309,4 @@ class TestFullIntegration:
         assert ctx.mtls
         assert ctx.npc_credential_lifecycle
 
-        # Security context file should exist
-        ctx_path = render_dir / "security" / "security-context.json"
-        assert ctx_path.exists()
+        assert (render_dir / "security" / "security-context.json").exists()

--- a/tests/test_security_integrator.py
+++ b/tests/test_security_integrator.py
@@ -238,6 +238,17 @@ class TestMTLSIntegration:
         assert ctx.mtls["enabled"] is True
         cert_files = list((render_dir / "security" / "mtls").glob("*/*.pem"))
         assert len(cert_files) >= 3
+        assert ctx.service_runtime["svc-idp"].env["LDAP_TLS_VERIFY_CLIENT"] == "demand"
+        assert ctx.service_runtime["svc-idp"].env["LDAP_TLS_CRT_FILENAME"] == "ldap.crt"
+        assert any(
+            payload.mount_path == "/container/service/slapd/assets/certs/ldap.crt"
+            for payload in ctx.service_runtime["svc-idp"].payloads
+        )
+        assert any(port.port == 636 for port in ctx.service_runtime["svc-idp"].ports)
+        assert any(
+            payload.mount_path == "/etc/mysql/conf.d/openrange-mtls.cnf"
+            for payload in ctx.service_runtime["svc-db"].payloads
+        )
 
     @pytest.mark.skipif(
         not _has_cryptography(), reason="cryptography library not available"

--- a/tests/test_security_integrator.py
+++ b/tests/test_security_integrator.py
@@ -155,12 +155,26 @@ class TestIdentityIntegration:
         integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
         ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=2)
 
-        idp_sidecar = ctx.service_patches["svc-idp"].sidecars[0]
+        idp_sidecar = ctx.service_runtime["svc-idp"].sidecars[0]
 
         assert idp_sidecar.name == "idp-helper"
-        assert idp_sidecar.image is None
-        assert idp_sidecar.inherit_image_from_service is True
-        assert idp_sidecar.inherit_payloads_from_service is True
+        assert idp_sidecar.image_source == "service"
+        assert idp_sidecar.include_service_payloads is True
+
+    def test_render_extensions_export_security_runtime_and_summary(
+        self, sample_world, render_dir
+    ):
+        integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))
+        ctx = integrator.integrate(sample_world, render_dir=render_dir, tier=2)
+        extensions = ctx.render_extensions()
+
+        assert "svc-idp" in extensions.services
+        assert extensions.values["security"]["tier"] == 2
+        assert extensions.summary_updates["security_tier"] == 2
+        assert any(
+            path.endswith("security/security-context.json")
+            for path in extensions.rendered_files
+        )
 
     def test_spiffe_ids_in_identities(self, sample_world, render_dir):
         integrator = SecurityIntegrator(SecurityIntegratorConfig(enabled=True))


### PR DESCRIPTION
Closes #

## Summary

This is the world-model version of the security runtime cleanup.

Instead of generating the world and then layering security changes onto rendered services afterward, `WorldIR` now carries a typed security runtime plan and render materializes the files, payloads, and sidecars from that plan. That keeps the source of truth in the model, makes later mutations target the world instead of a patch layer, and removes the old pipeline-side security surgery.

It also keeps the render boundary deterministic: the same world now re-renders the same encryption bundle, mTLS material, and security context output.

## Testing

- `uv run -m open_range.cli admit -m src/open_range/_resources/manifests/tier1_basic.yaml -o "$tmpdir/admit" --store-dir "$tmpdir/store" --validation-profile graph_only --security-tier 3`
- Live Kind smoke on `blackberry`: built and admitted `tier1_basic.yaml` with `security_tier=3`, ran `OpenRange.reset()`, and verified `svc-idp` came up `2/2`, the helper files were mounted, and `/healthz` returned `{"status": "ok"}`

## Review Notes

This is intentionally the deeper architecture step on top of `fix/pr142-service-patch-contract`, not just another wiring patch. The main thing to sanity-check is whether `WorldIR` owning the security runtime intent feels like the right source-of-truth boundary.
