### PR TITLE
Fix DB mTLS to require client certs end to end

### DIFF
--- a/src/open_range/admit.py
+++ b/src/open_range/admit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 import shutil
 import subprocess
 import time
@@ -235,6 +236,7 @@ class LocalAdmissionController:
             backend = PodActionBackend()
             backend.bind(snapshot, release)
             checks.append(_live_service_smoke_check(world, release))
+            checks.append(_live_db_mtls_check(world, release))
             clear_runtime_markers(release, world)
             checks.append(_live_red_reference_check(snapshot, release, backend))
             checks.append(_live_siem_ingest_check(release))
@@ -894,6 +896,108 @@ def _live_service_smoke_check(world: WorldIR, release) -> ValidatorCheckReport:
         name="live_service_smoke",
         passed=not failures,
         details={"failures": failures},
+        error="; ".join(failures),
+    )
+
+
+def _live_db_mtls_check(world: WorldIR, release) -> ValidatorCheckReport:
+    mtls = world.security_runtime.mtls
+    if not mtls or not mtls.get("enabled"):
+        return ValidatorCheckReport(
+            name="live_db_mtls",
+            passed=True,
+            details={"note": "mTLS not enabled"},
+        )
+
+    web_clients = [
+        service
+        for service in world.services
+        if service.kind == "web_app" and "svc-db" in service.dependencies
+    ]
+    if not web_clients:
+        return ValidatorCheckReport(
+            name="live_db_mtls",
+            passed=True,
+            details={"note": "no built-in web client depends on svc-db"},
+        )
+
+    web_client = web_clients[0]
+    positive_cmd = (
+        "mysql --defaults-extra-file=/etc/mysql/conf.d/openrange-client-mtls.cnf "
+        '-Nse "SELECT 1;"'
+    )
+    positive_result = run_async(
+        release.pods.exec(
+            web_client.id,
+            positive_cmd,
+            timeout=15.0,
+            container="db-client-mtls",
+        )
+    )
+
+    negative_cmd = shlex.join(
+        [
+            "mysql",
+            "--protocol=TCP",
+            "--connect-timeout=5",
+            "-h",
+            "svc-db",
+            "-uapp",
+            "-papp-pass",
+            "app",
+            "-Nse",
+            "SELECT 'openrange-db-mtls-ok';",
+        ]
+    )
+    negative_result = run_async(
+        release.pods.exec("sandbox-red", negative_cmd, timeout=15.0)
+    )
+    negative_output = (
+        "\n".join(
+            part for part in (negative_result.stdout, negative_result.stderr) if part
+        )
+        .strip()
+        .lower()
+    )
+
+    failures: list[str] = []
+    if not positive_result.ok:
+        failures.append(
+            f"positive_path:{positive_result.stderr or positive_result.stdout or 'failed'}"
+        )
+    if negative_result.ok:
+        failures.append("no_cert_path:unexpected_success")
+    elif not any(
+        marker in negative_output
+        for marker in (
+            "access denied",
+            "require x509",
+            "x509",
+            "certificate",
+            "ssl",
+            "tls",
+            "1045",
+        )
+    ):
+        failures.append(
+            f"no_cert_path:unexpected_failure_mode:{negative_result.stderr or negative_result.stdout or 'failed'}"
+        )
+
+    return ValidatorCheckReport(
+        name="live_db_mtls",
+        passed=not failures,
+        details={
+            "web_client": web_client.id,
+            "positive_runner": web_client.id,
+            "positive_container": "db-client-mtls",
+            "positive_cmd": positive_cmd,
+            "positive_stdout": positive_result.stdout.strip(),
+            "positive_stderr": positive_result.stderr.strip(),
+            "negative_runner": "sandbox-red",
+            "negative_cmd": negative_cmd,
+            "negative_stdout": negative_result.stdout.strip(),
+            "negative_stderr": negative_result.stderr.strip(),
+        },
         error="; ".join(failures),
     )
 

--- a/src/open_range/admit.py
+++ b/src/open_range/admit.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import json
-import shlex
 import shutil
 import subprocess
-import time
 from pathlib import Path
 from typing import Callable, Protocol
 from urllib.parse import urlencode
@@ -27,6 +25,7 @@ from open_range.encryption_enforcement import check_encryption_enforcement
 from open_range.execution import PodActionBackend
 from open_range.identity_enforcement import check_identity_enforcement
 from open_range.k3d_runner import K3dBackend
+from open_range.live_checks import check_live_db_mtls, check_live_service_smoke
 from open_range.mtls_enforcement import check_mtls_enforcement
 from open_range.objectives import evaluate_objective_grader_live
 from open_range.predicates import PredicateEngine
@@ -235,8 +234,8 @@ class LocalAdmissionController:
             snapshot = _ephemeral_snapshot(world, artifacts, reference_bundle)
             backend = PodActionBackend()
             backend.bind(snapshot, release)
-            checks.append(_live_service_smoke_check(world, release))
-            checks.append(_live_db_mtls_check(world, release))
+            checks.append(check_live_service_smoke(world, release))
+            checks.append(check_live_db_mtls(world, release))
             clear_runtime_markers(release, world)
             checks.append(_live_red_reference_check(snapshot, release, backend))
             checks.append(_live_siem_ingest_check(release))
@@ -871,174 +870,6 @@ def _ephemeral_snapshot(
         reference_bundle=reference_bundle,
         world_hash=world_hash(world),
     )
-
-
-def _live_service_smoke_check(world: WorldIR, release) -> ValidatorCheckReport:
-    failures: list[str] = []
-    for service in world.services:
-        runner = _smoke_runner_for_service(world, service.id)
-        cmd = _smoke_probe_command(service)
-        last_error = "smoke failed"
-        ok = False
-        attempts = 10 if service.kind == "db" else 3
-        retry_delay_s = 2.0 if service.kind == "db" else 1.0
-        for attempt in range(attempts):
-            result = run_async(release.pods.exec(runner, cmd, timeout=10.0))
-            if result.ok:
-                ok = True
-                break
-            last_error = result.stderr or result.stdout or "smoke failed"
-            if attempt + 1 < attempts:
-                time.sleep(retry_delay_s)
-        if not ok:
-            failures.append(f"{service.id}:{last_error}")
-    return ValidatorCheckReport(
-        name="live_service_smoke",
-        passed=not failures,
-        details={"failures": failures},
-        error="; ".join(failures),
-    )
-
-
-def _live_db_mtls_check(world: WorldIR, release) -> ValidatorCheckReport:
-    mtls = world.security_runtime.mtls
-    if not mtls or not mtls.get("enabled"):
-        return ValidatorCheckReport(
-            name="live_db_mtls",
-            passed=True,
-            details={"note": "mTLS not enabled"},
-        )
-
-    web_clients = [
-        service
-        for service in world.services
-        if service.kind == "web_app" and "svc-db" in service.dependencies
-    ]
-    if not web_clients:
-        return ValidatorCheckReport(
-            name="live_db_mtls",
-            passed=True,
-            details={"note": "no built-in web client depends on svc-db"},
-        )
-
-    web_client = web_clients[0]
-    positive_cmd = (
-        "mysql --defaults-extra-file=/etc/mysql/conf.d/openrange-client-mtls.cnf "
-        '-Nse "SELECT 1;"'
-    )
-    positive_result = run_async(
-        release.pods.exec(
-            web_client.id,
-            positive_cmd,
-            timeout=15.0,
-            container="db-client-mtls",
-        )
-    )
-
-    negative_cmd = shlex.join(
-        [
-            "mysql",
-            "--protocol=TCP",
-            "--connect-timeout=5",
-            "-h",
-            "svc-db",
-            "-uapp",
-            "-papp-pass",
-            "app",
-            "-Nse",
-            "SELECT 'openrange-db-mtls-ok';",
-        ]
-    )
-    negative_result = run_async(
-        release.pods.exec("sandbox-red", negative_cmd, timeout=15.0)
-    )
-    negative_output = (
-        "\n".join(
-            part for part in (negative_result.stdout, negative_result.stderr) if part
-        )
-        .strip()
-        .lower()
-    )
-
-    failures: list[str] = []
-    if not positive_result.ok:
-        failures.append(
-            f"positive_path:{positive_result.stderr or positive_result.stdout or 'failed'}"
-        )
-    if negative_result.ok:
-        failures.append("no_cert_path:unexpected_success")
-    elif not any(
-        marker in negative_output
-        for marker in (
-            "access denied",
-            "require x509",
-            "x509",
-            "certificate",
-            "ssl",
-            "tls",
-            "1045",
-        )
-    ):
-        failures.append(
-            f"no_cert_path:unexpected_failure_mode:{negative_result.stderr or negative_result.stdout or 'failed'}"
-        )
-
-    return ValidatorCheckReport(
-        name="live_db_mtls",
-        passed=not failures,
-        details={
-            "web_client": web_client.id,
-            "positive_runner": web_client.id,
-            "positive_container": "db-client-mtls",
-            "positive_cmd": positive_cmd,
-            "positive_stdout": positive_result.stdout.strip(),
-            "positive_stderr": positive_result.stderr.strip(),
-            "negative_runner": "sandbox-red",
-            "negative_cmd": negative_cmd,
-            "negative_stdout": negative_result.stdout.strip(),
-            "negative_stderr": negative_result.stderr.strip(),
-        },
-        error="; ".join(failures),
-    )
-
-
-def _smoke_runner_for_service(world: WorldIR, service_id: str) -> str:
-    service_by_id = {service.id: service for service in world.services}
-    host_zone_by_id = {host.id: host.zone for host in world.hosts}
-    service = service_by_id[service_id]
-    zone = host_zone_by_id.get(service.host, "")
-    if zone in {"dmz", "external"}:
-        return "sandbox-red"
-    if zone == "management":
-        return "sandbox-blue"
-    if zone in {"corp", "data"}:
-        runner = _first_green_sandbox_in_zones(world, ("dmz", "corp", zone))
-        if runner:
-            return runner
-    runner = _first_green_sandbox_in_zones(world, (zone,))
-    if runner:
-        return runner
-    return "sandbox-blue" if zone == "management" else "sandbox-red"
-
-
-def _first_green_sandbox_in_zones(world: WorldIR, zones: tuple[str, ...]) -> str:
-    host_zone_by_id = {host.id: host.zone for host in world.hosts}
-    allowed = set(zones)
-    for persona in world.green_personas:
-        zone = host_zone_by_id.get(persona.home_host, "")
-        if zone in allowed:
-            safe = "".join(ch.lower() if ch.isalnum() else "-" for ch in persona.id)
-            return f"sandbox-green-{safe.strip('-')}"
-    return ""
-
-
-def _smoke_probe_command(service: ServiceSpec) -> str:
-    port = service.ports[0] if service.ports else 80
-    if service.id == "svc-web":
-        return f"wget -qO- http://{service.id}:{port}/ | grep -q OpenRange"
-    if service.id == "svc-siem":
-        return "wget -qO- http://svc-siem:9200/all.log >/dev/null"
-    return f"nc -z -w 3 {service.id} {port}"
 
 
 def _live_red_reference_check(

--- a/src/open_range/cluster.py
+++ b/src/open_range/cluster.py
@@ -47,14 +47,23 @@ class PodSet:
     pod_ids: dict[str, str] = field(default_factory=dict)
     kubectl_cmd: tuple[str, ...] = ("kubectl",)
 
-    async def exec(self, service: str, cmd: str, timeout: float = 30.0) -> ExecResult:
+    async def exec(
+        self,
+        service: str,
+        cmd: str,
+        timeout: float = 30.0,
+        *,
+        container: str | None = None,
+    ) -> ExecResult:
         namespace, pod = self._resolve(service)
+        container_args = ["-c", container] if container else []
         proc = await asyncio.create_subprocess_exec(
             *self.kubectl_cmd,
             "exec",
             pod,
             "-n",
             namespace,
+            *container_args,
             "--",
             "sh",
             "-c",

--- a/src/open_range/image_policy.py
+++ b/src/open_range/image_policy.py
@@ -1,0 +1,39 @@
+"""Central runtime image policy for rendered OpenRange components.
+
+Keep third-party image choices here so dependency review happens in one place.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+DEFAULT_SERVICE_IMAGE: Final[str] = "ubuntu:22.04"
+
+SERVICE_IMAGE_BY_KIND: Final[dict[str, str]] = {
+    "web_app": "php:8.1-apache",
+    "email": "namshi/smtp:latest",
+    "idp": "osixia/openldap:1.5.0",
+    "fileshare": "dperson/samba:latest",
+    "db": "mysql:8.0",
+    "siem": "busybox:1.36",
+}
+
+# Reused for red/blue sandboxes and the DB mTLS helper so there is a single
+# review point for this third-party troubleshooting image.
+SANDBOX_MULTITOOL_IMAGE: Final[str] = "wbitt/network-multitool:alpine-extra"
+
+SANDBOX_IMAGE_BY_ROLE: Final[dict[str, str]] = {
+    "red": SANDBOX_MULTITOOL_IMAGE,
+    "blue": SANDBOX_MULTITOOL_IMAGE,
+    "green": "busybox:1.36",
+}
+
+DB_MTLS_HELPER_IMAGE: Final[str] = SANDBOX_MULTITOOL_IMAGE
+
+
+def service_image_for_kind(kind: str) -> str:
+    return SERVICE_IMAGE_BY_KIND.get(kind, DEFAULT_SERVICE_IMAGE)
+
+
+def sandbox_image_for_role(role: str) -> str:
+    return SANDBOX_IMAGE_BY_ROLE.get(role, DEFAULT_SERVICE_IMAGE)

--- a/src/open_range/live_checks.py
+++ b/src/open_range/live_checks.py
@@ -1,0 +1,192 @@
+"""Kind-backed live smoke checks used by admission."""
+
+from __future__ import annotations
+
+import shlex
+import time
+
+from open_range.admission import ValidatorCheckReport
+from open_range.async_utils import run_async
+from open_range.world_ir import ServiceSpec, WorldIR
+
+_DB_MTLS_CLIENT_CONTAINER = "db-client-mtls"
+_DB_MTLS_CLIENT_CONFIG = "/etc/mysql/conf.d/openrange-client-mtls.cnf"
+_DB_MTLS_FAILURE_MARKERS = (
+    "access denied",
+    "require x509",
+    "x509",
+    "certificate",
+    "ssl",
+    "tls",
+    "1045",
+)
+
+
+def check_live_service_smoke(world: WorldIR, release) -> ValidatorCheckReport:
+    failures: list[str] = []
+    for service in world.services:
+        runner = smoke_runner_for_service(world, service.id)
+        cmd = _smoke_probe_command(service)
+        last_error = "smoke failed"
+        ok = False
+        attempts = 10 if service.kind == "db" else 3
+        retry_delay_s = 2.0 if service.kind == "db" else 1.0
+        for attempt in range(attempts):
+            result = run_async(release.pods.exec(runner, cmd, timeout=10.0))
+            if result.ok:
+                ok = True
+                break
+            last_error = result.stderr or result.stdout or "smoke failed"
+            if attempt + 1 < attempts:
+                time.sleep(retry_delay_s)
+        if not ok:
+            failures.append(f"{service.id}:{last_error}")
+    return ValidatorCheckReport(
+        name="live_service_smoke",
+        passed=not failures,
+        details={"failures": failures},
+        error="; ".join(failures),
+    )
+
+
+def check_live_db_mtls(world: WorldIR, release) -> ValidatorCheckReport:
+    mtls = world.security_runtime.mtls
+    if not mtls or not mtls.get("enabled"):
+        return ValidatorCheckReport(
+            name="live_db_mtls",
+            passed=True,
+            details={"note": "mTLS not enabled"},
+        )
+
+    web_client = _db_mtls_web_client(world)
+    if web_client is None:
+        return ValidatorCheckReport(
+            name="live_db_mtls",
+            passed=True,
+            details={"note": "no built-in web client depends on svc-db"},
+        )
+
+    positive_cmd = _db_mtls_positive_cmd()
+    positive_result = run_async(
+        release.pods.exec(
+            web_client.id,
+            positive_cmd,
+            timeout=15.0,
+            container=_DB_MTLS_CLIENT_CONTAINER,
+        )
+    )
+
+    negative_cmd = _db_mtls_negative_cmd()
+    negative_result = run_async(
+        release.pods.exec("sandbox-red", negative_cmd, timeout=15.0)
+    )
+
+    failures = _db_mtls_failures(positive_result, negative_result)
+    return ValidatorCheckReport(
+        name="live_db_mtls",
+        passed=not failures,
+        details={
+            "web_client": web_client.id,
+            "positive_runner": web_client.id,
+            "positive_container": _DB_MTLS_CLIENT_CONTAINER,
+            "positive_cmd": positive_cmd,
+            "positive_stdout": positive_result.stdout.strip(),
+            "positive_stderr": positive_result.stderr.strip(),
+            "negative_runner": "sandbox-red",
+            "negative_cmd": negative_cmd,
+            "negative_stdout": negative_result.stdout.strip(),
+            "negative_stderr": negative_result.stderr.strip(),
+        },
+        error="; ".join(failures),
+    )
+
+
+def smoke_runner_for_service(world: WorldIR, service_id: str) -> str:
+    service_by_id = {service.id: service for service in world.services}
+    host_zone_by_id = {host.id: host.zone for host in world.hosts}
+    service = service_by_id[service_id]
+    zone = host_zone_by_id.get(service.host, "")
+    if zone in {"dmz", "external"}:
+        return "sandbox-red"
+    if zone == "management":
+        return "sandbox-blue"
+    if zone in {"corp", "data"}:
+        runner = _first_green_sandbox_in_zones(world, ("dmz", "corp", zone))
+        if runner:
+            return runner
+    runner = _first_green_sandbox_in_zones(world, (zone,))
+    if runner:
+        return runner
+    return "sandbox-blue" if zone == "management" else "sandbox-red"
+
+
+def _db_mtls_web_client(world: WorldIR) -> ServiceSpec | None:
+    for service in world.services:
+        if service.kind == "web_app" and "svc-db" in service.dependencies:
+            return service
+    return None
+
+
+def _db_mtls_positive_cmd() -> str:
+    return f'mysql --defaults-extra-file={_DB_MTLS_CLIENT_CONFIG} -Nse "SELECT 1;"'
+
+
+def _db_mtls_negative_cmd() -> str:
+    return shlex.join(
+        [
+            "mysql",
+            "--protocol=TCP",
+            "--connect-timeout=5",
+            "-h",
+            "svc-db",
+            "-uapp",
+            "-papp-pass",
+            "app",
+            "-Nse",
+            "SELECT 'openrange-db-mtls-ok';",
+        ]
+    )
+
+
+def _db_mtls_failures(positive_result, negative_result) -> list[str]:
+    failures: list[str] = []
+    if not positive_result.ok:
+        failures.append(
+            f"positive_path:{positive_result.stderr or positive_result.stdout or 'failed'}"
+        )
+    if negative_result.ok:
+        failures.append("no_cert_path:unexpected_success")
+    elif not _negative_result_reflects_mtls_enforcement(negative_result):
+        failures.append(
+            f"no_cert_path:unexpected_failure_mode:{negative_result.stderr or negative_result.stdout or 'failed'}"
+        )
+    return failures
+
+
+def _negative_result_reflects_mtls_enforcement(result) -> bool:
+    output = (
+        "\n".join(part for part in (result.stdout, result.stderr) if part)
+        .strip()
+        .lower()
+    )
+    return any(marker in output for marker in _DB_MTLS_FAILURE_MARKERS)
+
+
+def _first_green_sandbox_in_zones(world: WorldIR, zones: tuple[str, ...]) -> str:
+    host_zone_by_id = {host.id: host.zone for host in world.hosts}
+    allowed = set(zones)
+    for persona in world.green_personas:
+        zone = host_zone_by_id.get(persona.home_host, "")
+        if zone in allowed:
+            safe = "".join(ch.lower() if ch.isalnum() else "-" for ch in persona.id)
+            return f"sandbox-green-{safe.strip('-')}"
+    return ""
+
+
+def _smoke_probe_command(service: ServiceSpec) -> str:
+    port = service.ports[0] if service.ports else 80
+    if service.id == "svc-web":
+        return f"wget -qO- http://{service.id}:{port}/ | grep -q OpenRange"
+    if service.id == "svc-siem":
+        return "wget -qO- http://svc-siem:9200/all.log >/dev/null"
+    return f"nc -z -w 3 {service.id} {port}"

--- a/src/open_range/objectives.py
+++ b/src/open_range/objectives.py
@@ -321,10 +321,11 @@ def evaluate_objective_grader_live(
             grader.expected_ref in combined_output or bool(linked_events)
         )
     if grader.grader_kind == "db_row_read":
-        query = "mysql -uapp -papp-pass app -Nse " + shlex.quote(
+        query = _db_query_command(
+            snapshot,
             "SELECT contents FROM assets "
             f"WHERE asset_id = '{grader.target_id}' "
-            "LIMIT 1;"
+            "LIMIT 1;",
         )
         result = run_async(
             pods.exec(grader.service_id or "svc-db", query, timeout=10.0)
@@ -338,10 +339,11 @@ def evaluate_objective_grader_live(
             )
         )
     if grader.grader_kind == "db_row_write":
-        query = "mysql -uapp -papp-pass app -Nse " + shlex.quote(
+        query = _db_query_command(
+            snapshot,
             "SELECT COUNT(*) FROM assets "
             f"WHERE asset_id = '{grader.target_id}' "
-            "LIMIT 1;"
+            "LIMIT 1;",
         )
         result = run_async(
             pods.exec(grader.service_id or "svc-db", query, timeout=10.0)
@@ -356,6 +358,41 @@ def evaluate_objective_grader_live(
             return True
         return _probe_live_objective_effect(snapshot, pods, grader)
     return False
+
+
+def _db_query_command(snapshot: object, query: str) -> str:
+    if _snapshot_mtls_enabled(snapshot):
+        return _mtls_mysql_query_command(query)
+    return "mysql -uapp -papp-pass app -Nse " + shlex.quote(query)
+
+
+def _snapshot_mtls_enabled(snapshot: object) -> bool:
+    world = getattr(snapshot, "world", None)
+    security_runtime = getattr(world, "security_runtime", None)
+    mtls = getattr(security_runtime, "mtls", None)
+    if isinstance(mtls, Mapping):
+        return bool(mtls.get("enabled"))
+    return False
+
+
+def _mtls_mysql_query_command(query: str) -> str:
+    return shlex.join(
+        [
+            "mysql",
+            "--protocol=TCP",
+            "-h",
+            "127.0.0.1",
+            "--ssl-mode=VERIFY_CA",
+            "--ssl-ca=/etc/mtls/ca.pem",
+            "--ssl-cert=/etc/mtls/cert.pem",
+            "--ssl-key=/etc/mtls/key.pem",
+            "-uapp",
+            "-papp-pass",
+            "app",
+            "-Nse",
+            query,
+        ]
+    )
 
 
 def evaluate_red_objectives(

--- a/src/open_range/render.py
+++ b/src/open_range/render.py
@@ -10,6 +10,10 @@ from typing import Any, Protocol
 
 import yaml
 
+from open_range.image_policy import (
+    SANDBOX_IMAGE_BY_ROLE,
+    service_image_for_kind,
+)
 from open_range.runtime_extensions import (
     RenderExtensions,
     apply_service_runtime_extensions,
@@ -22,23 +26,6 @@ from open_range.world_ir import GreenPersona, ServiceSpec, WorldIR
 
 
 _CHART_DIR = Path(__file__).resolve().parent / "chart"
-
-_IMAGE_BY_KIND = {
-    "web_app": "php:8.1-apache",
-    "email": "namshi/smtp:latest",
-    "idp": "osixia/openldap:1.5.0",
-    "fileshare": "dperson/samba:latest",
-    "db": "mysql:8.0",
-    "siem": "busybox:1.36",
-}
-
-_DEFAULT_SANDBOX_MULTITOOL_IMAGE = "wbitt/network-multitool:alpine-extra"
-
-_SANDBOX_IMAGE_BY_ROLE = {
-    "red": _DEFAULT_SANDBOX_MULTITOOL_IMAGE,
-    "blue": _DEFAULT_SANDBOX_MULTITOOL_IMAGE,
-    "green": "busybox:1.36",
-}
 
 
 class KindRenderer(Protocol):
@@ -152,7 +139,7 @@ class EnterpriseSaaSKindRenderer:
                 "host": service.host,
                 "zone": host.zone,
                 "kind": service.kind,
-                "image": _IMAGE_BY_KIND.get(service.kind, "ubuntu:22.04"),
+                "image": service_image_for_kind(service.kind),
                 "ports": [{"name": f"p{port}", "port": port} for port in service.ports],
                 "dependencies": list(service.dependencies),
                 "telemetry_surfaces": list(service.telemetry_surfaces),
@@ -172,7 +159,7 @@ class EnterpriseSaaSKindRenderer:
             "sandbox-red": {
                 "enabled": True,
                 "zone": "external" if "external" in world.zones else world.zones[0],
-                "image": _SANDBOX_IMAGE_BY_ROLE["red"],
+                "image": SANDBOX_IMAGE_BY_ROLE["red"],
                 "role": "red",
                 "command": ["/bin/sh", "-lc", "sleep infinity"],
             },
@@ -181,7 +168,7 @@ class EnterpriseSaaSKindRenderer:
                 "zone": "management"
                 if "management" in world.zones
                 else world.zones[-1],
-                "image": _SANDBOX_IMAGE_BY_ROLE["blue"],
+                "image": SANDBOX_IMAGE_BY_ROLE["blue"],
                 "role": "blue",
                 "command": ["/bin/sh", "-lc", "sleep infinity"],
             },
@@ -277,7 +264,7 @@ class EnterpriseSaaSKindRenderer:
 
     @staticmethod
     def _image_digest_for(kind: str) -> str:
-        image = _IMAGE_BY_KIND.get(kind, "ubuntu:22.04")
+        image = service_image_for_kind(kind)
         digest = hashlib.sha256(image.encode("utf-8")).hexdigest()[:24]
         return f"{image}@sha256:{digest}"
 
@@ -411,7 +398,7 @@ def _green_sandbox(persona: GreenPersona, host_by_id: dict[str, Any]) -> dict[st
     return {
         "enabled": True,
         "zone": zone,
-        "image": _SANDBOX_IMAGE_BY_ROLE["green"],
+        "image": SANDBOX_IMAGE_BY_ROLE["green"],
         "role": "green",
         "persona": persona.id,
         "mailbox": persona.mailbox,

--- a/src/open_range/security_integrator.py
+++ b/src/open_range/security_integrator.py
@@ -33,6 +33,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from open_range.image_policy import DB_MTLS_HELPER_IMAGE
 from open_range.runtime_extensions import (
     RuntimePort,
     RuntimeSidecar,
@@ -46,8 +47,6 @@ from open_range.security_runtime import (
 from open_range.world_ir import WorldIR
 
 logger = logging.getLogger(__name__)
-
-_WEB_DB_MTLS_SIDECAR_IMAGE = "wbitt/network-multitool:alpine-extra"
 
 
 # ---------------------------------------------------------------------------
@@ -600,7 +599,7 @@ class SecurityIntegrator:
                     svc_name,
                     RuntimeSidecar(
                         name="db-client-mtls",
-                        image=_WEB_DB_MTLS_SIDECAR_IMAGE,
+                        image=DB_MTLS_HELPER_IMAGE,
                         command=("/bin/sh", "-lc", "sleep infinity"),
                         include_service_payloads=True,
                     ),

--- a/src/open_range/security_integrator.py
+++ b/src/open_range/security_integrator.py
@@ -47,6 +47,8 @@ from open_range.world_ir import WorldIR
 
 logger = logging.getLogger(__name__)
 
+_WEB_DB_MTLS_SIDECAR_IMAGE = "wbitt/network-multitool:alpine-extra"
+
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -254,11 +256,13 @@ class SecurityIntegrator:
         # Build service→zone mapping from WorldIR
         services: dict[str, str] = {}
         service_kinds: dict[str, str] = {}
+        service_dependencies: dict[str, tuple[str, ...]] = {}
         host_by_id = {h.id: h for h in world.hosts}
         for svc in world.services:
             zone = host_by_id[svc.host].zone if svc.host in host_by_id else "default"
             services[svc.id] = zone
             service_kinds[svc.id] = svc.kind
+            service_dependencies[svc.id] = tuple(svc.dependencies)
 
         domain = "range.local"
 
@@ -269,7 +273,14 @@ class SecurityIntegrator:
             self._integrate_encryption(ctx, world, services, rng)
 
         if tier_cfg.mtls:
-            self._integrate_mtls(ctx, services, service_kinds, domain, rng)
+            self._integrate_mtls(
+                ctx,
+                services,
+                service_kinds,
+                service_dependencies,
+                domain,
+                rng,
+            )
 
         if tier_cfg.npc_credential_lifecycle:
             self._integrate_npc_lifecycle(ctx)
@@ -477,6 +488,7 @@ class SecurityIntegrator:
         ctx: SecurityContext,
         services: dict[str, str],
         service_kinds: dict[str, str],
+        service_dependencies: dict[str, tuple[str, ...]],
         domain: str,
         rng: random.Random,
     ) -> None:
@@ -562,6 +574,35 @@ class SecurityIntegrator:
                         key="security-mtls-mysql.cnf",
                         mount_path="/etc/mysql/conf.d/openrange-mtls.cnf",
                         source_path=f"security/mtls/{svc_name}/mysql.cnf",
+                    ),
+                )
+                ctx.append_payload(
+                    svc_name,
+                    ctx.runtime_payload(
+                        key="security-mtls-mysql-init.sql",
+                        mount_path="/docker-entrypoint-initdb.d/02-openrange-mtls.sql",
+                        source_path=f"security/mtls/{svc_name}/mysql-init.sql",
+                    ),
+                )
+            if "svc-db" in service_dependencies.get(svc_name, ()):
+                ctx.append_payload(
+                    svc_name,
+                    ctx.runtime_payload(
+                        key="security-mtls-mysql-client.cnf",
+                        mount_path="/etc/mysql/conf.d/openrange-client-mtls.cnf",
+                        source_path=f"security/mtls/{svc_name}/mysql-client.cnf",
+                    ),
+                )
+            if service_kind == "web_app" and "svc-db" in service_dependencies.get(
+                svc_name, ()
+            ):
+                ctx.append_sidecar(
+                    svc_name,
+                    RuntimeSidecar(
+                        name="db-client-mtls",
+                        image=_WEB_DB_MTLS_SIDECAR_IMAGE,
+                        command=("/bin/sh", "-lc", "sleep infinity"),
+                        include_service_payloads=True,
                     ),
                 )
 

--- a/src/open_range/security_runtime.py
+++ b/src/open_range/security_runtime.py
@@ -387,6 +387,9 @@ def _mtls_files(
 
     services, _ = _service_zone_layout(world)
     service_kinds = {service.id: service.kind for service in world.services}
+    service_dependencies = {
+        service.id: tuple(service.dependencies) for service in world.services
+    }
     now = _DETERMINISTIC_CERT_EPOCH
     # Keep deterministic render-time certs valid across calendar time.
     # The explicit expired_cert weakness remains the supported way to
@@ -520,7 +523,30 @@ def _mtls_files(
                 "ssl-key=/etc/mtls/key.pem\n"
                 "require_secure_transport=ON\n"
             )
-
+            file_contents[f"security/mtls/{service_id}/mysql-init.sql"] = (
+                "CREATE USER IF NOT EXISTS 'app'@'%' IDENTIFIED WITH mysql_native_password BY 'app-pass';\n"
+                "CREATE USER IF NOT EXISTS 'app'@'localhost' IDENTIFIED WITH mysql_native_password BY 'app-pass';\n"
+                "ALTER USER 'app'@'%' IDENTIFIED WITH mysql_native_password BY 'app-pass';\n"
+                "ALTER USER 'app'@'localhost' IDENTIFIED WITH mysql_native_password BY 'app-pass';\n"
+                "ALTER USER 'app'@'%' REQUIRE X509;\n"
+                "ALTER USER 'app'@'localhost' REQUIRE X509;\n"
+                "GRANT ALL PRIVILEGES ON app.* TO 'app'@'%';\n"
+                "GRANT ALL PRIVILEGES ON app.* TO 'app'@'localhost';\n"
+                "FLUSH PRIVILEGES;\n"
+            )
+        if "svc-db" in service_dependencies.get(service_id, ()):
+            file_contents[f"security/mtls/{service_id}/mysql-client.cnf"] = (
+                "[client]\n"
+                "host=svc-db\n"
+                "user=app\n"
+                "password=app-pass\n"
+                "database=app\n"
+                "protocol=TCP\n"
+                "connect-timeout=5\n"
+                "ssl-ca=/etc/mtls/ca.pem\n"
+                "ssl-cert=/etc/mtls/cert.pem\n"
+                "ssl-key=/etc/mtls/key.pem\n"
+            )
     return file_contents
 
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -10,6 +10,7 @@ import pytest
 from open_range.build_config import BuildConfig
 from open_range.compiler import EnterpriseSaaSManifestCompiler
 from open_range.episode_config import EpisodeConfig
+from open_range.image_policy import DB_MTLS_HELPER_IMAGE
 from open_range.manifest import validate_manifest
 from open_range.pipeline import BuildPipeline
 from open_range.render import EnterpriseSaaSKindRenderer
@@ -165,7 +166,7 @@ def test_build_config_can_enable_security_integration(tmp_path: Path):
         payload["mountPath"] == "/etc/mysql/conf.d/openrange-client-mtls.cnf"
         for payload in web_payloads
     )
-    assert web_sidecar["image"] == "wbitt/network-multitool:alpine-extra"
+    assert web_sidecar["image"] == DB_MTLS_HELPER_IMAGE
     assert web_sidecar["command"] == ["/bin/sh", "-lc", "sleep infinity"]
     assert any(payload["mountPath"] == "/etc/mtls/cert.pem" for payload in db_payloads)
     assert any(

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -120,9 +120,16 @@ def test_build_config_can_enable_security_integration(tmp_path: Path):
     idp_service = candidate.artifacts.chart_values["services"]["svc-idp"]
     idp_env = idp_service["env"]
     idp_payloads = idp_service["payloads"]
+    web_service = candidate.artifacts.chart_values["services"]["svc-web"]
+    web_payloads = web_service["payloads"]
     db_service = candidate.artifacts.chart_values["services"]["svc-db"]
     db_payloads = db_service["payloads"]
     idp_sidecar = idp_service["sidecars"][0]
+    web_sidecar = next(
+        sidecar
+        for sidecar in web_service["sidecars"]
+        if sidecar["name"] == "db-client-mtls"
+    )
 
     assert any(
         payload["mountPath"] == "/opt/openrange/identity_provider_server.py"
@@ -154,9 +161,19 @@ def test_build_config_can_enable_security_integration(tmp_path: Path):
         payload["mountPath"] == "/etc/openrange/wrapped_dek.json"
         for payload in db_payloads
     )
+    assert any(
+        payload["mountPath"] == "/etc/mysql/conf.d/openrange-client-mtls.cnf"
+        for payload in web_payloads
+    )
+    assert web_sidecar["image"] == "wbitt/network-multitool:alpine-extra"
+    assert web_sidecar["command"] == ["/bin/sh", "-lc", "sleep infinity"]
     assert any(payload["mountPath"] == "/etc/mtls/cert.pem" for payload in db_payloads)
     assert any(
         payload["mountPath"] == "/etc/mysql/conf.d/openrange-mtls.cnf"
+        for payload in db_payloads
+    )
+    assert any(
+        payload["mountPath"] == "/docker-entrypoint-initdb.d/02-openrange-mtls.sql"
         for payload in db_payloads
     )
     mysql_tls_config = next(
@@ -164,8 +181,20 @@ def test_build_config_can_enable_security_integration(tmp_path: Path):
         for payload in db_service["payloads"]
         if payload["mountPath"] == "/etc/mysql/conf.d/openrange-mtls.cnf"
     )
+    mysql_mtls_init = next(
+        payload["content"]
+        for payload in db_service["payloads"]
+        if payload["mountPath"] == "/docker-entrypoint-initdb.d/02-openrange-mtls.sql"
+    )
+    mysql_client_config = next(
+        payload["content"]
+        for payload in web_service["payloads"]
+        if payload["mountPath"] == "/etc/mysql/conf.d/openrange-client-mtls.cnf"
+    )
     assert "require_secure_transport=ON" in mysql_tls_config
     assert "ssl-cert=/etc/mtls/cert.pem" in mysql_tls_config
+    assert "REQUIRE X509" in mysql_mtls_init
+    assert "ssl-cert=/etc/mtls/cert.pem" in mysql_client_config
 
 
 def test_security_integration_renders_idp_runtime_hooks_with_helm(tmp_path: Path):

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -239,6 +239,93 @@ def test_live_outbound_grader_probes_ssrf_realizations_without_output_tokens() -
     )
 
 
+def test_live_db_read_grader_uses_mtls_mysql_flags() -> None:
+    grader = SimpleNamespace(
+        grader_kind="db_row_read",
+        service_id="svc-db",
+        target_id="finance_docs",
+        expected_ref="seeded-finance_docs",
+    )
+    calls: list[tuple[str, str]] = []
+
+    class _Pods:
+        async def exec(self, service: str, cmd: str, timeout: float = 10.0):
+            del timeout
+            calls.append((service, cmd))
+            return SimpleNamespace(
+                ok=True,
+                stdout="seeded-finance_docs\n",
+                stderr="",
+            )
+
+    snapshot = SimpleNamespace(
+        world=SimpleNamespace(security_runtime=SimpleNamespace(mtls={"enabled": True})),
+        file_assets={},
+        db_seed_state={},
+    )
+
+    assert (
+        evaluate_objective_grader_live(
+            "asset_read(finance_docs)",
+            grader,
+            snapshot=snapshot,
+            pods=_Pods(),
+            events=(),
+            service_health={"svc-db": 1.0},
+            outputs=(),
+        )
+        is True
+    )
+    assert calls == [("svc-db", calls[0][1])]
+    assert "--protocol=TCP" in calls[0][1]
+    assert "--ssl-ca=/etc/mtls/ca.pem" in calls[0][1]
+    assert "--ssl-cert=/etc/mtls/cert.pem" in calls[0][1]
+    assert "--ssl-key=/etc/mtls/key.pem" in calls[0][1]
+
+
+def test_live_db_read_grader_falls_back_without_mtls() -> None:
+    grader = SimpleNamespace(
+        grader_kind="db_row_read",
+        service_id="svc-db",
+        target_id="finance_docs",
+        expected_ref="seeded-finance_docs",
+    )
+    calls: list[tuple[str, str]] = []
+
+    class _Pods:
+        async def exec(self, service: str, cmd: str, timeout: float = 10.0):
+            del timeout
+            calls.append((service, cmd))
+            return SimpleNamespace(
+                ok=True,
+                stdout="seeded-finance_docs\n",
+                stderr="",
+            )
+
+    snapshot = SimpleNamespace(
+        world=SimpleNamespace(security_runtime=SimpleNamespace(mtls={})),
+        file_assets={},
+        db_seed_state={},
+    )
+
+    assert (
+        evaluate_objective_grader_live(
+            "asset_read(finance_docs)",
+            grader,
+            snapshot=snapshot,
+            pods=_Pods(),
+            events=(),
+            service_health={"svc-db": 1.0},
+            outputs=(),
+        )
+        is True
+    )
+    assert calls == [("svc-db", calls[0][1])]
+    assert "--ssl-ca=/etc/mtls/ca.pem" not in calls[0][1]
+    assert "--ssl-cert=/etc/mtls/cert.pem" not in calls[0][1]
+    assert "--ssl-key=/etc/mtls/key.pem" not in calls[0][1]
+
+
 def test_live_outbound_grader_requires_probe_when_ssrf_realization_exists() -> None:
     payload = manifest_payload()
     payload["objectives"]["red"] = [{"predicate": "outbound_service(svc-web)"}]

--- a/tests/test_render_admission.py
+++ b/tests/test_render_admission.py
@@ -11,6 +11,7 @@ from open_range.build_config import BuildConfig
 from open_range.code_web import code_web_payload
 from open_range.compiler import EnterpriseSaaSManifestCompiler
 from open_range.curriculum import FrontierMutationPolicy, PopulationStats
+from open_range.image_policy import SANDBOX_IMAGE_BY_ROLE, service_image_for_kind
 from open_range.pipeline import BuildPipeline
 from open_range.predicates import PredicateEngine
 from open_range.render import EnterpriseSaaSKindRenderer
@@ -105,11 +106,11 @@ def test_kind_renderer_emits_expected_files(tmp_path: Path):
     assert "sandbox-red" in artifacts.chart_values["sandboxes"]
     assert (
         artifacts.chart_values["sandboxes"]["sandbox-red"]["image"]
-        == "wbitt/network-multitool:alpine-extra"
+        == SANDBOX_IMAGE_BY_ROLE["red"]
     )
     assert (
         artifacts.chart_values["sandboxes"]["sandbox-blue"]["image"]
-        == "wbitt/network-multitool:alpine-extra"
+        == SANDBOX_IMAGE_BY_ROLE["blue"]
     )
     assert (
         artifacts.chart_values["services"]["svc-db"]["payloads"][0]["mountPath"]
@@ -132,7 +133,7 @@ def test_kind_renderer_emits_expected_files(tmp_path: Path):
         for rule in artifacts.chart_values["firewallRules"]
     )
     assert artifacts.pinned_image_digests["svc-web"].startswith(
-        "php:8.1-apache@sha256:"
+        f"{service_image_for_kind('web_app')}@sha256:"
     )
 
 

--- a/tests/test_render_admission.py
+++ b/tests/test_render_admission.py
@@ -466,6 +466,51 @@ def test_live_service_smoke_check_uses_reachable_zone_runners() -> None:
     assert calls_by_target["svc-db"].startswith("sandbox-green-")
 
 
+def test_live_db_mtls_check_proves_client_cert_required(tmp_path: Path) -> None:
+    pipeline = BuildPipeline(store=FileSnapshotStore(tmp_path / "snapshots"))
+    candidate = pipeline.build(
+        _manifest_payload(),
+        tmp_path / "rendered-security",
+        BuildConfig(
+            validation_profile="graph_only",
+            security_integration_enabled=True,
+            security_tier=3,
+        ),
+    )
+    calls: list[tuple[str, str]] = []
+
+    class FakePods:
+        async def exec(
+            self,
+            service: str,
+            cmd: str,
+            timeout: float = 30.0,
+            *,
+            container: str | None = None,
+        ) -> ExecResult:
+            del timeout
+            calls.append((service, container or "", cmd))
+            if container == "db-client-mtls":
+                return ExecResult(stdout="1\n", stderr="", exit_code=0)
+            if "mysql --protocol=TCP" in cmd:
+                return ExecResult(stdout="", stderr="ERROR 1045 (28000)", exit_code=1)
+            return ExecResult(stdout="", stderr="miss", exit_code=1)
+
+    report = admit_mod._live_db_mtls_check(
+        candidate.world, SimpleNamespace(pods=FakePods())
+    )
+
+    assert report.passed is True
+    assert calls[0][0] == "svc-web"
+    assert calls[0][1] == "db-client-mtls"
+    assert (
+        "--defaults-extra-file=/etc/mysql/conf.d/openrange-client-mtls.cnf"
+        in calls[0][2]
+    )
+    assert calls[1][0] == "sandbox-red"
+    assert "--ssl-cert=/etc/mtls/cert.pem" not in calls[1][2]
+
+
 def test_admission_controller_rejects_world_without_telemetry(tmp_path: Path):
     world = _build_seeded_world()
     broken = world.replace_edges(telemetry=())

--- a/tests/test_render_admission.py
+++ b/tests/test_render_admission.py
@@ -24,6 +24,7 @@ from tests.support import (
 )
 
 admit_mod = importlib.import_module("open_range.admit")
+live_checks_mod = importlib.import_module("open_range.live_checks")
 
 
 def _manifest_payload() -> dict:
@@ -450,7 +451,7 @@ def test_live_service_smoke_check_uses_reachable_zone_runners() -> None:
             calls.append((service, cmd))
             return ExecResult(stdout="ok", stderr="", exit_code=0)
 
-    report = admit_mod._live_service_smoke_check(
+    report = live_checks_mod.check_live_service_smoke(
         world, SimpleNamespace(pods=FakePods())
     )
     calls_by_target = {
@@ -496,7 +497,7 @@ def test_live_db_mtls_check_proves_client_cert_required(tmp_path: Path) -> None:
                 return ExecResult(stdout="", stderr="ERROR 1045 (28000)", exit_code=1)
             return ExecResult(stdout="", stderr="miss", exit_code=1)
 
-    report = admit_mod._live_db_mtls_check(
+    report = live_checks_mod.check_live_db_mtls(
         candidate.world, SimpleNamespace(pods=FakePods())
     )
 

--- a/tests/test_security_integrator.py
+++ b/tests/test_security_integrator.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from open_range.image_policy import DB_MTLS_HELPER_IMAGE
 from open_range.security_runtime import materialize_security_runtime
 from open_range.security_integrator import (
     DEFAULT_TIER_MAP,
@@ -244,7 +245,7 @@ class TestMTLSIntegration:
         )
         web_sidecar = ctx.service_runtime["svc-web"].sidecars[0]
         assert web_sidecar.name == "db-client-mtls"
-        assert web_sidecar.image == "wbitt/network-multitool:alpine-extra"
+        assert web_sidecar.image == DB_MTLS_HELPER_IMAGE
         assert web_sidecar.command == ("/bin/sh", "-lc", "sleep infinity")
         assert web_sidecar.include_service_payloads is True
         assert ctx.service_runtime["svc-idp"].env["LDAP_TLS_VERIFY_CLIENT"] == "demand"

--- a/tests/test_security_integrator.py
+++ b/tests/test_security_integrator.py
@@ -238,6 +238,15 @@ class TestMTLSIntegration:
         assert ctx.mtls["enabled"] is True
         cert_files = list((render_dir / "security" / "mtls").glob("*/*.pem"))
         assert len(cert_files) >= 3
+        assert any(
+            payload.mount_path == "/etc/mysql/conf.d/openrange-client-mtls.cnf"
+            for payload in ctx.service_runtime["svc-web"].payloads
+        )
+        web_sidecar = ctx.service_runtime["svc-web"].sidecars[0]
+        assert web_sidecar.name == "db-client-mtls"
+        assert web_sidecar.image == "wbitt/network-multitool:alpine-extra"
+        assert web_sidecar.command == ("/bin/sh", "-lc", "sleep infinity")
+        assert web_sidecar.include_service_payloads is True
         assert ctx.service_runtime["svc-idp"].env["LDAP_TLS_VERIFY_CLIENT"] == "demand"
         assert ctx.service_runtime["svc-idp"].env["LDAP_TLS_CRT_FILENAME"] == "ldap.crt"
         assert any(
@@ -247,6 +256,10 @@ class TestMTLSIntegration:
         assert any(port.port == 636 for port in ctx.service_runtime["svc-idp"].ports)
         assert any(
             payload.mount_path == "/etc/mysql/conf.d/openrange-mtls.cnf"
+            for payload in ctx.service_runtime["svc-db"].payloads
+        )
+        assert any(
+            payload.mount_path == "/docker-entrypoint-initdb.d/02-openrange-mtls.sql"
             for payload in ctx.service_runtime["svc-db"].payloads
         )
 


### PR DESCRIPTION
Closes #163

## Summary

This makes the built-in runtime path enforce MySQL client certificates end to end instead of stopping at server-side TLS.

The DB runtime now seeds an X509-required `app` user and renders a MySQL TLS client config for services that depend on `svc-db`. For the current `svc-web` image, the runtime attaches a `db-client-mtls` helper sidecar so the built-in path can actually present the mounted certs without changing the existing PHP base image. Live admission also now checks that the cert-backed path succeeds while the same DB access fails from `sandbox-red` without client certs.

I also gated the live DB objective probes so non-mTLS worlds still use the plain MySQL command path instead of incorrectly requiring `/etc/mtls/*` files.

## Testing

- Manual live verification on `blackberry`:
  - `~/.local/bin/uv run -m open_range.cli build -m manifests/tier1_basic.yaml -o /tmp/open-range-issue163-render --security-tier 3`
  - `helm upgrade --install or-issue163 /tmp/open-range-issue163-render/openrange --set-string global.namePrefix=or-issue163 --wait --timeout 300s`
  - `docker exec openrange-control-plane kubectl exec -n or-issue163-dmz deploy/svc-web -c db-client-mtls -- sh -lc 'mysql --defaults-extra-file=/etc/mysql/conf.d/openrange-client-mtls.cnf -Nse "SELECT 1;"'`
  - `docker exec openrange-control-plane kubectl exec -n or-issue163-external deploy/sandbox-red -- sh -lc 'mysql --protocol=TCP --connect-timeout=5 -h svc-db -uapp -papp-pass app -Nse "SELECT 1;"'`
- Local verification beyond CI-covered hooks:
  - `uv run -m pytest tests -q`

## Review Notes

The current `php:8.1-apache` image does not provide a usable MySQL TLS client on this repo's runtime path, so the implementation uses a `db-client-mtls` sidecar on `svc-web` rather than wiring native PHP DB calls directly. That keeps the built-in app->DB path honest without broadening this issue into custom image build/publish work.
