### PR TITLE
docs: add conventional commit PR title guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,11 @@
 Keep this PR body concise and review-friendly.
 -->
 
+> Use a conventional commit style PR title, for example `fix: ...`, `refactor: ...`, or `docs: ...`.
+
 ## Self-Review
 
+- [ ] PR title uses a conventional commit style summary
 - [ ] Scope is focused and matches the linked issue or change theme
 - [ ] I reviewed the diff for V1 architectural drift, reference leakage, and validation-profile regressions where relevant
 - [ ] Tests and docs were updated where behavior or workflows changed


### PR DESCRIPTION
## Self-Review

- [x] PR title uses a conventional commit style summary
- [x] Scope is focused and matches the linked issue or change theme
- [x] I reviewed the diff for V1 architectural drift, reference leakage, and validation-profile regressions where relevant
- [x] Tests and docs were updated where behavior or workflows changed

Closes #

## Summary

- add a short visible reminder that PR titles should use conventional commit style
- add a self-review checkbox so authors confirm the PR title follows that format

## Testing

No special verification beyond CI-covered checks.
