### PR TITLE
feat: port graphschema in-tree as packages/graphschema/ workspace member

### DIFF
--- a/packages/graphschema/CHANGELOG.md
+++ b/packages/graphschema/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes documented here. Versions follow semver; breaking
+changes to the wire format bump the ontology id (`@version`), not the
+package version.
+
+## [Unreleased]
+
+## [0.1.0] — 2026-05-26
+
+Initial release.
+
+- `Node`, `Edge`, `WorldGraph`: typed property graph primitives.
+- `Ontology`, `NodeKind`, `EdgeKind`, `AttrSpec`, `AttrType`: declarative schema.
+- `Role`, `Visibility`: cross-cutting enums.
+- `validate(graph, ontology, invariants=...)`: three-tier validator
+  (structure → ontology conformance → caller invariants).
+- `GraphPatch` + `apply_patch`: the only mutation primitive.
+- `WorldGraph.content_hash()`: deterministic `sha256` over canonical JSON.
+- `py.typed` marker — full type information ships with the package.

--- a/packages/graphschema/LICENSE
+++ b/packages/graphschema/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vecna Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/graphschema/README.md
+++ b/packages/graphschema/README.md
@@ -1,0 +1,57 @@
+# graphschema
+
+[![ci](https://github.com/vecna-labs/graphschema/actions/workflows/ci.yml/badge.svg)](https://github.com/vecna-labs/graphschema/actions/workflows/ci.yml)
+[![python](https://img.shields.io/badge/python-3.14+-blue)](https://www.python.org)
+[![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+
+Typed property graphs in Python. Declare an ontology in plain data;
+get validation, diffs, and content hashing for free. Zero
+dependencies, ~700 lines, fully typed.
+
+```python
+from graphschema import (
+    AttrSpec, AttrType, Edge, EdgeKind, Node, NodeKind,
+    Ontology, WorldGraph, validate,
+)
+
+rooms = Ontology(
+    id="rooms@0.1.0",
+    node_kinds={
+        "room": NodeKind("room", attrs={
+            "label": AttrSpec(AttrType.STRING, required=True),
+        }),
+    },
+    edge_kinds={
+        "leads_to": EdgeKind("leads_to", endpoints=[("room", "room")]),
+    },
+)
+
+g = WorldGraph(ontology=rooms.id)
+g.add_node(Node("a", "room", attrs={"label": "lobby"}))
+g.add_node(Node("b", "room", attrs={"label": "vault"}))
+g.add_edge(Edge("e1", "leads_to", "a", "b"))
+
+assert not [i for i in validate(g, rooms) if i.severity == "error"]
+print(g.content_hash())  # sha256:…  same content → same hash
+```
+
+## Install
+
+```bash
+uv add git+https://github.com/vecna-labs/graphschema.git
+```
+
+Requires Python ≥ 3.14.
+
+## Develop
+
+```bash
+uv sync
+uv run pytest
+uv run ruff check
+uv run mypy --strict src tests
+```
+
+## License
+
+MIT.

--- a/packages/graphschema/pyproject.toml
+++ b/packages/graphschema/pyproject.toml
@@ -1,0 +1,59 @@
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[project]
+name = "graphschema"
+version = "0.1.0"
+description = "Typed property-graph meta-model with declarative schemas."
+readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
+requires-python = ">=3.14"
+authors = [{ name = "Vecna AI" }]
+keywords = ["graph", "ontology", "schema", "property-graph", "typed-graph"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Libraries",
+    "Typing :: Typed",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/vecna-labs/graphschema"
+Repository = "https://github.com/vecna-labs/graphschema"
+Issues = "https://github.com/vecna-labs/graphschema/issues"
+
+[dependency-groups]
+dev = [
+    "mypy>=1.19",
+    "pytest>=9.0",
+    "ruff>=0.15.6",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/graphschema"]
+include = ["src/graphschema/py.typed"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py314"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "SIM"]
+
+[tool.mypy]
+python_version = "3.14"
+mypy_path = ["src"]
+strict = true
+warn_unreachable = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = "-q"

--- a/packages/graphschema/src/graphschema/__init__.py
+++ b/packages/graphschema/src/graphschema/__init__.py
@@ -1,0 +1,60 @@
+"""Typed property-graph meta-model.
+
+The top-level `graphschema` namespace re-exports the meta-model from
+`graphschema._ir`. Downstream packages declare their own ontologies on
+top of these primitives.
+
+Typical use:
+
+    from graphschema import (
+        AttrSpec, AttrType, Edge, EdgeKind, Node, NodeKind,
+        Ontology, WorldGraph, validate,
+    )
+
+    onto = Ontology(
+        id="rooms@0.1.0",
+        node_kinds={"room": NodeKind("room", attrs={
+            "label": AttrSpec(AttrType.STRING, required=True),
+        })},
+        edge_kinds={"leads_to": EdgeKind("leads_to", endpoints=[("room", "room")])},
+    )
+    g = WorldGraph(ontology=onto.id)
+    g.add_node(Node("a", "room", attrs={"label": "lobby"}))
+    issues = validate(g, onto)
+"""
+
+from __future__ import annotations
+
+from graphschema._ir import (
+    AttrSpec,
+    AttrType,
+    Edge,
+    EdgeKind,
+    GraphPatch,
+    Issue,
+    Node,
+    NodeKind,
+    Ontology,
+    Role,
+    Visibility,
+    WorldGraph,
+    apply_patch,
+    validate,
+)
+
+__all__ = [
+    "AttrSpec",
+    "AttrType",
+    "Edge",
+    "EdgeKind",
+    "GraphPatch",
+    "Issue",
+    "Node",
+    "NodeKind",
+    "Ontology",
+    "Role",
+    "Visibility",
+    "WorldGraph",
+    "apply_patch",
+    "validate",
+]

--- a/packages/graphschema/src/graphschema/_ir.py
+++ b/packages/graphschema/src/graphschema/_ir.py
@@ -1,0 +1,672 @@
+"""Typed property-graph meta-model.
+
+The fixed typed-property-graph layer this package is built on. It owns
+`Node`, `Edge`, `WorldGraph`, the declarative `Ontology` schema, and the
+three-tier `validate()` (structural, ontology conformance, caller
+invariants).
+
+This module is deliberately ontology-agnostic — it knows nothing about
+any specific domain, nor any specific cognitive ontology. A graph's
+domain meaning lives entirely in its `Ontology`, declared as data; one
+generic validator checks any graph against any ontology.
+
+The four primitives in this file are:
+
+  * `Node` / `Edge`         — the data of a typed property graph.
+  * `WorldGraph`            — a graph plus an ontology id and opaque
+                              meta; supports `content_hash()` for
+                              deterministic content-addressed identity.
+  * `Ontology`, `NodeKind`, `EdgeKind`, `AttrSpec` — the declarative
+                              schema; pure data, no runtime.
+  * `validate()`            — three-tier validator returning structured
+                              `Issue` values rather than raising.
+  * `GraphPatch` + `apply_patch()` — universal diff type for mutating a
+                              graph in place.
+
+The JSON shape implied by `content_hash()` is intended to be the
+on-the-wire contract: keys sorted, no whitespace, empty optional fields
+omitted, `meta`/`runtime` excluded so two graphs that differ only in
+provenance noise share identity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class AttrType(StrEnum):
+    """Allowed attribute primitive types in an ontology.
+
+    String-valued so the enum *is* its wire form — `AttrType.STRING.value ==
+    "string"` matches the lowercase wire tokens.
+    """
+
+    STRING = "string"
+    INT = "int"
+    FLOAT = "float"
+    BOOL = "bool"
+    ENUM = "enum"
+    REF = "ref"
+    JSON = "json"
+
+
+class Visibility(StrEnum):
+    """Whether a node is part of the surface an observer can see directly.
+
+    `PUBLIC` is the default and is omitted on the wire. `HIDDEN` nodes still
+    exist in the graph (an undisclosed asset, a private piece of state),
+    but they are not part of the directly-observable surface — discovering
+    hidden state may be the point.
+    """
+
+    PUBLIC = "public"
+    HIDDEN = "hidden"
+
+
+class Role(StrEnum):
+    """The fixed, world-absolute role vocabulary the generic machinery reads.
+
+    Roles are deliberately a small closed set so generic code can branch on
+    them without knowing any domain. World-absolute means a role is true
+    regardless of what task is being run; task-relative facts live on the
+    caller's task spec, never here.
+    """
+
+    ACTOR = "actor"
+    NPC = "npc"
+    EXTERNAL = "external"
+
+
+@dataclass
+class AttrSpec:
+    """One attribute slot declared by an ontology.
+
+    `type` chooses the primitive (or `REF` for an id pointing at another node,
+    or `JSON` for an opaque blob). `enum` is required when `type` is `ENUM` and
+    lists the legal values; `ref_kinds`, when set on a `REF`, restricts the
+    target node's kind. `default` is informational — the validator does not
+    apply it; the caller decides whether to.
+    """
+
+    type: AttrType
+    required: bool = False
+    enum: list[str] | None = None
+    ref_kinds: list[str] | None = None
+    default: Any = None
+    description: str = ""
+
+
+@dataclass
+class NodeKind:
+    """A node-kind declaration in an ontology.
+
+    `parent` names another kind whose attrs this kind inherits — the child's
+    `attrs` override the parent's by key, and required attrs from the parent
+    are still enforced. `attrs` is the *local* attr map (parent attrs are
+    composed in by the validator).
+    """
+
+    id: str
+    parent: str | None = None
+    attrs: dict[str, AttrSpec] = field(default_factory=dict)
+    description: str = ""
+
+
+@dataclass
+class EdgeKind:
+    """An edge-kind declaration in an ontology.
+
+    `endpoints` is the list of allowed `(src_kind, dst_kind)` pairs. `src_max`
+    and `dst_max` are degree caps per node of the given side, both `None` for
+    unbounded.
+    """
+
+    id: str
+    endpoints: list[tuple[str, str]] = field(default_factory=list)
+    src_max: int | None = None
+    dst_max: int | None = None
+    attrs: dict[str, AttrSpec] = field(default_factory=dict)
+    description: str = ""
+
+
+@dataclass
+class Ontology:
+    """A declared schema for one graph: node kinds and edge kinds.
+
+    The schema is itself plain data so a single generic validator can check
+    any graph against any ontology. Nothing hard-codes the meaning of a
+    specific kind.
+
+    Graph-wide invariants beyond the declared node/edge shape are passed in
+    as callables to `validate()`, not stored on the Ontology — they are
+    functions, not data, and they depend on caller-specific reasoning that
+    an Ontology deliberately cannot express.
+    """
+
+    id: str
+    node_kinds: dict[str, NodeKind] = field(default_factory=dict)
+    edge_kinds: dict[str, EdgeKind] = field(default_factory=dict)
+
+
+@dataclass
+class Node:
+    """A node in a typed property graph.
+
+    `kind` is the ontology-defined vocabulary. `attrs` is the property bag,
+    type-checked against the ontology. `roles` is a subset of the fixed `Role`
+    enum. `runtime` and `meta` are opaque to the meta-model — the core never
+    reads them, so callers can stash whatever they like there. `meta` and
+    `runtime` are also excluded from `content_hash()`.
+    """
+
+    id: str
+    kind: str
+    attrs: dict[str, Any] = field(default_factory=dict)
+    roles: set[Role] = field(default_factory=set)
+    visibility: Visibility = Visibility.PUBLIC
+    runtime: dict[str, Any] = field(default_factory=dict)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Edge:
+    """A directed typed edge from `src` to `dst`.
+
+    Both `src` and `dst` must reference nodes in the same graph. `attrs` is the
+    property bag, type-checked against the ontology's `EdgeKind.attrs`.
+    """
+
+    id: str
+    kind: str
+    src: str
+    dst: str
+    attrs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Issue:
+    """One validation finding.
+
+    `severity` is `"error"` or `"warning"`. `code` is a stable machine-readable
+    tag so callers can group / suppress findings without parsing `message`.
+    `where` is the offending id (node id, edge id) or pseudo-path.
+    """
+
+    severity: str
+    code: str
+    message: str
+    where: str
+
+
+@dataclass
+class WorldGraph:
+    """A typed property graph: nodes, edges, an ontology id, opaque meta.
+
+    `ontology` is the id string of the schema the graph is supposed to conform
+    to. The graph does not carry the schema itself — `validate()` takes the
+    ontology as a separate argument so the same graph can be checked against
+    multiple revisions of its schema.
+
+    `meta` is excluded from `content_hash()`: two graphs that differ only in
+    provenance / manifest noise share the same content-addressed identity.
+    """
+
+    ontology: str
+    nodes: dict[str, Node] = field(default_factory=dict)
+    edges: dict[str, Edge] = field(default_factory=dict)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def add_node(self, node: Node) -> None:
+        """Insert a node. Raises `KeyError` on id collision."""
+        if node.id in self.nodes:
+            raise KeyError(f"duplicate node id: {node.id!r}")
+        self.nodes[node.id] = node
+
+    def add_edge(self, edge: Edge) -> None:
+        """Insert an edge. Raises `KeyError` on id collision."""
+        if edge.id in self.edges:
+            raise KeyError(f"duplicate edge id: {edge.id!r}")
+        self.edges[edge.id] = edge
+
+    def in_edges(self, node_id: str, kind: str | None = None) -> list[Edge]:
+        """All edges whose `dst` is `node_id`, optionally filtered by kind."""
+        return [
+            e
+            for e in self.edges.values()
+            if e.dst == node_id and (kind is None or e.kind == kind)
+        ]
+
+    def out_edges(self, node_id: str, kind: str | None = None) -> list[Edge]:
+        """All edges whose `src` is `node_id`, optionally filtered by kind."""
+        return [
+            e
+            for e in self.edges.values()
+            if e.src == node_id and (kind is None or e.kind == kind)
+        ]
+
+    def by_kind(self, kind: str) -> list[Node]:
+        """All nodes of a given kind. Order is insertion order."""
+        return [n for n in self.nodes.values() if n.kind == kind]
+
+    def content_hash(self) -> str:
+        """`sha256:<hex>` over `ontology + nodes + edges` only.
+
+        Excludes `meta`, plus each node's `runtime` and `meta`, so two graphs
+        with the same logical content share one identity regardless of which
+        producer made them. The serialization is deterministic: keys sorted,
+        no whitespace, empty optional fields omitted.
+        """
+        nodes_data = [
+            _node_data(n) for n in sorted(self.nodes.values(), key=lambda n: n.id)
+        ]
+        edges_data = [
+            _edge_data(e) for e in sorted(self.edges.values(), key=lambda e: e.id)
+        ]
+        data = {
+            "ontology": self.ontology,
+            "nodes": nodes_data,
+            "edges": edges_data,
+        }
+        encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode()
+        return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _node_data(node: Node) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "id": node.id,
+        "kind": node.kind,
+        "attrs": dict(sorted(node.attrs.items())),
+    }
+    if node.roles:
+        out["roles"] = sorted(r.value for r in node.roles)
+    if node.visibility is not Visibility.PUBLIC:
+        out["visibility"] = node.visibility.value
+    return out
+
+
+def _edge_data(edge: Edge) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "id": edge.id,
+        "kind": edge.kind,
+        "src": edge.src,
+        "dst": edge.dst,
+    }
+    if edge.attrs:
+        out["attrs"] = dict(sorted(edge.attrs.items()))
+    return out
+
+
+@dataclass
+class GraphPatch:
+    """A diff applied to a `WorldGraph` via `apply_patch`.
+
+    Updates fully replace the existing node/edge (no per-attr merge) — the
+    caller decides what the new shape is, and the patch carries the full
+    replacement. Removals are ids only.
+    """
+
+    nodes_added: list[Node] = field(default_factory=list)
+    nodes_updated: list[Node] = field(default_factory=list)
+    nodes_removed: list[str] = field(default_factory=list)
+    edges_added: list[Edge] = field(default_factory=list)
+    edges_updated: list[Edge] = field(default_factory=list)
+    edges_removed: list[str] = field(default_factory=list)
+
+
+def apply_patch(graph: WorldGraph, patch: GraphPatch) -> WorldGraph:
+    """Apply a `GraphPatch` to `graph` IN PLACE and return it.
+
+    Mutates in place because a `WorldGraph` is already mutable and copying
+    would be wasted work for the common builder-repair / accreting-memory
+    update use case. The return value is the same object — returned only so
+    callers can chain. Order: removals, then updates, then additions, so an
+    update that happens to share an id with a removal in the same patch keeps
+    the new value and an addition cannot collide with something the patch
+    itself just removed.
+    """
+    for nid in patch.nodes_removed:
+        graph.nodes.pop(nid, None)
+        # an edge dangling on a removed node would silently violate the
+        # structural rule, so drop them here. The patch can still add edges
+        # back in the additions pass.
+        for eid in [e.id for e in graph.edges.values() if e.src == nid or e.dst == nid]:
+            graph.edges.pop(eid, None)
+    for eid in patch.edges_removed:
+        graph.edges.pop(eid, None)
+    for node in patch.nodes_updated:
+        graph.nodes[node.id] = node
+    for edge in patch.edges_updated:
+        graph.edges[edge.id] = edge
+    for node in patch.nodes_added:
+        if node.id in graph.nodes:
+            raise KeyError(f"patch adds duplicate node id: {node.id!r}")
+        graph.nodes[node.id] = node
+    for edge in patch.edges_added:
+        if edge.id in graph.edges:
+            raise KeyError(f"patch adds duplicate edge id: {edge.id!r}")
+        graph.edges[edge.id] = edge
+    return graph
+
+
+def validate(
+    graph: WorldGraph,
+    ontology: Ontology,
+    invariants: list[Callable[[WorldGraph], list[Issue]]] | None = None,
+) -> list[Issue]:
+    """Three-tier validation: structural, ontology conformance, caller invariants.
+
+    Tier 1 (structural) checks the shape of the graph regardless of any
+    schema: required fields are present and stringly typed, ids are unique,
+    and edge endpoints point at nodes that actually exist.
+
+    Tier 2 (conformance) checks the graph against `ontology`: every node /
+    edge kind is declared, every required attr is present, attr value types
+    match their `AttrSpec`, enum values are in range, REF attrs resolve to a
+    real node of an allowed kind, edge endpoints match a declared
+    `(src_kind, dst_kind)` pair, and degree caps are respected. Parent NodeKind
+    chains contribute required attrs.
+
+    Tier 3 (invariants) runs each caller-supplied callable on the graph and
+    concatenates its findings. Callers use these for the domain-specific
+    invariants the generic schema cannot express (cross-cutting structural
+    rules unique to a particular world-family).
+    """
+    issues: list[Issue] = []
+    issues.extend(_validate_structural(graph))
+    issues.extend(_validate_conformance(graph, ontology))
+    for inv in invariants or []:
+        issues.extend(inv(graph))
+    return issues
+
+
+def _validate_structural(graph: WorldGraph) -> list[Issue]:
+    issues: list[Issue] = []
+    for nid, node in graph.nodes.items():
+        # dict-key vs node.id desync would only happen if a caller mutated
+        # `graph.nodes` directly with a wrong key; catch it here so callers
+        # don't get cryptic conformance errors later.
+        if nid != node.id:
+            issues.append(
+                Issue(
+                    "error",
+                    "node_id_mismatch",
+                    f"node stored under key {nid!r} reports id {node.id!r}",
+                    nid,
+                )
+            )
+        if not isinstance(node.id, str) or not node.id:
+            issues.append(
+                Issue(
+                    "error",
+                    "node_missing_id",
+                    "node is missing a non-empty string id",
+                    nid,
+                )
+            )
+        if not isinstance(node.kind, str) or not node.kind:
+            issues.append(
+                Issue(
+                    "error",
+                    "node_missing_kind",
+                    f"node {node.id!r} is missing a non-empty string kind",
+                    node.id,
+                )
+            )
+    for eid, edge in graph.edges.items():
+        if eid != edge.id:
+            issues.append(
+                Issue(
+                    "error",
+                    "edge_id_mismatch",
+                    f"edge stored under key {eid!r} reports id {edge.id!r}",
+                    eid,
+                )
+            )
+        if not isinstance(edge.id, str) or not edge.id:
+            issues.append(
+                Issue(
+                    "error",
+                    "edge_missing_id",
+                    "edge is missing a non-empty string id",
+                    eid,
+                )
+            )
+        if not isinstance(edge.kind, str) or not edge.kind:
+            issues.append(
+                Issue(
+                    "error",
+                    "edge_missing_kind",
+                    f"edge {edge.id!r} is missing a non-empty string kind",
+                    edge.id,
+                )
+            )
+        if edge.src not in graph.nodes:
+            issues.append(
+                Issue(
+                    "error",
+                    "edge_dangling_src",
+                    f"edge {edge.id!r} src {edge.src!r} is not a node in the graph",
+                    edge.id,
+                )
+            )
+        if edge.dst not in graph.nodes:
+            issues.append(
+                Issue(
+                    "error",
+                    "edge_dangling_dst",
+                    f"edge {edge.id!r} dst {edge.dst!r} is not a node in the graph",
+                    edge.id,
+                )
+            )
+    return issues
+
+
+def _validate_conformance(graph: WorldGraph, ontology: Ontology) -> list[Issue]:
+    issues: list[Issue] = []
+    for node in graph.nodes.values():
+        node_kind = ontology.node_kinds.get(node.kind)
+        if node_kind is None:
+            issues.append(
+                Issue(
+                    "error",
+                    "unknown_node_kind",
+                    f"node {node.id!r} has kind {node.kind!r} not declared in "
+                    f"ontology {ontology.id!r}",
+                    node.id,
+                )
+            )
+            continue
+        attrs = _compose_node_attrs(node_kind, ontology)
+        issues.extend(_check_attrs(node.id, node.attrs, attrs, graph, ontology))
+
+    # degree caps are aggregate, so collect once per (node, kind, side).
+    out_counts: dict[tuple[str, str], int] = {}
+    in_counts: dict[tuple[str, str], int] = {}
+    for edge in graph.edges.values():
+        edge_kind = ontology.edge_kinds.get(edge.kind)
+        if edge_kind is None:
+            issues.append(
+                Issue(
+                    "error",
+                    "unknown_edge_kind",
+                    f"edge {edge.id!r} has kind {edge.kind!r} not declared in "
+                    f"ontology {ontology.id!r}",
+                    edge.id,
+                )
+            )
+            continue
+        issues.extend(
+            _check_attrs(edge.id, edge.attrs, edge_kind.attrs, graph, ontology)
+        )
+        src_node = graph.nodes.get(edge.src)
+        dst_node = graph.nodes.get(edge.dst)
+        # dangling endpoints were already flagged structurally; skip the
+        # edge-kind pair check rather than emit a redundant cascade.
+        if src_node is None or dst_node is None:
+            continue
+        pair = (src_node.kind, dst_node.kind)
+        if edge_kind.endpoints and pair not in [tuple(p) for p in edge_kind.endpoints]:
+            allowed = ", ".join(f"({s}, {d})" for s, d in edge_kind.endpoints)
+            issues.append(
+                Issue(
+                    "error",
+                    "edge_endpoint_mismatch",
+                    f"edge {edge.id!r} of kind {edge.kind!r} has endpoints "
+                    f"({src_node.kind}, {dst_node.kind}); allowed: {allowed}",
+                    edge.id,
+                )
+            )
+        out_counts[(edge.src, edge.kind)] = out_counts.get((edge.src, edge.kind), 0) + 1
+        in_counts[(edge.dst, edge.kind)] = in_counts.get((edge.dst, edge.kind), 0) + 1
+
+    for (src_id, edge_kind_id), count in out_counts.items():
+        edge_kind = ontology.edge_kinds[edge_kind_id]
+        if edge_kind.src_max is not None and count > edge_kind.src_max:
+            issues.append(
+                Issue(
+                    "error",
+                    "edge_src_degree_exceeded",
+                    f"node {src_id!r} has {count} out-edges of kind {edge_kind_id!r}; "
+                    f"src_max={edge_kind.src_max}",
+                    src_id,
+                )
+            )
+    for (dst_id, edge_kind_id), count in in_counts.items():
+        edge_kind = ontology.edge_kinds[edge_kind_id]
+        if edge_kind.dst_max is not None and count > edge_kind.dst_max:
+            issues.append(
+                Issue(
+                    "error",
+                    "edge_dst_degree_exceeded",
+                    f"node {dst_id!r} has {count} in-edges of kind {edge_kind_id!r}; "
+                    f"dst_max={edge_kind.dst_max}",
+                    dst_id,
+                )
+            )
+    return issues
+
+
+def _compose_node_attrs(kind: NodeKind, ontology: Ontology) -> dict[str, AttrSpec]:
+    """Walk the parent chain and merge attrs; child overrides parent by key."""
+    chain: list[NodeKind] = []
+    seen: set[str] = set()
+    current: NodeKind | None = kind
+    while current is not None:
+        if current.id in seen:
+            # malformed ontology — break the cycle silently. Cycle detection
+            # belongs to a separate ontology-validator pass; here we just
+            # avoid spinning.
+            break
+        seen.add(current.id)
+        chain.append(current)
+        current = ontology.node_kinds.get(current.parent) if current.parent else None
+    composed: dict[str, AttrSpec] = {}
+    for k in reversed(chain):
+        composed.update(k.attrs)
+    return composed
+
+
+def _check_attrs(
+    where: str,
+    values: dict[str, Any],
+    specs: dict[str, AttrSpec],
+    graph: WorldGraph,
+    ontology: Ontology,
+) -> list[Issue]:
+    issues: list[Issue] = []
+    for name, spec in specs.items():
+        if name not in values:
+            if spec.required:
+                issues.append(
+                    Issue(
+                        "error",
+                        "missing_required_attr",
+                        f"{where!r} is missing required attr {name!r}",
+                        where,
+                    )
+                )
+            continue
+        issues.extend(
+            _check_attr_value(where, name, values[name], spec, graph, ontology)
+        )
+    return issues
+
+
+_PRIMITIVE_CHECK: dict[AttrType, Callable[[Any], bool]] = {
+    AttrType.STRING: lambda v: isinstance(v, str),
+    AttrType.INT: lambda v: isinstance(v, int) and not isinstance(v, bool),
+    AttrType.FLOAT: lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+    AttrType.BOOL: lambda v: isinstance(v, bool),
+    AttrType.JSON: lambda v: True,
+}
+
+
+def _check_attr_value(
+    where: str,
+    name: str,
+    value: Any,
+    spec: AttrSpec,
+    graph: WorldGraph,
+    ontology: Ontology,
+) -> list[Issue]:
+    if spec.type is AttrType.ENUM:
+        if not spec.enum or value not in spec.enum:
+            allowed = ", ".join(repr(v) for v in (spec.enum or []))
+            return [
+                Issue(
+                    "error",
+                    "enum_value_invalid",
+                    f"{where!r} attr {name!r} value {value!r} not in enum: [{allowed}]",
+                    where,
+                )
+            ]
+        return []
+    if spec.type is AttrType.REF:
+        if not isinstance(value, str):
+            return [
+                Issue(
+                    "error",
+                    "ref_not_string",
+                    f"{where!r} attr {name!r} REF value {value!r} is not a string id",
+                    where,
+                )
+            ]
+        target = graph.nodes.get(value)
+        if target is None:
+            return [
+                Issue(
+                    "error",
+                    "ref_dangling",
+                    f"{where!r} attr {name!r} REF {value!r} does not resolve to a node",
+                    where,
+                )
+            ]
+        if spec.ref_kinds and target.kind not in spec.ref_kinds:
+            allowed = ", ".join(repr(k) for k in spec.ref_kinds)
+            return [
+                Issue(
+                    "error",
+                    "ref_kind_disallowed",
+                    f"{where!r} attr {name!r} REF {value!r} points at a "
+                    f"{target.kind!r}; allowed ref_kinds: [{allowed}]",
+                    where,
+                )
+            ]
+        return []
+    check = _PRIMITIVE_CHECK[spec.type]
+    if not check(value):
+        return [
+            Issue(
+                "error",
+                "attr_type_mismatch",
+                f"{where!r} attr {name!r} expected {spec.type.value}, got "
+                f"{type(value).__name__} ({value!r})",
+                where,
+            )
+        ]
+    return []

--- a/packages/graphschema/tests/test_ir.py
+++ b/packages/graphschema/tests/test_ir.py
@@ -1,0 +1,468 @@
+"""Tests for the typed-property-graph meta-model.
+
+Covers:
+- WorldGraph mutation (add_node, add_edge, in/out_edges, by_kind).
+- content_hash determinism: same content -> same hash; meta/runtime excluded.
+- AttrSpec / NodeKind / EdgeKind / Ontology declaration shape.
+- Three-tier validate(): structural, conformance, caller invariants.
+- GraphPatch + apply_patch ordering and cascading edge removal.
+- Role and Visibility serialization in content_hash payloads.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from graphschema import (
+    AttrSpec,
+    AttrType,
+    Edge,
+    EdgeKind,
+    GraphPatch,
+    Issue,
+    Node,
+    NodeKind,
+    Ontology,
+    Role,
+    Visibility,
+    WorldGraph,
+    apply_patch,
+    validate,
+)
+
+
+def test_add_node_inserts_into_dict() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing"))
+    assert "a" in g.nodes
+    assert g.nodes["a"].kind == "thing"
+
+
+def test_add_node_rejects_duplicate_id() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing"))
+    with pytest.raises(KeyError, match="duplicate node id"):
+        g.add_node(Node("a", "thing"))
+
+
+def test_add_edge_inserts_into_dict() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing"))
+    g.add_node(Node("b", "thing"))
+    g.add_edge(Edge("e1", "rel", "a", "b"))
+    assert "e1" in g.edges
+
+
+def test_add_edge_rejects_duplicate_id() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing"))
+    g.add_node(Node("b", "thing"))
+    g.add_edge(Edge("e1", "rel", "a", "b"))
+    with pytest.raises(KeyError):
+        g.add_edge(Edge("e1", "rel", "a", "b"))
+
+
+def test_in_and_out_edges_filter_by_kind() -> None:
+    g = WorldGraph(ontology="x@1")
+    for nid in ("a", "b", "c"):
+        g.add_node(Node(nid, "thing"))
+    g.add_edge(Edge("e1", "traversed", "a", "b"))
+    g.add_edge(Edge("e2", "part_of", "a", "c"))
+    g.add_edge(Edge("e3", "traversed", "b", "a"))
+    assert {e.id for e in g.out_edges("a")} == {"e1", "e2"}
+    assert {e.id for e in g.out_edges("a", "traversed")} == {"e1"}
+    assert {e.id for e in g.in_edges("a")} == {"e3"}
+    assert {e.id for e in g.in_edges("a", "part_of")} == set()
+
+
+def test_by_kind_returns_insertion_order() -> None:
+    g = WorldGraph(ontology="x@1")
+    for nid in ("c", "a", "b"):
+        g.add_node(Node(nid, "thing"))
+    g.add_node(Node("z", "thought"))
+    things = g.by_kind("thing")
+    assert [n.id for n in things] == ["c", "a", "b"]
+    assert [n.id for n in g.by_kind("thought")] == ["z"]
+
+
+def _two_node_graph() -> WorldGraph:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A"}))
+    g.add_node(Node("b", "thing", attrs={"label": "B"}))
+    g.add_edge(Edge("e1", "rel", "a", "b", attrs={"weight": 1}))
+    return g
+
+
+def test_content_hash_is_sha256_prefixed() -> None:
+    h = _two_node_graph().content_hash()
+    assert h.startswith("sha256:")
+    assert len(h) == len("sha256:") + 64
+
+
+def test_content_hash_deterministic_for_identical_graphs() -> None:
+    assert _two_node_graph().content_hash() == _two_node_graph().content_hash()
+
+
+def test_content_hash_changes_with_ontology_id() -> None:
+    g1 = _two_node_graph()
+    g2 = _two_node_graph()
+    g2.ontology = "y@1"
+    assert g1.content_hash() != g2.content_hash()
+
+
+def test_content_hash_changes_with_attrs() -> None:
+    g1 = _two_node_graph()
+    g2 = _two_node_graph()
+    g2.nodes["a"].attrs["label"] = "DIFFERENT"
+    assert g1.content_hash() != g2.content_hash()
+
+
+def test_content_hash_excludes_meta() -> None:
+    g1 = _two_node_graph()
+    g2 = _two_node_graph()
+    g2.meta = {"manifest": "different", "producer_version": "2.0"}
+    assert g1.content_hash() == g2.content_hash()
+
+
+def test_content_hash_excludes_node_meta_and_runtime() -> None:
+    g1 = _two_node_graph()
+    g2 = _two_node_graph()
+    g2.nodes["a"].meta = {"provenance_blob": "noise"}
+    g2.nodes["a"].runtime = {"port": 8080}
+    assert g1.content_hash() == g2.content_hash()
+
+
+def test_content_hash_changes_with_visibility() -> None:
+    g1 = _two_node_graph()
+    g2 = _two_node_graph()
+    g2.nodes["a"].visibility = Visibility.HIDDEN
+    assert g1.content_hash() != g2.content_hash()
+
+
+def test_content_hash_changes_with_roles() -> None:
+    g1 = _two_node_graph()
+    g2 = _two_node_graph()
+    g2.nodes["a"].roles = {Role.ACTOR}
+    assert g1.content_hash() != g2.content_hash()
+
+
+def test_content_hash_independent_of_insertion_order() -> None:
+    g1 = WorldGraph(ontology="x@1")
+    g1.add_node(Node("a", "thing"))
+    g1.add_node(Node("b", "thing"))
+    g2 = WorldGraph(ontology="x@1")
+    g2.add_node(Node("b", "thing"))
+    g2.add_node(Node("a", "thing"))
+    assert g1.content_hash() == g2.content_hash()
+
+
+def test_node_payload_omits_public_visibility_and_empty_roles() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A"}))
+    h = g.content_hash()
+    # If visibility=PUBLIC were emitted on the wire, this hash would differ
+    # from one where we explicitly set visibility=PUBLIC again (no-op).
+    g.nodes["a"].visibility = Visibility.PUBLIC
+    g.nodes["a"].roles = set()
+    assert g.content_hash() == h
+
+
+def _simple_ontology() -> Ontology:
+    """A minimal ontology used across the validation tests below."""
+    return Ontology(
+        id="x@1",
+        node_kinds={
+            "thing": NodeKind(
+                "thing",
+                attrs={
+                    "label": AttrSpec(AttrType.STRING, required=True),
+                    "weight": AttrSpec(AttrType.FLOAT),
+                    "tier": AttrSpec(AttrType.ENUM, enum=["a", "b", "c"]),
+                    "ref_to": AttrSpec(AttrType.REF, ref_kinds=["thing"]),
+                },
+            ),
+            "thought": NodeKind(
+                "thought",
+                attrs={
+                    "claim": AttrSpec(AttrType.STRING, required=True),
+                },
+            ),
+        },
+        edge_kinds={
+            "rel": EdgeKind(
+                "rel",
+                endpoints=[("thing", "thing")],
+                attrs={
+                    "weight": AttrSpec(AttrType.INT, default=1),
+                },
+            ),
+            "about": EdgeKind("about", endpoints=[("thought", "thing")]),
+        },
+    )
+
+
+def test_structural_dangling_edge_src() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A"}))
+    g.edges["e1"] = Edge("e1", "rel", "MISSING", "a")
+    issues = validate(g, _simple_ontology())
+    codes = {i.code for i in issues}
+    assert "edge_dangling_src" in codes
+
+
+def test_structural_dangling_edge_dst() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A"}))
+    g.edges["e1"] = Edge("e1", "rel", "a", "MISSING")
+    issues = validate(g, _simple_ontology())
+    assert "edge_dangling_dst" in {i.code for i in issues}
+
+
+def test_structural_dict_key_id_mismatch() -> None:
+    g = WorldGraph(ontology="x@1")
+    # Direct dict access — bypasses add_node guard.
+    g.nodes["wrong_key"] = Node("a", "thing", attrs={"label": "A"})
+    issues = validate(g, _simple_ontology())
+    assert "node_id_mismatch" in {i.code for i in issues}
+
+
+def test_structural_missing_node_kind() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.nodes["a"] = Node("a", "", attrs={"label": "A"})  # empty kind
+    issues = validate(g, _simple_ontology())
+    assert "node_missing_kind" in {i.code for i in issues}
+
+
+def test_conformance_unknown_node_kind() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "mysterious", attrs={"label": "A"}))
+    issues = validate(g, _simple_ontology())
+    codes = {i.code for i in issues}
+    assert "unknown_node_kind" in codes
+
+
+def test_conformance_missing_required_attr() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={}))  # missing required `label`
+    issues = validate(g, _simple_ontology())
+    assert "missing_required_attr" in {i.code for i in issues}
+
+
+def test_conformance_attr_type_mismatch() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A", "weight": "not-a-float"}))
+    issues = validate(g, _simple_ontology())
+    assert "attr_type_mismatch" in {i.code for i in issues}
+
+
+def test_conformance_bool_not_int() -> None:
+    """bool is a subclass of int but should NOT pass as INT in our validator."""
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A"}))
+    g.add_node(Node("b", "thing", attrs={"label": "B"}))
+    g.add_edge(Edge("e1", "rel", "a", "b", attrs={"weight": True}))
+    issues = validate(g, _simple_ontology())
+    assert "attr_type_mismatch" in {i.code for i in issues}
+
+
+def test_conformance_int_accepted_for_float() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A", "weight": 5}))
+    issues = validate(g, _simple_ontology())
+    errors = [i for i in issues if i.severity == "error"]
+    assert errors == []
+
+
+def test_conformance_enum_value_invalid() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A", "tier": "z"}))
+    issues = validate(g, _simple_ontology())
+    assert "enum_value_invalid" in {i.code for i in issues}
+
+
+def test_conformance_ref_dangling() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A", "ref_to": "MISSING"}))
+    issues = validate(g, _simple_ontology())
+    assert "ref_dangling" in {i.code for i in issues}
+
+
+def test_conformance_ref_kind_disallowed() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A", "ref_to": "b"}))
+    g.add_node(Node("b", "thought", attrs={"claim": "..."}))
+    issues = validate(g, _simple_ontology())
+    assert "ref_kind_disallowed" in {i.code for i in issues}
+
+
+def test_conformance_edge_endpoint_mismatch() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A"}))
+    g.add_node(Node("b", "thought", attrs={"claim": "..."}))
+    g.add_edge(Edge("e1", "rel", "a", "b"))  # rel expects (thing, thing)
+    issues = validate(g, _simple_ontology())
+    assert "edge_endpoint_mismatch" in {i.code for i in issues}
+
+
+def test_conformance_unknown_edge_kind() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A"}))
+    g.add_node(Node("b", "thing", attrs={"label": "B"}))
+    g.add_edge(Edge("e1", "unknown_relation", "a", "b"))
+    issues = validate(g, _simple_ontology())
+    assert "unknown_edge_kind" in {i.code for i in issues}
+
+
+def test_conformance_degree_caps() -> None:
+    onto = Ontology(
+        id="x@1",
+        node_kinds={
+            "thing": NodeKind(
+                "thing",
+                attrs={
+                    "label": AttrSpec(AttrType.STRING, required=True),
+                },
+            ),
+        },
+        edge_kinds={
+            "rel": EdgeKind("rel", endpoints=[("thing", "thing")], src_max=1),
+        },
+    )
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A"}))
+    g.add_node(Node("b", "thing", attrs={"label": "B"}))
+    g.add_node(Node("c", "thing", attrs={"label": "C"}))
+    g.add_edge(Edge("e1", "rel", "a", "b"))
+    g.add_edge(Edge("e2", "rel", "a", "c"))  # exceeds src_max=1
+    issues = validate(g, onto)
+    assert "edge_src_degree_exceeded" in {i.code for i in issues}
+
+
+def test_conformance_parent_attrs_inherited() -> None:
+    onto = Ontology(
+        id="x@1",
+        node_kinds={
+            "component": NodeKind(
+                "component",
+                attrs={
+                    "name": AttrSpec(AttrType.STRING, required=True),
+                },
+            ),
+            "service": NodeKind(
+                "service",
+                parent="component",
+                attrs={
+                    "port": AttrSpec(AttrType.INT),
+                },
+            ),
+        },
+        edge_kinds={},
+    )
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "service", attrs={"port": 8080}))
+    issues = validate(g, onto)
+    assert "missing_required_attr" in {i.code for i in issues}
+
+
+def test_invariants_are_invoked_and_concatenated() -> None:
+    def at_least_one_thought(g: WorldGraph) -> list[Issue]:
+        if not g.by_kind("thought"):
+            return [Issue("error", "no_thought", "graph must have a thought", "graph")]
+        return []
+
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "A"}))
+    issues = validate(g, _simple_ontology(), invariants=[at_least_one_thought])
+    assert "no_thought" in {i.code for i in issues}
+
+
+def test_apply_patch_adds_nodes_and_edges() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing"))
+    patch = GraphPatch(
+        nodes_added=[Node("b", "thing")],
+        edges_added=[Edge("e1", "rel", "a", "b")],
+    )
+    apply_patch(g, patch)
+    assert "b" in g.nodes
+    assert "e1" in g.edges
+
+
+def test_apply_patch_updates_replace_entirely() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(
+        Node("a", "thing", attrs={"label": "OLD", "other": "kept-by-caller-or-not"})
+    )
+    patch = GraphPatch(nodes_updated=[Node("a", "thing", attrs={"label": "NEW"})])
+    apply_patch(g, patch)
+    # update REPLACES; if a caller wanted to keep `other` they'd include it.
+    assert g.nodes["a"].attrs == {"label": "NEW"}
+
+
+def test_apply_patch_removes_node_and_cascades_edges() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing"))
+    g.add_node(Node("b", "thing"))
+    g.add_node(Node("c", "thing"))
+    g.add_edge(Edge("e1", "rel", "a", "b"))
+    g.add_edge(Edge("e2", "rel", "b", "c"))
+    g.add_edge(Edge("e3", "rel", "a", "c"))
+    apply_patch(g, GraphPatch(nodes_removed=["b"]))
+    assert "b" not in g.nodes
+    assert "e1" not in g.edges
+    assert "e2" not in g.edges
+    assert "e3" in g.edges
+
+
+def test_apply_patch_order_removals_before_additions() -> None:
+    """An addition with the same id as a removal in the same patch should land."""
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing", attrs={"label": "OLD"}))
+    patch = GraphPatch(
+        nodes_removed=["a"],
+        nodes_added=[Node("a", "thing", attrs={"label": "REINTRODUCED"})],
+    )
+    apply_patch(g, patch)
+    assert g.nodes["a"].attrs["label"] == "REINTRODUCED"
+
+
+def test_apply_patch_duplicate_add_raises() -> None:
+    g = WorldGraph(ontology="x@1")
+    g.add_node(Node("a", "thing"))
+    with pytest.raises(KeyError, match="patch adds duplicate node id"):
+        apply_patch(g, GraphPatch(nodes_added=[Node("a", "thing")]))
+
+
+def test_hash_payload_is_canonical_json() -> None:
+    """The hash payload sorts keys and omits empty optional fields — that
+    means a json.loads of the hashed bytes is a stable, comparable shape."""
+    g = WorldGraph(ontology="x@1")
+    g.add_node(
+        Node(
+            "a",
+            "thing",
+            attrs={"z": 1, "a": 2},
+            roles={Role.ACTOR},
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    g.add_node(Node("b", "thing", attrs={"label": "B"}))
+    g.add_edge(Edge("e1", "rel", "a", "b", attrs={"k": "v"}))
+    from graphschema._ir import _edge_data, _node_data
+
+    data = {
+        "ontology": g.ontology,
+        "nodes": [_node_data(n) for n in sorted(g.nodes.values(), key=lambda n: n.id)],
+        "edges": [_edge_data(e) for e in sorted(g.edges.values(), key=lambda e: e.id)],
+    }
+    encoded = json.dumps(data, sort_keys=True, separators=(",", ":"))
+    decoded = json.loads(encoded)
+    assert decoded["ontology"] == "x@1"
+    assert decoded["nodes"][0]["id"] == "a"
+    assert decoded["nodes"][0]["roles"] == ["actor"]
+    assert decoded["nodes"][0]["visibility"] == "hidden"
+    # public visibility AND empty roles are NOT serialized
+    assert "visibility" not in decoded["nodes"][1]
+    assert "roles" not in decoded["nodes"][1]

--- a/packages/openrange-pack-sdk/pyproject.toml
+++ b/packages/openrange-pack-sdk/pyproject.toml
@@ -17,4 +17,4 @@ dependencies = [
 packages = ["src/openrange_pack_sdk"]
 
 [tool.uv.sources]
-graphschema = { git = "https://github.com/vecna-labs/graphschema.git", rev = "main" }
+graphschema = { workspace = true }

--- a/packs/cyber_webapp/pyproject.toml
+++ b/packs/cyber_webapp/pyproject.toml
@@ -30,5 +30,5 @@ dependencies = [
 packages = ["cyber_webapp"]
 
 [tool.uv.sources]
+graphschema = { workspace = true }
 openrange-pack-sdk = { workspace = true }
-graphschema = { git = "https://github.com/vecna-labs/graphschema.git", rev = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,12 @@ dev = [
 ]
 
 [tool.uv.workspace]
-members = ["packs/cyber_webapp", "packages/openrange-pack-sdk"]
+members = ["packs/cyber_webapp", "packages/graphschema", "packages/openrange-pack-sdk"]
 
 [tool.uv.sources]
+graphschema = { workspace = true }
 openrange-cyber-webapp = { workspace = true }
 openrange-pack-sdk = { workspace = true }
-graphschema = { git = "https://github.com/vecna-labs/graphschema.git", rev = "main" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/openrange"]
@@ -58,7 +58,12 @@ select = ["E", "F", "I", "B", "UP", "SIM"]
 
 [tool.mypy]
 python_version = "3.14"
-mypy_path = ["src", "packs/cyber_webapp", "packages/openrange-pack-sdk/src"]
+mypy_path = [
+    "src",
+    "packs/cyber_webapp",
+    "packages/graphschema/src",
+    "packages/openrange-pack-sdk/src",
+]
 strict = true
 warn_unreachable = true
 
@@ -74,7 +79,11 @@ module = ["strands", "strands.*", "strands_tools", "strands_tools.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-testpaths = ["tests", "packages/openrange-pack-sdk/tests"]
+testpaths = [
+    "tests",
+    "packages/graphschema/tests",
+    "packages/openrange-pack-sdk/tests",
+]
 
 [tool.coverage.run]
 branch = true

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -1,11 +1,17 @@
-"""Repo-wide import-boundary invariants:
+"""Repo-wide import-boundary invariants. Dependency stack, bottom-up:
+
+    graphschema ← openrange_pack_sdk ← {openrange, packs/*}
+
+Each layer may depend only on layers below it.
 
 1. ``packs/`` MUST NOT import from ``openrange``.
 2. ``src/openrange/`` MUST NOT import from any pack.
 3. ``packages/openrange-pack-sdk/`` MUST NOT import from any pack.
 4. ``packages/openrange-pack-sdk/`` MUST NOT import from ``openrange``
-   (the SDK is contract-only, zero runtime deps beyond ``graphschema``).
-5. ``openrange.__init__`` MUST NOT re-export ``openrange_pack_sdk`` symbols
+   (the SDK is contract-only).
+5. ``packages/graphschema/`` MUST NOT import from any pack, the SDK, or
+   ``openrange`` (graphschema sits at the bottom of the stack).
+6. ``openrange.__init__`` MUST NOT re-export ``openrange_pack_sdk`` symbols
    (no migration shim — callers import from the SDK directly).
 """
 
@@ -53,6 +59,7 @@ def test_import_boundaries() -> None:
     assert pack_modules, "expected at least one pack module under packs/"
 
     sdk_src = REPO_ROOT / "packages" / "openrange-pack-sdk" / "src"
+    graphschema_src = REPO_ROOT / "packages" / "graphschema" / "src"
     openrange_src = REPO_ROOT / "src" / "openrange"
     openrange_init = openrange_src / "__init__.py"
 
@@ -77,6 +84,22 @@ def test_import_boundaries() -> None:
                 violations.append(f"sdk→pack  {file.relative_to(REPO_ROOT)} → {leak}")
         for leak in sorted(_imports_under(imports, "openrange")):
             violations.append(f"sdk→openrange  {file.relative_to(REPO_ROOT)} → {leak}")
+
+    for file in _py_files(graphschema_src):
+        imports = _imports_in(file)
+        for pack in pack_modules:
+            for leak in sorted(_imports_under(imports, pack)):
+                violations.append(
+                    f"graphschema→pack  {file.relative_to(REPO_ROOT)} → {leak}"
+                )
+        for leak in sorted(_imports_under(imports, "openrange")):
+            violations.append(
+                f"graphschema→openrange  {file.relative_to(REPO_ROOT)} → {leak}"
+            )
+        for leak in sorted(_imports_under(imports, "openrange_pack_sdk")):
+            violations.append(
+                f"graphschema→sdk  {file.relative_to(REPO_ROOT)} → {leak}"
+            )
 
     init_imports = _imports_in(openrange_init)
     for leak in sorted(_imports_under(init_imports, "openrange_pack_sdk")):

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,7 @@ resolution-markers = [
 
 [manifest]
 members = [
+    "graphschema",
     "openrange",
     "openrange-cyber-webapp",
     "openrange-pack-sdk",
@@ -426,7 +427,23 @@ wheels = [
 [[package]]
 name = "graphschema"
 version = "0.1.0"
-source = { git = "https://github.com/vecna-labs/graphschema.git?rev=main#cca7368716523b9cae2eac17a589d94d0fd2a93c" }
+source = { editable = "packages/graphschema" }
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.19" },
+    { name = "pytest", specifier = ">=9.0" },
+    { name = "ruff", specifier = ">=0.15.6" },
+]
 
 [[package]]
 name = "h11"
@@ -795,7 +812,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "graphschema", git = "https://github.com/vecna-labs/graphschema.git?rev=main" },
+    { name = "graphschema", editable = "packages/graphschema" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "openrange-pack-sdk", editable = "packages/openrange-pack-sdk" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -826,7 +843,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "graphschema", git = "https://github.com/vecna-labs/graphschema.git?rev=main" },
+    { name = "graphschema", editable = "packages/graphschema" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "openrange-pack-sdk", editable = "packages/openrange-pack-sdk" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -841,7 +858,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "graphschema", git = "https://github.com/vecna-labs/graphschema.git?rev=main" }]
+requires-dist = [{ name = "graphschema", editable = "packages/graphschema" }]
 
 [[package]]
 name = "opentelemetry-api"


### PR DESCRIPTION
## Summary

- Move graphschema into the openrange workspace at `packages/graphschema/`
- Drop `graphschema = { git = "...", rev = "main" }` from all three pyprojects → `{ workspace = true }`
- Kills the floating-dep footgun (`rev = "main"` could silently change builds on any graphschema push)
- Extends `tests/test_import_boundaries.py` with the new bottom-of-stack invariant

## Why

Three pyprojects (root, openrange-pack-sdk, cyber_webapp) pinned graphschema to `rev = "main"`, so every `uv sync` could fetch a different commit. After this PR, graphschema is in-tree with a single source of truth.

Dependency stack is now:

```
graphschema ← openrange_pack_sdk ← {openrange, packs/*}
```

## What's in the diff

- `packages/graphschema/` — full source ported verbatim from `github.com/vecna-labs/graphschema @ cca7368`. `src/`, `tests/`, `pyproject.toml`, `README.md`, `CHANGELOG.md`, `LICENSE`. Skipped `.github/` (openrange has its own CI).
- Root pyproject: workspace members + sources + `mypy_path` + `pytest.testpaths`
- SDK pyproject: graphschema source → workspace
- cyber_webapp pyproject: graphschema source → workspace
- `uv.lock`: regenerated

## Boundary invariant 5 (new)

graphschema sits at the bottom — it must not import from openrange, the SDK, or any pack. Positive-controlled: injecting `from openrange_pack_sdk import Snapshot` into graphschema's package init trips the test with `graphschema→sdk` in the failure message.

## Note for downstream consumers

`github.com/vecna-labs/graphschema` is untouched by this PR. The Vecna feature branch depending on it can keep using the standalone repo; when ready, they can switch their git source to point at this repo's `packages/graphschema/` subdir.

## Test plan

- [x] mypy / ruff / boundary check clean
- [x] 509 tests pass (was 470; +39 from graphschema's own test_ir.py)
- [x] Positive control on invariant 5 (graphschema→sdk caught)
- [x] `import graphschema` resolves to the in-tree path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
