### PR TITLE
chore: add Contributor License Agreement + CLA Assistant workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,39 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-assistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: |
+          (github.event.comment.body == 'recheck' ||
+           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+          github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/vecna-labs/open-range/blob/main/CLA.md
+          branch: main
+          allowlist: dependabot[bot],renovate[bot]
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-notsigned-prcomment: >
+            Thank you for your contribution to OpenRange. Before this pull
+            request can be merged, please read the
+            [Contributor License Agreement](https://github.com/vecna-labs/open-range/blob/main/CLA.md)
+            and sign it by posting a comment containing exactly the text below.
+            You only need to do this once.
+          custom-allsigned-prcomment: All contributors have signed the CLA. Thank you!

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,110 @@
+# OpenRange Individual Contributor License Agreement
+
+Thank you for your interest in contributing to OpenRange (the "Project"),
+maintained by the OpenRange Authors ("We" or "Us").
+
+This Contributor License Agreement ("Agreement") documents the rights granted
+by contributors to Us. To make this document effective, please sign it
+following the instructions in [CONTRIBUTING.md](./CONTRIBUTING.md). This
+Agreement is for your protection as a contributor as well as the protection of
+the Project and its users; it does not change your rights to use your own
+Contributions for any other purpose.
+
+This Agreement is derived from the Apache Software Foundation Individual
+Contributor License Agreement v2.0.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner or legal entity authorized
+by the copyright owner that is entering into this Agreement with Us.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally
+submitted by You to Us for inclusion in, or documentation of, the Project. For
+the purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to Us or our representatives,
+including but not limited to communication on electronic mailing lists,
+source code control systems, and issue tracking systems that are managed by,
+or on behalf of, Us for the purpose of discussing and improving the Project,
+but excluding communication that is conspicuously marked or otherwise
+designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us
+and to recipients of software distributed by Us a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us
+and to recipients of software distributed by Us a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer the Project, where such license applies only to those
+patent claims licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s) with the
+Project to which such Contribution(s) was submitted.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Project to which You have contributed, constitutes direct
+or contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Project shall terminate
+as of the date such litigation is filed.
+
+## 4. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses. If your employer(s)
+   has rights to intellectual property that you create that includes your
+   Contributions, you represent that you have received permission to make
+   Contributions on behalf of that employer, that your employer has waived
+   such rights for your Contributions to the Project, or that your employer
+   has executed a separate Corporate Contributor License Agreement with Us.
+
+2. Each of Your Contributions is Your original creation (see Section 6 for
+   submissions on behalf of others).
+
+3. Your Contribution submissions include complete details of any third-party
+   license or other restriction (including, but not limited to, related
+   patents and trademarks) of which You are personally aware and which are
+   associated with any part of Your Contributions.
+
+## 5. Support
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 6. Submissions on Behalf of Others
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to the Project separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which You are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".
+
+## 7. Updates
+
+You agree to notify Us of any facts or circumstances of which You become aware
+that would make the representations in this Agreement inaccurate in any
+respect.
+
+---
+
+## Corporate Contributors
+
+If You are making Contributions on behalf of a corporation or other legal
+entity, please contact the maintainers to arrange a Corporate Contributor
+License Agreement. Until a Corporate CLA is in place, individual employees
+should sign this Individual CLA and confirm with their employer that they
+have authorization to do so.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,17 @@
 
 Thanks for contributing.
 
+## Contributor License Agreement
+
+Before we can merge your first pull request, you need to sign the
+[Contributor License Agreement](./CLA.md). The CLA bot will comment on your
+PR with instructions — you sign by posting a single comment, once, and the
+bot remembers you for every future PR.
+
+If you are contributing on behalf of an employer, please confirm with them
+that you have authorization to sign before doing so. For corporate-wide
+agreements, contact the maintainers.
+
 ## What To Work On
 
 We welcome contributions of all sizes. A good place to start is the issue board:


### PR DESCRIPTION
## Summary

Adds an Individual CLA and a CLA Assistant workflow.

- [`CLA.md`](./CLA.md) — Apache-ICLA-v2.0-derived. Grants the project copyright and patent rights; the project distributes under MIT.
- [`.github/workflows/cla.yml`](./.github/workflows/cla.yml) — `contributor-assistant/github-action@v2.6.1`. On each PR, the bot checks every author against `signatures/version1/cla.json`. Unsigned authors get a comment with a sign line; replying with the line records their signature in-repo.
- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — short section pointing contributors at the flow.

`dependabot[bot]` and `renovate[bot]` are allowlisted. The signatures file is created on first sign.

Follow-up if needed: a Corporate CLA (`CCLA.md` + second signatures file) for orgs that prefer one umbrella agreement over per-employee signatures.

Sister PR on open-trajectory-gym: https://github.com/vecna-labs/open-trajectory-gym/pull/1.
