### PR TITLE
fix: narrow bundled docs package surface and clean PyPI metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,16 +6,24 @@ build-backend = "setuptools.build_meta"
 name = "open-range"
 version = "0.1.0"
 description = "Manifest-first red/blue/green cyber range package"
-readme = "README.md"
+readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "OpenRange Authors" }
 ]
 requires-python = ">=3.11"
 license = "MIT"
+keywords = [
+    "cyber-range",
+    "cybersecurity",
+    "red-team",
+    "blue-team",
+    "agent-training",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -32,8 +40,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/venca-labs/open-range"
-"Bug Tracker" = "https://github.com/venca-labs/open-range/issues"
+Homepage = "https://github.com/vecna-labs/open-range"
+Documentation = "https://github.com/vecna-labs/open-range/tree/main/docs"
+Issues = "https://github.com/vecna-labs/open-range/issues"
+Repository = "https://github.com/vecna-labs/open-range"
 
 [project.optional-dependencies]
 npc = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/vecna-labs/open-range"
-Documentation = "https://github.com/vecna-labs/open-range/tree/main/docs"
+Documentation = "https://github.com/vecna-labs/open-range#documentation"
 Issues = "https://github.com/vecna-labs/open-range/issues"
 Repository = "https://github.com/vecna-labs/open-range"
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-from __future__ import annotations
-
-from setuptools import setup
-
-setup()

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-from shutil import copy2
-
 from setuptools import setup
-from setuptools.command.build_py import build_py as _build_py
 
-
-class build_py(_build_py):
-    def run(self) -> None:
-        super().run()
-        root = Path(__file__).resolve().parent
-        source_dir = root / "docs"
-        target_dir = Path(self.build_lib) / "open_range" / "_resources" / "docs"
-        target_dir.mkdir(parents=True, exist_ok=True)
-        source_docs = {path.name: path for path in source_dir.glob("*.md")}
-        for path in target_dir.glob("*.md"):
-            if path.name not in source_docs:
-                path.unlink()
-        for name, source_path in source_docs.items():
-            copy2(source_path, target_dir / name)
-
-
-setup(cmdclass={"build_py": build_py})
+setup()

--- a/src/open_range/__init__.py
+++ b/src/open_range/__init__.py
@@ -28,12 +28,10 @@ from open_range.manifest import (
 from open_range.objectives import ObjectiveGraderSpec, StandardAttackObjective
 from open_range.pipeline import BuildPipeline, CandidateWorld, admit, admit_child, build
 from open_range.resources import (
-    bundled_docs_dir,
     bundled_manifest_dir,
     bundled_manifest_names,
     bundled_manifest_path,
     bundled_schema_dir,
-    load_bundled_doc,
     load_bundled_manifest,
     load_bundled_manifest_registry,
     load_bundled_schema,
@@ -103,13 +101,11 @@ __all__ = [
     "admit",
     "admit_child",
     "build",
-    "bundled_docs_dir",
     "bundled_manifest_dir",
     "bundled_manifest_names",
     "bundled_manifest_path",
     "bundled_schema_dir",
     "generate_trace_dataset",
-    "load_bundled_doc",
     "load_bundled_manifest",
     "load_bundled_manifest_registry",
     "load_bundled_schema",

--- a/src/open_range/resources.py
+++ b/src/open_range/resources.py
@@ -1,4 +1,4 @@
-"""Access bundled manifests, schemas, docs, and other installable assets."""
+"""Access bundled manifests, schemas, and other installable assets."""
 
 from __future__ import annotations
 
@@ -21,16 +21,6 @@ def bundled_manifest_dir() -> Path:
 
 def bundled_schema_dir() -> Path:
     return resource_root() / "schemas"
-
-
-def bundled_docs_dir() -> Path:
-    package_docs_dir = resource_root() / "docs"
-    if any(package_docs_dir.glob("*.md")):
-        return package_docs_dir
-    repo_docs_dir = resource_root().parents[2] / "docs"
-    if repo_docs_dir.exists():
-        return repo_docs_dir
-    return package_docs_dir
 
 
 def bundled_manifest_names() -> tuple[str, ...]:
@@ -65,17 +55,11 @@ def load_bundled_schema(name: str) -> dict[str, Any]:
     return payload
 
 
-def load_bundled_doc(name: str) -> str:
-    return (bundled_docs_dir() / name).read_text(encoding="utf-8")
-
-
 __all__ = [
-    "bundled_docs_dir",
     "bundled_manifest_dir",
     "bundled_manifest_names",
     "bundled_manifest_path",
     "bundled_schema_dir",
-    "load_bundled_doc",
     "load_bundled_manifest",
     "load_bundled_manifest_registry",
     "load_bundled_schema",

--- a/tests/test_package_resources.py
+++ b/tests/test_package_resources.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from open_range.resources import (
-    bundled_docs_dir,
     bundled_schema_dir,
-    load_bundled_doc,
     load_bundled_schema,
     resource_root,
 )
@@ -17,7 +15,7 @@ def test_bundled_resource_tree_exists():
     assert root.exists()
     assert (root / "manifests").exists()
     assert bundled_schema_dir().exists()
-    assert bundled_docs_dir().exists()
+    assert not (root / "docs").exists()
 
 
 def test_bundled_schemas_match_checked_in_schemas():
@@ -31,19 +29,3 @@ def test_bundled_schemas_match_checked_in_schemas():
             repo_dir / name
         ).read_text(encoding="utf-8")
         assert isinstance(load_bundled_schema(name), dict)
-
-
-def test_load_bundled_doc_reads_source_of_truth_docs():
-    contents = load_bundled_doc("architecture.md")
-    weakness_contents = load_bundled_doc("weakness-lifecycle.md")
-    npc_contents = load_bundled_doc("npc-profiles.md")
-
-    assert "Python control plane" in contents
-    assert "Blue has two distinct control actions" in weakness_contents
-    assert "NPC Profile Spec" in npc_contents
-    assert "Current Scope" in npc_contents
-
-
-def test_repo_checkout_uses_single_docs_source_of_truth():
-    assert bundled_docs_dir().resolve() == Path("docs").resolve()
-    assert tuple((Path("src/open_range/_resources/docs")).glob("*.md")) == ()

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -9,7 +9,9 @@ import open_range.runtime as runtime_module
 
 def test_top_level_package_keeps_internal_runtime_and_sft_helpers_private() -> None:
     forbidden = {
+        "bundled_docs_dir",
         "build_decision_prompt",
+        "load_bundled_doc",
         "render_action_completion",
         "render_decision_prompt",
         "system_prompt_for_role",


### PR DESCRIPTION
## Self-Review

- [x] PR title uses a conventional commit style summary
- [x] Scope is focused and matches the linked issue or change theme
- [x] I reviewed the diff for V1 architectural drift, reference leakage, and validation-profile regressions where relevant
- [x] Tests and docs were updated where behavior or workflows changed

Closes #95
Refs #96

## Summary

- remove bundled docs helpers from the supported package surface and stop treating checkout-local `docs/` as an install-time API fallback
- drop the docs copy hook from packaging and tighten tests around the narrowed resource contract
- fix broken GitHub package URLs in `pyproject.toml` and add basic PyPI-facing metadata for the first release path

## Testing

- `uv run -m pytest tests/test_package_resources.py tests/test_public_surface.py -q`
- `uv build --wheel`
- `uvx twine check dist/*`

## Review Notes

- this only covers the metadata part of #96; publish workflow and branch-trigger cleanup are still separate follow-up work
