### PR TITLE
feat: add OpenAI-compatible LLM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ Optional Strands Agents support:
 uv sync --extra strands
 ```
 
+The `OpenAICompatibleBackend` uses the Chat Completions API shape and accepts
+`base_url`, `api_key`, `model`, `timeout`, and optional headers without any
+extra dependencies. It is the lightweight stdlib option for OpenAI and
+compatible servers such as OpenRouter, Groq, Together, Fireworks, DeepSeek,
+Ollama, vLLM, and llama.cpp server. The default model is `gpt-4o-mini`, which is
+mainly useful with OpenAI's API; set `model` explicitly for local and
+third-party compatible servers. When a JSON schema is supplied, it requests
+`response_format={"type": "json_schema", ...}` and returns both the raw text and
+parsed JSON object. Schema strictness defaults to off for broader provider
+compatibility and can be enabled with `json_schema_strict=True`.
+
 ## Build a world
 
 ```python

--- a/src/openrange/__init__.py
+++ b/src/openrange/__init__.py
@@ -71,6 +71,7 @@ from openrange.core.episode import (
 )
 from openrange.llm import (
     CODEX_DEFAULT_MODEL,
+    OPENAI_COMPATIBLE_DEFAULT_MODEL,
     CodexBackend,
     LLMBackend,
     LLMBackendError,
@@ -78,6 +79,7 @@ from openrange.llm import (
     LLMRequest,
     LLMRequestError,
     LLMResult,
+    OpenAICompatibleBackend,
 )
 from openrange.npc import (
     NPC,
@@ -148,6 +150,8 @@ __all__ = [
     "Observation",
     "OpenRangeError",
     "OpenRangeRun",
+    "OPENAI_COMPATIBLE_DEFAULT_MODEL",
+    "OpenAICompatibleBackend",
     "PACKS",
     "Pack",
     "PackError",

--- a/src/openrange/llm.py
+++ b/src/openrange/llm.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import tempfile
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, cast
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 from openrange.core import OpenRangeError
 
 CODEX_DEFAULT_MODEL = "gpt-5.3-codex-spark"
+OPENAI_COMPATIBLE_DEFAULT_MODEL = "gpt-4o-mini"
 
 
 class LLMError(OpenRangeError):
@@ -151,6 +156,104 @@ class CodexBackend:
             return LLMResult(raw, parse_json_object(raw))
 
 
+@dataclass(frozen=True, slots=True)
+class OpenAICompatibleBackend:
+    """HTTP backend for OpenAI Chat Completions-compatible providers.
+
+    ``extra_headers`` are applied last, so callers can intentionally override
+    the default ``Authorization`` bearer header for providers that use a
+    different auth scheme.
+    """
+
+    base_url: str = "https://api.openai.com/v1"
+    model: str = OPENAI_COMPATIBLE_DEFAULT_MODEL
+    api_key: str | None = None
+    api_key_env: str = "OPENAI_API_KEY"
+    timeout: float = 120.0
+    extra_headers: Mapping[str, str] | None = None
+    json_schema_strict: bool = False
+
+    def preflight(self) -> None:
+        """Validate local configuration without making a network call."""
+        if not self.base_url.strip():
+            raise LLMBackendError("OpenAICompatibleBackend requires a base_url")
+        scheme = urlparse(self.base_url).scheme
+        if scheme not in {"http", "https"}:
+            raise LLMBackendError(
+                "OpenAICompatibleBackend base_url must use http or https",
+            )
+        if not self.model.strip():
+            raise LLMBackendError("OpenAICompatibleBackend requires a model")
+        if self.timeout <= 0:
+            raise LLMBackendError("OpenAICompatibleBackend timeout must be positive")
+
+    def complete(self, request: LLMRequest) -> LLMResult:
+        self.preflight()
+        http_request = Request(
+            self._chat_completions_url(),
+            data=json.dumps(self._payload(request)).encode("utf-8"),
+            headers=self._headers(),
+            method="POST",
+        )
+        try:
+            with urlopen(http_request, timeout=self.timeout) as response:
+                raw = response.read().decode("utf-8")
+        except HTTPError as exc:
+            detail = _openai_compatible_error_detail(exc)
+            raise LLMBackendError(
+                f"OpenAI-compatible HTTP {exc.code}: {detail}",
+                returncode=exc.code,
+            ) from exc
+        except TimeoutError as exc:
+            raise _openai_compatible_timeout_error(self.timeout) from exc
+        except URLError as exc:
+            if isinstance(exc.reason, TimeoutError):
+                raise _openai_compatible_timeout_error(self.timeout) from exc
+            raise LLMBackendError(
+                f"OpenAI-compatible request failed: {exc.reason}",
+            ) from exc
+
+        return _openai_compatible_result(raw, request)
+
+    def _chat_completions_url(self) -> str:
+        return f"{self.base_url.rstrip('/')}/chat/completions"
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        api_key = (
+            self.api_key if self.api_key is not None else os.getenv(self.api_key_env)
+        )
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        if self.extra_headers is not None:
+            headers.update(self.extra_headers)
+        return headers
+
+    def _payload(self, request: LLMRequest) -> dict[str, object]:
+        messages: list[dict[str, str]] = []
+        if request.system is not None:
+            messages.append({"role": "system", "content": request.system})
+        messages.append({"role": "user", "content": request.prompt})
+
+        payload: dict[str, object] = {
+            "model": self.model,
+            "messages": messages,
+        }
+        if request.json_schema is not None:
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "openrange_response",
+                    "strict": self.json_schema_strict,
+                    "schema": request.json_schema,
+                },
+            }
+        return payload
+
+
 def run_codex(
     command: Sequence[str],
     *,
@@ -172,6 +275,60 @@ def run_codex(
         raise LLMBackendError(f"codex timed out after {timeout} seconds") from exc
     except OSError as exc:
         raise LLMBackendError(str(exc)) from exc
+
+
+def _openai_compatible_error_detail(exc: HTTPError) -> str:
+    body = exc.read().decode("utf-8", errors="replace").strip()
+    if not body:
+        return exc.reason
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        return body
+    if isinstance(data, dict):
+        error = data.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if isinstance(message, str) and message:
+                return message
+        message = data.get("message")
+        if isinstance(message, str) and message:
+            return message
+    return body
+
+
+def _openai_compatible_timeout_error(timeout: float) -> LLMBackendError:
+    return LLMBackendError(
+        f"OpenAI-compatible request timed out after {timeout} seconds",
+    )
+
+
+def _openai_compatible_result(raw: str, request: LLMRequest) -> LLMResult:
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise LLMBackendError(
+            f"OpenAI-compatible response was not JSON: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise LLMBackendError("OpenAI-compatible response was not an object")
+
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise LLMBackendError("OpenAI-compatible response had no choices")
+    first = choices[0]
+    if not isinstance(first, dict):
+        raise LLMBackendError("OpenAI-compatible choice was not an object")
+    message = first.get("message")
+    if not isinstance(message, dict):
+        raise LLMBackendError("OpenAI-compatible choice had no message")
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise LLMBackendError("OpenAI-compatible message content was not text")
+
+    if request.json_schema is None:
+        return LLMResult(content)
+    return LLMResult(content, parse_json_object(content))
 
 
 def parse_json_object(raw: str) -> Mapping[str, object]:

--- a/tests/test_openai_compatible_backend.py
+++ b/tests/test_openai_compatible_backend.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+import time
+from collections.abc import Callable, Iterator, Mapping
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, cast
+
+import pytest
+
+import openrange as OR
+from openrange.llm import LLMBackendError
+
+ServerResponse = tuple[int, Mapping[str, object] | str, float]
+RequestHandler = Callable[
+    [Mapping[str, object], Mapping[str, str], str],
+    ServerResponse,
+]
+
+
+@contextlib.contextmanager
+def running_openai_server(
+    handler: RequestHandler,
+) -> Iterator[tuple[str, list[dict[str, object]]]]:
+    requests: list[dict[str, object]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, _format: str, *_args: object) -> None:
+            pass
+
+        def do_POST(self) -> None:
+            content_length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(content_length).decode("utf-8")
+            payload = cast(dict[str, object], json.loads(body))
+            headers = dict(self.headers.items())
+            requests.append(
+                {
+                    "path": self.path,
+                    "headers": headers,
+                    "payload": payload,
+                },
+            )
+
+            status, response, delay = handler(payload, headers, self.path)
+            if delay:
+                time.sleep(delay)
+            response_bytes = (
+                response.encode("utf-8")
+                if isinstance(response, str)
+                else json.dumps(response).encode("utf-8")
+            )
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(response_bytes)))
+            self.end_headers()
+            with contextlib.suppress(BrokenPipeError):
+                self.wfile.write(response_bytes)
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host = cast(str, server.server_address[0])
+        port = server.server_address[1]
+        yield f"http://{host}:{port}", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_openai_compatible_backend_sends_plain_chat_completion() -> None:
+    def handler(
+        _payload: Mapping[str, object],
+        _headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        return 200, {"choices": [{"message": {"content": "plain answer"}}]}, 0
+
+    with running_openai_server(handler) as (base_url, requests):
+        result = OR.OpenAICompatibleBackend(
+            base_url=f"{base_url}/v1",
+            api_key="test-key",
+            model="demo-model",
+            extra_headers={"X-Test": "yes"},
+        ).complete(OR.LLMRequest("build a world", system="be precise"))
+
+    assert result == OR.LLMResult("plain answer")
+    request = requests[0]
+    payload = cast(dict[str, Any], request["payload"])
+    assert request["path"] == "/v1/chat/completions"
+    assert payload["model"] == "demo-model"
+    assert payload["messages"] == [
+        {"role": "system", "content": "be precise"},
+        {"role": "user", "content": "build a world"},
+    ]
+    assert "response_format" not in payload
+    headers = cast(dict[str, str], request["headers"])
+    assert headers["Authorization"] == "Bearer test-key"
+    assert headers["X-Test"] == "yes"
+
+
+def test_openai_compatible_backend_requests_structured_json() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"ok": {"type": "boolean"}},
+        "required": ["ok"],
+    }
+
+    def handler(
+        payload: Mapping[str, object],
+        _headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        response_format = cast(dict[str, Any], payload["response_format"])
+        assert response_format["type"] == "json_schema"
+        assert response_format["json_schema"]["schema"] == schema
+        assert response_format["json_schema"]["strict"] is False
+        return 200, {"choices": [{"message": {"content": '{"ok": true}'}}]}, 0
+
+    with running_openai_server(handler) as (base_url, _requests):
+        result = OR.OpenAICompatibleBackend(
+            base_url=f"{base_url}/v1",
+            api_key="test-key",
+            model="demo-model",
+        ).complete(OR.LLMRequest("return json", json_schema=schema))
+
+    assert result.text == '{"ok": true}'
+    assert result.parsed_json == {"ok": True}
+
+
+def test_openai_compatible_backend_can_request_strict_json_schema() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"ok": {"type": "boolean"}},
+        "required": ["ok"],
+    }
+
+    def handler(
+        payload: Mapping[str, object],
+        _headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        response_format = cast(dict[str, Any], payload["response_format"])
+        assert response_format["json_schema"]["strict"] is True
+        return 200, {"choices": [{"message": {"content": '{"ok": true}'}}]}, 0
+
+    with running_openai_server(handler) as (base_url, _requests):
+        result = OR.OpenAICompatibleBackend(
+            base_url=f"{base_url}/v1",
+            api_key="test-key",
+            model="demo-model",
+            json_schema_strict=True,
+        ).complete(OR.LLMRequest("return json", json_schema=schema))
+
+    assert result.parsed_json == {"ok": True}
+
+
+def test_openai_compatible_backend_reads_api_key_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENRANGE_TEST_API_KEY", "env-key")
+
+    def handler(
+        _payload: Mapping[str, object],
+        headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        assert headers["Authorization"] == "Bearer env-key"
+        return 200, {"choices": [{"message": {"content": "plain answer"}}]}, 0
+
+    with running_openai_server(handler) as (base_url, _requests):
+        result = OR.OpenAICompatibleBackend(
+            base_url=f"{base_url}/v1",
+            api_key_env="OPENRANGE_TEST_API_KEY",
+            model="demo-model",
+        ).complete(OR.LLMRequest("hello"))
+
+    assert result == OR.LLMResult("plain answer")
+
+
+def test_openai_compatible_backend_rejects_non_http_base_url() -> None:
+    backend = OR.OpenAICompatibleBackend(
+        base_url="file:///tmp/openai",
+        api_key="test-key",
+        model="demo-model",
+    )
+
+    with pytest.raises(LLMBackendError, match="base_url must use http or https"):
+        backend.preflight()
+
+
+def test_openai_compatible_backend_maps_http_errors() -> None:
+    def handler(
+        _payload: Mapping[str, object],
+        _headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        return 401, {"error": {"message": "bad api key"}}, 0
+
+    with running_openai_server(handler) as (base_url, _requests):
+        backend = OR.OpenAICompatibleBackend(
+            base_url=f"{base_url}/v1",
+            api_key="test-key",
+            model="demo-model",
+        )
+        with pytest.raises(LLMBackendError, match="HTTP 401: bad api key"):
+            backend.complete(OR.LLMRequest("hello"))
+
+
+def test_openai_compatible_backend_maps_timeouts() -> None:
+    def handler(
+        _payload: Mapping[str, object],
+        _headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        return 200, {"choices": [{"message": {"content": "late"}}]}, 0.2
+
+    with running_openai_server(handler) as (base_url, _requests):
+        backend = OR.OpenAICompatibleBackend(
+            base_url=f"{base_url}/v1",
+            api_key="test-key",
+            model="demo-model",
+            timeout=0.01,
+        )
+        with pytest.raises(LLMBackendError, match="timed out after 0.01 seconds"):
+            backend.complete(OR.LLMRequest("hello"))


### PR DESCRIPTION
## Summary
- add `OpenAICompatibleBackend` for Chat Completions-compatible HTTP providers
- support text and JSON-schema requests, API key/env auth, extra headers, timeouts, and HTTP error mapping
- export the backend from the public API and document the `openai-compatible` optional install target
- add mocked HTTP tests for text, structured JSON, HTTP errors, and timeout handling

## Verification
- `uv lock --check`
- `uv run ruff format src\openrange\llm.py src\openrange\__init__.py tests\test_openai_compatible_backend.py`
- `uv run ruff check README.md pyproject.toml src\openrange\llm.py src\openrange\__init__.py tests\test_openai_compatible_backend.py`
- `uv run mypy src\openrange\llm.py tests\test_openai_compatible_backend.py`
- `uv run pytest tests\test_openai_compatible_backend.py -q`
- `git diff --check`

Note: I also tried `uv run pytest tests\test_openai_compatible_backend.py tests\test_llm_and_dashboard.py -q`; the new tests passed, but existing `test_llm_and_dashboard.py` cases fail on Windows because Python scripts are executed directly as Win32 binaries and `os.getpgid` is unavailable on Windows.

Refs #188