### PR TITLE
docs: tighten contributor and PR workflow docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,28 @@
 <!--
-Inspired by lightweight templates used in projects like uv and Zed.
 Keep this PR body concise and review-friendly.
 -->
+
+## Self-Review
+
+- [ ] Scope is focused and matches the linked issue or change theme
+- [ ] I reviewed the diff for V1 architectural drift, reference leakage, and validation-profile regressions where relevant
+- [ ] Tests and docs were updated where behavior or workflows changed
 
 Closes #
 
 ## Summary
 
-<!-- What changed, and why? -->
+<!-- What changed, and why? Keep this to a few concrete bullets. -->
 
 ## Testing
 
 <!--
-Keep verification terse:
+Keep this short and reviewer-visible:
 - do not list routine Ruff / format / generic unit-test commands when CI already runs them
 - list only manual or non-routine verification that reviewers would not otherwise see
+- include exact commands for admission, runtime, Kind, training, or eval checks
 - if there was no special verification beyond CI-covered lint/unit checks, say that plainly
-- do not paste long terminal transcripts
+- do not paste long terminal transcripts or logs
 -->
 
 - Not run
@@ -24,6 +30,6 @@ Keep verification terse:
 ## Review Notes
 
 <!--
-Optional. Call out non-obvious tradeoffs, follow-up work, or reviewer focus areas.
+Optional. Call out reviewer focus areas, non-obvious tradeoffs, risks, or follow-up work.
 Delete this section if there is nothing special to flag.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Guidance for coding agents working on the current `v1` OpenRange branch.
+Guidance for coding agents working on the current OpenRange codebase.
 
 ## What OpenRange Is
 
@@ -155,7 +155,7 @@ Prefer `uv run -m ...` for Python commands in this repo.
 
 ## PR Guidelines
 
-- default pull requests for this repo should target `v1`, not `main`, unless the user explicitly asks otherwise
+- default pull requests for this repo should target `dev`, not `main`, unless the user explicitly asks otherwise
 - keep each PR focused on one theme
 - follow `.github/PULL_REQUEST_TEMPLATE.md`
 - keep the `Testing` section terse and factual

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ contract, especially around:
 
 Prefer `uv run -m ...` for Python commands in this repo.
 
-- create or refresh the local environment with `uv sync --extra dev`
+- create or refresh the local environment with `uv sync --group dev`
 - run the main test suite with `uv run -m pytest tests -q`
 - run focused tests with `uv run -m pytest tests/test_runtime.py -q`
 - inspect the CLI with `uv run -m open_range.cli --help`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,13 +141,15 @@ contract, especially around:
 
 ## Build, Test, and Dev Commands
 
-Prefer `uv run -m ...` for Python commands in this repo.
+Prefer the public CLI entry points for user-facing package commands, such as
+`uv run openrange` and the demo scripts. Use `uv run -m ...` for module-only
+repo commands.
 
 - create or refresh the local environment with `uv sync --group dev`
 - run the main test suite with `uv run -m pytest tests -q`
 - run focused tests with `uv run -m pytest tests/test_runtime.py -q`
-- inspect the CLI with `uv run -m open_range.cli --help`
-- run demos with `uv run -m open_range.examples.demo` and `uv run -m open_range.examples.bootstrap`
+- inspect the CLI with `uv run openrange --help`
+- run demos with `uv run openrange-demo` and `uv run openrange-bootstrap-demo`
 - do not use `source .venv/bin/activate` for normal development flows
 - do not fall back to raw `python -m ...` when `uv run -m ...` is available
 - if `uv` is not on `PATH`, resolve the machine's local `uv` path first instead of falling back to venv activation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,180 +1,52 @@
 # AGENTS.md
 
-Guidance for coding agents working on the current OpenRange codebase.
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for local setup, checks, and pull
+request format.
 
-## What OpenRange Is
+## Repo-Specific Rules
 
-OpenRange is a standalone, manifest-first Python package for building, admitting,
-storing, and running bounded enterprise cyber worlds.
+- Keep public docs and examples on the package entry points:
+  `openrange`, `openrange-demo`, and `openrange-bootstrap-demo`.
+- Use `uv run -m ...` only for module-only repo commands.
+- Default pull requests should target `dev`, not `main`, unless asked
+  otherwise.
+- Keep changes focused, and add tests when behavior changes.
 
-It is not the old OpenEnv server/client stack.
-It is not the old public golden-path architecture.
+## Product Boundary
 
-The core contract is:
-
-1. public manifest
-2. compile to `WorldIR`
-3. seed exact weaknesses
-4. synthesize bounded artifacts
-5. render Kind artifacts
-6. admit through deterministic validation plus private references
-7. freeze an immutable snapshot
-8. run episodes through the decision-loop runtime
-
-## Current Objective
-
-OpenRange V1 is a validator-admitted enterprise web-security training environment
-that combines:
-
-- exact code-level web flaws
-- exact config, workflow, secret, and telemetry weaknesses
-- private reference attack/defense traces
-- green-user runtime dynamics
-- immutable snapshots and mutation between worlds
-
-The scoped claim is:
-
-- Red: exploit-to-objective behavior on the web-first enterprise slice
-- Blue: detection, containment, and continuity under green-user noise
-
-Do not broaden the claim to:
-
-- full enterprise remediation automation
-- exhaustive shortcut elimination
-- broad cyber-benchmark coverage outside the bounded slice
-
-## Architectural Invariants
-
+- OpenRange is a manifest-first Python package, not the legacy OpenEnv
+  server/client stack and not the old public golden-path architecture.
 - The public manifest defines the business, not the answer key.
 - `WorldIR` is the canonical typed world model.
 - `ReferenceBundle` is private validator-owned oracle data.
-- Public `Snapshot` objects do not carry references by default.
-- Runtime/admission use hydrated runtime snapshots when references are needed.
+- Public `Snapshot` objects do not carry references by default; hydrate through
+  the store when references are needed.
 - Training runs on immutable admitted snapshots only.
 - Green is environment-owned at runtime, not trainer-stepped.
 - Runtime is decision-driven via `next_decision()` and `act()`.
-- Rewards and terminal conditions are objective/event grounded.
-- `BuildConfig` and `EpisodeConfig` are the only official ablation surfaces.
 
-## Admission Rules
+## Validation Rules
 
-`LocalAdmissionController` is an admission controller, not a loose test suite.
+- `LocalAdmissionController` is an admission gate, not a loose test suite.
+- `validation_profile="full"` is the claim-strong path and requires live Kind
+  validation on the public pipeline path.
+- Offline or reduced workflows must opt into a weaker profile explicitly, such
+  as `graph_only`.
+- Do not silently downgrade validation strength.
 
-It must answer:
+## Naming And Leakage
 
-- does the world make structural sense?
-- does at least one reference attack path work?
-- does at least one reference defense path work?
-- do necessity and shortcut checks pass?
-- is the world stable enough to train on?
-
-Important:
-
-- `validation_profile="full"` is claim-strong and requires live Kind validation
-  when using the public pipeline path
-- offline or reduced-validation workflows must opt into a weaker profile
-  explicitly, such as `graph_only`
-
-## References, Not Golden Paths
-
-Use the current naming:
-
-- `ReferenceBundle`
-- `reference_attack_traces`
-- `reference_defense_traces`
-
-Do not reintroduce public golden-path semantics in the package surface.
-
-References are:
-
-- private
-- validator-owned
-- executable
-- not the public environment contract
-
-## Snapshot Boundary
-
-There are two conceptual snapshot layers:
-
-- `Snapshot`: public immutable world/state/report artifact
-- hydrated runtime snapshot: internal snapshot plus private references
-
-If code only needs world/state/report metadata, it should use `Snapshot`.
-If code needs reference traces, it should hydrate explicitly through the store.
-
-## Training Data Rules
-
-The learning system should train on branch-native traces, not generic cyber chat.
-
-Required properties:
-
-- admitted-snapshot grounded
-- lineage-aware
-- role-correct
-- mode-specific
-- split by lineage root, not random row
-- separate `runtime` and `sim` trace sources
-
-Default decision prompts should mirror runtime observations.
-Do not leak hidden weakness inventory or reference data into prompt text.
-
-## Package Shape
-
-Primary modules:
-
-- `src/open_range/manifest.py`
-- `src/open_range/compiler.py`
-- `src/open_range/weaknesses.py`
-- `src/open_range/synth.py`
-- `src/open_range/render.py`
-- `src/open_range/admit.py`
-- `src/open_range/store.py`
-- `src/open_range/runtime.py`
-- `src/open_range/tracegen.py`
-
-Examples and scripts are secondary surfaces and must stay aligned with the core
-contract, especially around:
-
-- explicit offline validation profiles
-- hydrated runtime snapshots
-- multi-reference support
-
-## Build, Test, and Dev Commands
-
-Prefer the public CLI entry points for user-facing package commands, such as
-`uv run openrange` and the demo scripts. Use `uv run -m ...` for module-only
-repo commands.
-
-- create or refresh the local environment with `uv sync --group dev`
-- run the main test suite with `uv run -m pytest tests -q`
-- run focused tests with `uv run -m pytest tests/test_runtime.py -q`
-- inspect the CLI with `uv run openrange --help`
-- run demos with `uv run openrange-demo` and `uv run openrange-bootstrap-demo`
-- do not use `source .venv/bin/activate` for normal development flows
-- do not fall back to raw `python -m ...` when `uv run -m ...` is available
-- if `uv` is not on `PATH`, resolve the machine's local `uv` path first instead of falling back to venv activation
-- run `docker` and `kind` directly, without wrapping them in Python env activation
-
-## PR Guidelines
-
-- default pull requests for this repo should target `dev`, not `main`, unless the user explicitly asks otherwise
-- keep each PR focused on one theme
-- follow `.github/PULL_REQUEST_TEMPLATE.md`
-- keep the `Testing` section terse and factual
-- do not list routine Ruff, formatting, or generic unit-test commands in the PR body when CI already runs them
-- reserve the `Testing` section for manual verification, integration checks, Kind/admission runs, training/eval smoke tests, or anything else the workflow does not already cover
-- if there was no special verification beyond CI-covered lint/unit checks, say that plainly instead of pasting the commands
-- do not paste long verification logs or terminal transcripts into the PR body
-- include the exact verification commands used in the PR description for admission, runtime, Kind-backed, training, or other non-routine validation
-- use `Review Notes` only for reviewer-relevant context such as risks, tradeoffs, or follow-up work
+- Use `ReferenceBundle`, `reference_attack_traces`, and
+  `reference_defense_traces`.
+- Do not reintroduce public golden-path semantics in the package surface.
+- Do not leak hidden weakness inventory or private reference data into public
+  APIs, snapshots, or prompt text.
 
 ## Review Priorities
 
-When reviewing or changing code, prioritize:
-
-1. architectural drift from the V1 objective
+1. architectural drift from the current objective
 2. hidden-oracle leakage
 3. silent downgrade from live to offline validation
-4. reward/objective mismatch between admission and runtime
+4. reward or objective mismatch between admission and runtime
 5. training-data mismatch with the actual runtime surface
 6. stale compatibility shims back toward the deleted architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to OpenRange
 
-Thanks for helping improve OpenRange.
+Thanks for contributing.
 
-## Good Contributions
+## What To Work On
 
 Small bug fixes, tests, docs improvements, and scoped quality-of-life changes are
 great candidates for pull requests.
@@ -10,12 +10,8 @@ great candidates for pull requests.
 Please start with an issue or discussion before investing heavily in:
 
 - larger features or scope-expanding behavior
-- admission or runtime contract changes
-- validation policy changes
+- admission, runtime, or validation contract changes
 - broad refactors or compatibility shims back toward the deleted architecture
-
-That early check-in helps us stay aligned on the current V1 scope and avoids
-wasted work.
 
 ## Local Setup
 
@@ -30,7 +26,6 @@ Useful smoke checks:
 ```bash
 uv run openrange --help
 uv run openrange-demo
-uv run openrange-bootstrap-demo
 ```
 
 Training dependencies are optional:
@@ -43,31 +38,21 @@ uv sync --extra training
 
 Before opening a pull request, run the checks relevant to your change.
 
-Routine CI-covered checks:
-
 ```bash
 uv run ruff format --check .
 uv run ruff check .
 uv run pytest tests/ -v --tb=short
+```
+
+Optional Docker parse check:
+
+```bash
 docker buildx build --check -f Dockerfile .
 ```
 
-For local iteration, it is fine to run narrower targeted tests first and reserve
-heavier validation for the changes that need it.
-
-If your change touches admission, runtime, Kind-backed flows, training, or
-evaluation, include the exact non-routine verification commands you ran in the
-PR description.
-
-## Before You Open A PR
-
-- Keep the change focused on one theme.
-- Add tests when behavior changes.
-- Update docs or examples when public behavior or workflows change.
-- Keep offline validation explicit in docs and scripts; use weaker profiles such
-  as `graph_only` only when that tradeoff is intentional.
-- Avoid public-surface wording that leaks private references or reintroduces
-  golden-path semantics.
+For local iteration, prefer targeted tests first. If your change touches
+admission, runtime, Kind-backed flows, training, or evaluation, include the
+exact non-routine verification commands you ran in the PR description.
 
 ## Pull Requests
 
@@ -87,7 +72,6 @@ Keep the `Testing` section short and factual:
 
 - list only manual or non-routine verification that reviewers would not
   otherwise see in CI
-- include exact commands for admission, runtime, Kind, training, or eval checks
 - if there was no special verification beyond CI-covered lint/unit checks, say
   that plainly
 - do not paste long terminal transcripts into the PR body
@@ -100,6 +84,5 @@ work.
 If you need more background before changing core behavior, start with:
 
 - [`docs/architecture.md`](docs/architecture.md)
-- [`docs/v1-paper-scope.md`](docs/v1-paper-scope.md)
 - [`docs/training-data-spec.md`](docs/training-data-spec.md)
 - [`AGENTS.md`](AGENTS.md) for repo-specific Codex guidance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,9 @@ uv sync --group dev
 Useful smoke checks:
 
 ```bash
-uv run -m open_range.cli --help
-uv run -m open_range.examples.demo
-uv run -m open_range.examples.bootstrap
+uv run openrange --help
+uv run openrange-demo
+uv run openrange-bootstrap-demo
 ```
 
 Training dependencies are optional:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Good pull requests are usually:
 - backed by tests when behavior changes
 - accompanied by doc updates when public behavior or workflows change
 
-Target `v1` by default unless a maintainer asks for a different base branch.
+Target `dev` by default unless a maintainer asks for a different base branch.
 
 Use the repository PR template in
 [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,21 @@
 # Contributing to OpenRange
 
-Thanks for contributing.
+Thanks for helping improve OpenRange.
 
-## What To Work On
+## Good Contributions
 
 Small bug fixes, tests, docs improvements, and scoped quality-of-life changes are
 great candidates for pull requests.
 
-For larger features, behavioral changes, or broad refactors, please start with
-an issue or discussion before investing heavily in implementation. That helps us
-align on scope early and avoids wasted work.
+Please start with an issue or discussion before investing heavily in:
+
+- larger features or scope-expanding behavior
+- admission or runtime contract changes
+- validation policy changes
+- broad refactors or compatibility shims back toward the deleted architecture
+
+That early check-in helps us stay aligned on the current V1 scope and avoids
+wasted work.
 
 ## Local Setup
 
@@ -22,8 +28,9 @@ uv sync --group dev
 Useful smoke checks:
 
 ```bash
-uv run openrange --help
-uv run openrange-demo
+uv run -m open_range.cli --help
+uv run -m open_range.examples.demo
+uv run -m open_range.examples.bootstrap
 ```
 
 Training dependencies are optional:
@@ -36,17 +43,31 @@ uv sync --extra training
 
 Before opening a pull request, run the checks relevant to your change.
 
+Routine CI-covered checks:
+
 ```bash
 uv run ruff format --check .
 uv run ruff check .
 uv run pytest tests/ -v --tb=short
-```
-
-Optional Docker parse check:
-
-```bash
 docker buildx build --check -f Dockerfile .
 ```
+
+For local iteration, it is fine to run narrower targeted tests first and reserve
+heavier validation for the changes that need it.
+
+If your change touches admission, runtime, Kind-backed flows, training, or
+evaluation, include the exact non-routine verification commands you ran in the
+PR description.
+
+## Before You Open A PR
+
+- Keep the change focused on one theme.
+- Add tests when behavior changes.
+- Update docs or examples when public behavior or workflows change.
+- Keep offline validation explicit in docs and scripts; use weaker profiles such
+  as `graph_only` only when that tradeoff is intentional.
+- Avoid public-surface wording that leaks private references or reintroduces
+  golden-path semantics.
 
 ## Pull Requests
 
@@ -57,20 +78,28 @@ Good pull requests are usually:
 - backed by tests when behavior changes
 - accompanied by doc updates when public behavior or workflows change
 
+Target `v1` by default unless a maintainer asks for a different base branch.
+
 Use the repository PR template in
 [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md).
 
 Keep the `Testing` section short and factual:
 
-- list the command(s) you ran
-- mark them pass/fail
-- if something was not run, say so plainly
+- list only manual or non-routine verification that reviewers would not
+  otherwise see in CI
+- include exact commands for admission, runtime, Kind, training, or eval checks
+- if there was no special verification beyond CI-covered lint/unit checks, say
+  that plainly
 - do not paste long terminal transcripts into the PR body
+
+Use `Review Notes` only for reviewer focus areas, tradeoffs, risks, or follow-up
+work.
 
 ## Project Context
 
 If you need more background before changing core behavior, start with:
 
 - [`docs/architecture.md`](docs/architecture.md)
+- [`docs/v1-paper-scope.md`](docs/v1-paper-scope.md)
 - [`docs/training-data-spec.md`](docs/training-data-spec.md)
 - [`AGENTS.md`](AGENTS.md) for repo-specific Codex guidance

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ uv run scripts/generate_traces.py \
 Or through the CLI:
 
 ```bash
-uv run openrange traces -m manifests/tier1_basic.yaml -o /tmp/openrange-traces --roots 3 --mutations 1
+openrange traces -m manifests/tier1_basic.yaml -o /tmp/openrange-traces --roots 3 --mutations 1
 ```
 
 The generator also writes role/source shards such as:
@@ -262,10 +262,10 @@ uv run -m pytest tests -q
 ## Development checks
 
 ```bash
-uv sync --group dev
-uv run ruff format --check .
+uv sync
+uv run ruff format .
 uv run ruff check .
-uv run pytest tests/ -v --tb=short
+uv run pytest
 uv run pre-commit install
 uv run pre-commit run --all-files
 ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ training-data generation.
 
 ```bash
 uv sync
-uv run -m open_range.cli --help
+uv run openrange --help
 ```
 
 Or install the package directly:
@@ -81,13 +81,13 @@ This is the fastest way to see the package working end to end without setting up
 Kind:
 
 ```bash
-uv run -m open_range.examples.demo
+uv run openrange-demo
 ```
 
 You can also point it at a checked-in manifest:
 
 ```bash
-uv run -m open_range.examples.demo --manifest manifests/tier1_basic.yaml
+uv run openrange-demo --manifest manifests/tier1_basic.yaml
 ```
 
 ### 3. Admit a Snapshot Locally
@@ -95,7 +95,7 @@ uv run -m open_range.examples.demo --manifest manifests/tier1_basic.yaml
 For a local first run, use the explicit offline profile:
 
 ```bash
-uv run -m open_range.cli admit \
+uv run openrange admit \
   -m manifests/tier1_basic.yaml \
   -o /tmp/openrange-build \
   --store-dir /tmp/openrange-snapshots \
@@ -105,7 +105,7 @@ uv run -m open_range.cli admit \
 Then reset the runtime onto an admitted snapshot:
 
 ```bash
-uv run -m open_range.cli reset \
+uv run openrange reset \
   --store-dir /tmp/openrange-snapshots \
   --mode blue_only_live \
   --sample-seed 7
@@ -117,7 +117,7 @@ a live Kind-backed setup.
 ### 4. Generate Trace Data
 
 ```bash
-uv run -m open_range.cli traces \
+uv run openrange traces \
   -m manifests/tier1_basic.yaml \
   -o /tmp/openrange-traces \
   --roots 3 \
@@ -184,7 +184,7 @@ The package also ships a bootstrap example that compares a cheap sim-plane trace
 with a runtime episode:
 
 ```bash
-uv run -m open_range.examples.bootstrap
+uv run openrange-bootstrap-demo
 ```
 
 ## License
@@ -219,7 +219,7 @@ uv run scripts/generate_traces.py \
 Or through the CLI:
 
 ```bash
-uv run -m open_range.cli traces -m manifests/tier1_basic.yaml -o /tmp/openrange-traces --roots 3 --mutations 1
+uv run openrange traces -m manifests/tier1_basic.yaml -o /tmp/openrange-traces --roots 3 --mutations 1
 ```
 
 The generator also writes role/source shards such as:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ validates that world with private reference traces and deterministic probes,
 freezes it as an immutable snapshot, and runs episodes with red, blue, and
 green-user dynamics.
 
-> **Project Provenance:** OpenRange is managed by **Vecna** as an open-source project. 
+> **Project Provenance:** OpenRange is managed by **Vecna** as an open-source project.
 > The core evaluation engine and admission concepts in this repository were heavily inspired by the [open-cybernauts/open-range](https://github.com/open-cybernauts/open-range) proof of concept built during the OpenEnv HuggingFace Hackathon in early March.
 
 This branch exposes OpenRange as an installable Python package and CLI. It is
@@ -65,7 +65,7 @@ training-data generation.
 
 ```bash
 uv sync
-uv run openrange --help
+uv run -m open_range.cli --help
 ```
 
 Or install the package directly:
@@ -81,13 +81,13 @@ This is the fastest way to see the package working end to end without setting up
 Kind:
 
 ```bash
-uv run openrange-demo
+uv run -m open_range.examples.demo
 ```
 
 You can also point it at a checked-in manifest:
 
 ```bash
-uv run openrange-demo --manifest manifests/tier1_basic.yaml
+uv run -m open_range.examples.demo --manifest manifests/tier1_basic.yaml
 ```
 
 ### 3. Admit a Snapshot Locally
@@ -95,7 +95,7 @@ uv run openrange-demo --manifest manifests/tier1_basic.yaml
 For a local first run, use the explicit offline profile:
 
 ```bash
-uv run openrange admit \
+uv run -m open_range.cli admit \
   -m manifests/tier1_basic.yaml \
   -o /tmp/openrange-build \
   --store-dir /tmp/openrange-snapshots \
@@ -105,7 +105,7 @@ uv run openrange admit \
 Then reset the runtime onto an admitted snapshot:
 
 ```bash
-uv run openrange reset \
+uv run -m open_range.cli reset \
   --store-dir /tmp/openrange-snapshots \
   --mode blue_only_live \
   --sample-seed 7
@@ -117,7 +117,7 @@ a live Kind-backed setup.
 ### 4. Generate Trace Data
 
 ```bash
-uv run openrange traces \
+uv run -m open_range.cli traces \
   -m manifests/tier1_basic.yaml \
   -o /tmp/openrange-traces \
   --roots 3 \
@@ -184,7 +184,7 @@ The package also ships a bootstrap example that compares a cheap sim-plane trace
 with a runtime episode:
 
 ```bash
-uv run openrange-bootstrap-demo
+uv run -m open_range.examples.bootstrap
 ```
 
 ## License
@@ -219,7 +219,7 @@ uv run scripts/generate_traces.py \
 Or through the CLI:
 
 ```bash
-openrange traces -m manifests/tier1_basic.yaml -o /tmp/openrange-traces --roots 3 --mutations 1
+uv run -m open_range.cli traces -m manifests/tier1_basic.yaml -o /tmp/openrange-traces --roots 3 --mutations 1
 ```
 
 The generator also writes role/source shards such as:
@@ -262,10 +262,10 @@ uv run -m pytest tests -q
 ## Development checks
 
 ```bash
-uv sync
-uv run ruff format .
+uv sync --group dev
+uv run ruff format --check .
 uv run ruff check .
-uv run pytest
+uv run pytest tests/ -v --tb=short
 uv run pre-commit install
 uv run pre-commit run --all-files
 ```


### PR DESCRIPTION
Closes #136

## Summary

- align `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, and the PR template around one contributor workflow
- keep the public docs on the `openrange` / demo script surface while tightening local branch and setup guidance
- add a lightweight self-review section and keep PR testing notes focused on non-routine verification

## Testing

- `uv run -m pytest tests/test_cli.py -q`
- `uv run -m open_range.examples.demo --manifest manifests/tier1_basic.yaml`
- `uv venv /tmp/openrange-cli-check.nWEgYI`
- `uv pip install --python /tmp/openrange-cli-check.nWEgYI/bin/python .`
- `/tmp/openrange-cli-check.nWEgYI/bin/openrange --help`
- `/tmp/openrange-cli-check.nWEgYI/bin/openrange-demo --help`
- `/tmp/openrange-cli-check.nWEgYI/bin/openrange-bootstrap-demo --help`
- `/tmp/openrange-cli-check.nWEgYI/bin/openrange-demo --manifest manifests/tier1_basic.yaml`

## Review Notes

- Public docs intentionally use the package entry points (`openrange`, `openrange-demo`, `openrange-bootstrap-demo`).
- The earlier editable-env wrapper quirk is a separate issue and should not leak into user-facing docs.