### PR TITLE
feat(dashboard): auto-start server; project graph topology

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/__init__.py
@@ -76,18 +76,97 @@ class CyberWebappPack(Pack):
     def project_world(self, graph: WorldGraph) -> Mapping[str, object]:
         """Project the graph back to a flat world dict.
 
-        Surfaces the flag value so verifiers can compare against the
-        agent's submitted result. Other multi-node attrs are
-        intentionally omitted — the verifier only cares about the
-        flag; richer projections (service map, account index) come
-        when verifiers need them.
+        Surfaces the flag (for the verifier) plus a topology view
+        (services + edges + zones + users) the dashboard renders. The
+        dashboard auto-redacts ``flag`` / ``secret`` / ``password`` /
+        ``token`` keys, so the projected topology is safe to publish.
         """
+        flag = ""
         for node in graph.nodes:
             if node.type == "secret" and node.attrs.get("kind") == "flag":
-                return MappingProxyType(
-                    {"flag": str(node.attrs.get("value_ref", ""))},
-                )
-        return MappingProxyType({})
+                flag = str(node.attrs.get("value_ref", ""))
+                break
+
+        services: list[dict[str, object]] = []
+        zones: set[str] = set()
+        host_zone: dict[str, str] = {}
+        for node in graph.nodes:
+            if node.type == "host":
+                zone = str(node.attrs.get("zone", ""))
+                if zone:
+                    host_zone[node.id] = zone
+                    zones.add(zone)
+        service_host: dict[str, str] = {}
+        for edge in graph.edges:
+            if edge.relation == "runs_on":
+                service_host[edge.source] = edge.target
+        endpoints_by_service: dict[str, list[str]] = {}
+        for edge in graph.edges:
+            if edge.relation == "exposes":
+                endpoints_by_service.setdefault(edge.source, []).append(edge.target)
+        endpoint_path: dict[str, str] = {
+            n.id: str(n.attrs.get("path", "")) for n in graph.nodes if n.type == "endpoint"
+        }
+        vuln_targets: dict[str, str] = {}
+        vuln_kind: dict[str, str] = {}
+        for n in graph.nodes:
+            if n.type == "vulnerability":
+                vuln_kind[n.id] = str(n.attrs.get("kind", ""))
+        for edge in graph.edges:
+            if edge.relation == "affects":
+                vuln_targets[edge.source] = edge.target
+
+        for node in graph.nodes:
+            if node.type != "service":
+                continue
+            host_id = service_host.get(node.id)
+            zone = host_zone.get(host_id, "")
+            paths = sorted(endpoint_path.get(ep, "") for ep in endpoints_by_service.get(node.id, []))
+            vulns_on_service = [
+                vuln_kind[vid] for vid, target in vuln_targets.items()
+                if target == node.id and vid in vuln_kind
+            ]
+            vulns_on_endpoints = [
+                vuln_kind[vid] for vid, target in vuln_targets.items()
+                if target in endpoints_by_service.get(node.id, []) and vid in vuln_kind
+            ]
+            services.append({
+                "id": str(node.attrs.get("name", node.id)),
+                "kind": str(node.attrs.get("kind", "")),
+                "zone": zone or "default",
+                "exposure": str(node.attrs.get("exposure", "")),
+                "ports": [],
+                "paths": paths,
+                "vulns": sorted(set(vulns_on_service + vulns_on_endpoints)),
+            })
+
+        edges: list[dict[str, object]] = []
+        service_name_by_id: dict[str, str] = {
+            n.id: str(n.attrs.get("name", n.id)) for n in graph.nodes if n.type == "service"
+        }
+        for edge in graph.edges:
+            if edge.relation == "backed_by":
+                src = service_name_by_id.get(edge.source)
+                if src:
+                    edges.append({"source": src, "target": str(edge.target), "relation": "backed_by"})
+
+        users: list[dict[str, object]] = [
+            {
+                "id": str(n.attrs.get("username", n.id)),
+                "role": str(n.attrs.get("role", "user")),
+            }
+            for n in graph.nodes if n.type == "account"
+        ]
+
+        return MappingProxyType({
+            "flag": flag,
+            "topology": {
+                "services": services,
+                "edges": edges,
+                "zones": sorted(zones),
+                "users": users,
+            },
+        })
 
 
 __all__ = ["CyberWebappPack"]

--- a/src/openrange/runtime.py
+++ b/src/openrange/runtime.py
@@ -89,6 +89,7 @@ class OpenRangeRun:
             )
         )
         self._dashboard_view: DashboardView | None = None
+        self._dashboard_server: DashboardServerHandle | None = None
 
     def build(
         self,
@@ -128,7 +129,36 @@ class OpenRangeRun:
 
     def episode_service(self, snapshot: Snapshot) -> EpisodeService:
         view = self._ensure_dashboard_view(snapshot)
+        if view is not None and self._dashboard_server is None:
+            self._dashboard_server = self._start_dashboard_server(snapshot)
         return EpisodeService(self.root, dashboard=view)
+
+    def _start_dashboard_server(
+        self, snapshot: Snapshot,
+    ) -> DashboardServerHandle | None:
+        port = self.config.dashboard_port if self.config.dashboard_port else 0
+        try:
+            handle = self.serve_dashboard(
+                snapshot,
+                host=self.config.dashboard_host,
+                port=port,
+            )
+        except OSError as exc:
+            print(f"dashboard server failed to start: {exc}", flush=True)
+            return None
+        print(f"dashboard: {handle.url}", flush=True)
+        return handle
+
+    def close(self) -> None:
+        if self._dashboard_server is not None:
+            self._dashboard_server.close()
+            self._dashboard_server = None
+
+    def __enter__(self) -> OpenRangeRun:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
 
     def serve_dashboard(
         self,


### PR DESCRIPTION
## Summary

Two follow-up fixes from #213 — making the dashboard usable end-to-end:

1. **Auto-start the dashboard server in-process.** `RunConfig.dashboard_port` was wired through the eval CLI but `OpenRangeRun` never actually started a server — you had to call `run.serve_dashboard()` separately, which the example never did. Now `OpenRangeRun.episode_service()` auto-starts a `DashboardHTTPServer` (when `RunConfig.dashboard=True`) and prints `dashboard: http://127.0.0.1:<port>` to stdout. Server cleans up via `OpenRangeRun.close()` / context-manager.
2. **Project the world graph into the dashboard topology.** The cyber pack's `project_world` only surfaced the flag, so the dashboard's topology view rendered a single `web` service inferred from the task entrypoint — every other service, vuln, account, and zone was invisible. Now it emits a topology block (`services` with `kind`/`zone`/`exposure`/`paths`/`vulns`, `edges`, `zones`, `users`) so the dashboard renders the actual generated world.

## Result

- Bare `uv run python -m examples.codex_eval` now prints the dashboard URL before the agent runs.
- Topology endpoint serves real multi-service data — example from a live build:
  - 4 services across `web` / `api` / `db` / `db1` kinds
  - 2 zones (`dmz`, `corp`) populated from host `zone` attrs
  - vuln annotations per service (`db1: ["broken_authz"]`, etc.)
  - `backed_by` edge between `db` and its data store
  - `admin` user with `role: admin`
- `flag` value is still in `world` for the verifier; dashboard auto-redacts it via `sensitive_world_key()`.

## Test plan

- [x] `uv run pytest -q` — 124 passed
- [x] `uv run python -m examples.codex_eval --run-root or-runs/live` — passes (`AKIAG0SDIUMVOY8XFUYY` extracted via SSRF chain to `/svc/db/tables`, 2240 requests)
- [x] `curl http://127.0.0.1:<port>/api/topology` returns a multi-service payload with vulns + zones + users
- [ ] Open dashboard in browser, confirm graph view renders all services with vuln badges and traffic timeline shows agent + NPC requests against the right services

🤖 Generated with [Claude Code](https://claude.com/claude-code)
