### PR TITLE
[codex] Add mutation-policy calibration harness

### DIFF
--- a/src/open_range/curriculum.py
+++ b/src/open_range/curriculum.py
@@ -63,6 +63,7 @@ class ParentScore(_StrictModel):
     world_id: str = Field(min_length=1)
     total: float
     signals: dict[str, float] = Field(default_factory=dict)
+    contributions: dict[str, float] = Field(default_factory=dict)
 
 
 class MutationOp(_StrictModel):
@@ -85,9 +86,19 @@ class MutationPolicy(Protocol):
 class FrontierMutationPolicy:
     """Heuristic deterministic curriculum policy for admitted worlds."""
 
+    def score_weights(self) -> dict[str, float]:
+        return {
+            "stability": 0.35,
+            "frontier": 0.30,
+            "novelty": 0.15,
+            "signal_richness": 0.10,
+            "coverage": 0.10,
+        }
+
     def score_parents(
         self, population: list[PopulationStats]
     ) -> tuple[ParentScore, ...]:
+        weights = self.score_weights()
         ranked: list[ParentScore] = []
         for entry in population:
             if entry.split != "train":
@@ -96,24 +107,25 @@ class FrontierMutationPolicy:
             frontier = max(0.0, 1.0 - abs(entry.red_win_rate - 0.5) * 2.0)
             signal_richness = min(entry.blue_signal_points / 6.0, 1.0)
             coverage = min(entry.episodes / 10.0, 1.0)
-            total = (
-                0.35 * stability
-                + 0.30 * frontier
-                + 0.15 * entry.novelty
-                + 0.10 * signal_richness
-                + 0.10 * coverage
-            )
+            signals = {
+                "stability": stability,
+                "frontier": frontier,
+                "novelty": entry.novelty,
+                "signal_richness": signal_richness,
+                "coverage": coverage,
+            }
+            contributions = {
+                name: signals[name] * weight for name, weight in weights.items()
+            }
+            total = sum(contributions.values())
             ranked.append(
                 ParentScore(
                     snapshot_id=entry.snapshot_id,
                     world_id=entry.world_id,
                     total=round(total, 6),
-                    signals={
-                        "stability": round(stability, 6),
-                        "frontier": round(frontier, 6),
-                        "novelty": round(entry.novelty, 6),
-                        "signal_richness": round(signal_richness, 6),
-                        "coverage": round(coverage, 6),
+                    signals={name: round(value, 6) for name, value in signals.items()},
+                    contributions={
+                        name: round(value, 6) for name, value in contributions.items()
                     },
                 )
             )

--- a/src/open_range/devtools/__init__.py
+++ b/src/open_range/devtools/__init__.py
@@ -1,0 +1,1 @@
+"""Developer-facing helpers for calibrating and inspecting OpenRange internals."""

--- a/src/open_range/devtools/mutation_policy_calibration.py
+++ b/src/open_range/devtools/mutation_policy_calibration.py
@@ -1,0 +1,150 @@
+"""Inspect and compare mutation-policy parent scoring for development workflows."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, TextIO
+
+import click
+import yaml
+from pydantic import ValidationError
+
+from open_range.curriculum import FrontierMutationPolicy, PopulationStats
+
+
+def _load_population(stream: TextIO) -> list[PopulationStats]:
+    source_name = getattr(stream, "name", "<stdin>")
+    payload = yaml.safe_load(stream.read())
+    if isinstance(payload, list):
+        entries = payload
+    elif isinstance(payload, dict) and "population" in payload:
+        entries = payload["population"]
+    else:
+        raise click.ClickException(
+            f"{source_name} must be a list of PopulationStats entries or a mapping "
+            "with a top-level 'population' list"
+        )
+    if not isinstance(entries, list):
+        raise click.ClickException(
+            f"{source_name} must provide population entries as a list"
+        )
+    try:
+        return [PopulationStats.model_validate(entry) for entry in entries]
+    except ValidationError as exc:
+        raise click.ClickException(
+            f"invalid PopulationStats entry in {source_name}: {exc}"
+        ) from exc
+
+
+def build_score_report(
+    population: list[PopulationStats],
+    *,
+    policy: FrontierMutationPolicy | None = None,
+) -> dict[str, Any]:
+    active_policy = policy or FrontierMutationPolicy()
+    scores = active_policy.score_parents(population)
+    return {
+        "weights": active_policy.score_weights(),
+        "population_size": len(population),
+        "eligible_candidates": len(scores),
+        "skipped_candidates": [
+            entry.model_dump(mode="json")
+            for entry in population
+            if entry.split != "train"
+        ],
+        "scores": [score.model_dump(mode="json") for score in scores],
+    }
+
+
+def render_text_report(report: dict[str, Any]) -> str:
+    weights: dict[str, float] = report["weights"]
+    scores: list[dict[str, Any]] = report["scores"]
+    skipped: list[dict[str, Any]] = report["skipped_candidates"]
+
+    lines = [
+        f"Population size: {report['population_size']}",
+        f"Eligible train candidates: {report['eligible_candidates']}",
+        f"Skipped non-train candidates: {len(skipped)}",
+    ]
+
+    if scores:
+        snapshot_width = max(
+            len("Snapshot"), *(len(score["snapshot_id"]) for score in scores)
+        )
+        world_width = max(len("World"), *(len(score["world_id"]) for score in scores))
+        rank_width = len("Rank")
+        total_width = len("Total")
+        lines.extend(
+            [
+                "",
+                f"{'Rank':<{rank_width}}  {'Snapshot':<{snapshot_width}}  {'World':<{world_width}}  {'Total':>{total_width}}",
+                f"{'-' * rank_width}  {'-' * snapshot_width}  {'-' * world_width}  {'-' * total_width}",
+            ]
+        )
+        for index, score in enumerate(scores, start=1):
+            lines.append(
+                f"{index:<{rank_width}}  {score['snapshot_id']:<{snapshot_width}}  "
+                f"{score['world_id']:<{world_width}}  {score['total']:.6f}"
+            )
+
+        for index, score in enumerate(scores, start=1):
+            lines.extend(
+                [
+                    "",
+                    (
+                        f"{index}. {score['snapshot_id']} [{score['world_id']}] "
+                        f"total={score['total']:.6f}"
+                    ),
+                ]
+            )
+            for signal_name, weight in weights.items():
+                lines.append(
+                    "   "
+                    f"{signal_name}: value={score['signals'][signal_name]:.6f} "
+                    f"weight={weight:.2f} "
+                    f"contribution={score['contributions'][signal_name]:.6f}"
+                )
+    else:
+        lines.extend(["", "No train-split candidates were eligible for scoring."])
+
+    if skipped:
+        lines.extend(["", "Skipped candidates:"])
+        for entry in skipped:
+            lines.append(
+                f"  - {entry['snapshot_id']} [{entry['world_id']}] split={entry['split']}"
+            )
+
+    return "\n".join(lines)
+
+
+@click.command()
+@click.option(
+    "--population",
+    "population_file",
+    required=True,
+    type=click.File("r", encoding="utf-8"),
+    help=(
+        "JSON or YAML file containing PopulationStats entries. The file may be a "
+        "top-level list or a mapping with a 'population' list. Use '-' for stdin."
+    ),
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="text",
+    show_default=True,
+    type=click.Choice(["text", "json"]),
+    help="Render a human-readable calibration report or machine-readable JSON.",
+)
+def main(population_file: TextIO, output_format: str) -> None:
+    """Inspect parent-score behavior for the v1 frontier mutation policy."""
+    population = _load_population(population_file)
+    report = build_score_report(population)
+    if output_format == "json":
+        click.echo(json.dumps(report, indent=2, sort_keys=True))
+        return
+    click.echo(render_text_report(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mutation_policy_calibration.py
+++ b/tests/test_mutation_policy_calibration.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from open_range.curriculum import FrontierMutationPolicy, PopulationStats
+from open_range.devtools.mutation_policy_calibration import (
+    build_score_report,
+    main,
+)
+
+
+def _population_entries() -> list[dict[str, object]]:
+    return [
+        {
+            "snapshot_id": "snap-hard",
+            "world_id": "world-hard",
+            "split": "train",
+            "episodes": 12,
+            "red_win_rate": 0.05,
+            "blue_win_rate": 0.9,
+            "flake_rate": 0.02,
+            "novelty": 0.8,
+            "blue_signal_points": 5,
+        },
+        {
+            "snapshot_id": "snap-frontier",
+            "world_id": "world-frontier",
+            "split": "train",
+            "episodes": 8,
+            "red_win_rate": 0.52,
+            "blue_win_rate": 0.48,
+            "flake_rate": 0.01,
+            "novelty": 0.6,
+            "blue_signal_points": 4,
+        },
+        {
+            "snapshot_id": "snap-eval",
+            "world_id": "world-eval",
+            "split": "eval",
+            "episodes": 50,
+            "red_win_rate": 0.5,
+            "blue_win_rate": 0.5,
+            "flake_rate": 0.0,
+            "novelty": 1.0,
+            "blue_signal_points": 6,
+        },
+    ]
+
+
+def _write_population_file(tmp_path: Path, payload: object) -> Path:
+    population_path = tmp_path / "population.yaml"
+    population_path.write_text(
+        yaml.safe_dump(payload, sort_keys=False), encoding="utf-8"
+    )
+    return population_path
+
+
+def test_build_score_report_exposes_component_contributions():
+    report = build_score_report(
+        [PopulationStats.model_validate(entry) for entry in _population_entries()],
+        policy=FrontierMutationPolicy(),
+    )
+
+    assert report["eligible_candidates"] == 2
+    assert len(report["skipped_candidates"]) == 1
+    assert report["scores"][0]["snapshot_id"] == "snap-frontier"
+    assert report["scores"][0]["signals"] == {
+        "stability": 0.99,
+        "frontier": 0.96,
+        "novelty": 0.6,
+        "signal_richness": 0.666667,
+        "coverage": 0.8,
+    }
+    assert report["scores"][0]["contributions"] == {
+        "stability": 0.3465,
+        "frontier": 0.288,
+        "novelty": 0.09,
+        "signal_richness": 0.066667,
+        "coverage": 0.08,
+    }
+    assert report["scores"][0]["total"] == 0.871167
+
+
+def test_calibration_command_renders_text_report(tmp_path: Path):
+    population_path = _write_population_file(
+        tmp_path, {"population": _population_entries()}
+    )
+
+    result = CliRunner().invoke(main, ["--population", str(population_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "Population size: 3" in result.output
+    assert "Eligible train candidates: 2" in result.output
+    assert "snap-frontier" in result.output
+    assert "world-frontier" in result.output
+    assert "frontier: value=0.960000 weight=0.30 contribution=0.288000" in result.output
+    assert "Skipped candidates:" in result.output
+    assert "snap-eval [world-eval] split=eval" in result.output
+
+
+def test_calibration_command_renders_json_report(tmp_path: Path):
+    population_path = _write_population_file(tmp_path, _population_entries())
+
+    result = CliRunner().invoke(
+        main,
+        ["--population", str(population_path), "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["weights"] == {
+        "coverage": 0.1,
+        "frontier": 0.3,
+        "novelty": 0.15,
+        "signal_richness": 0.1,
+        "stability": 0.35,
+    }
+    assert payload["scores"][0]["snapshot_id"] == "snap-frontier"
+    assert payload["scores"][0]["contributions"]["signal_richness"] == 0.066667
+    assert payload["skipped_candidates"][0]["snapshot_id"] == "snap-eval"


### PR DESCRIPTION
Closes #94

## Summary

- add a lightweight dev-only mutation-policy calibration module that loads JSON or YAML `PopulationStats` input and renders ranked parent scores with readable per-signal breakdowns
- expose score weights and weighted signal contributions from `FrontierMutationPolicy` so the harness stays anchored to the live curriculum surface instead of duplicating heuristics
- add focused tests covering the breakdown data and both text and JSON report modes

## Testing

- No special verification beyond CI-covered lint and unit checks.

## Review Notes

- This stays out of the public runtime CLI surface and is intended for repo development via `uv run -m open_range.devtools.mutation_policy_calibration`.
