### PR TITLE
test: end-to-end episode-loop smoke (admit → episode → grade → evolve)

### DIFF
--- a/tests/test_episode_loop_smoke.py
+++ b/tests/test_episode_loop_smoke.py
@@ -1,0 +1,84 @@
+"""End-to-end smoke: the real episode loop closes without an LLM.
+
+Drives the actual pipeline that the unit tests stub out —
+``admit`` → ``start_episode`` → scripted agent writes ``result.json`` →
+``stop_episode`` (runtime ``collect`` → ``check_success``) → real
+``EpisodeReport`` → ``auto_evolve`` → next snapshot. A scripted agent
+(the kind's reference handler for build; the graph's flag for pentest)
+stands in for the LLM, so the integration seams are exercised for real
+rather than mocked.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cyber_webapp import WebappPack
+from cyber_webapp.families.build.reference import api_list_reference
+from openrange_pack_sdk import Snapshot, TaskSpec
+
+from openrange.core import auto_evolve
+from openrange.core.admit import admit
+from openrange.core.episode import EpisodeService
+
+MANIFEST = {
+    "world": {"goal": "episode loop smoke"},
+    "pack": {"id": "webapp"},
+    "runtime": {"tick": {"mode": "off"}},
+    "npc": [],
+}
+
+
+def _admit() -> Snapshot:
+    snap = admit(WebappPack(), MANIFEST)
+    assert isinstance(snap, Snapshot), snap
+    return snap
+
+
+def _only_task(snap: Snapshot, family: str) -> TaskSpec:
+    tasks = [t for t in snap.tasks if t.meta.get("family") == family]
+    assert len(tasks) == 1, f"expected exactly one {family} task, got {tasks}"
+    return tasks[0]
+
+
+def test_build_episode_grades_submitted_handler(tmp_path: Path) -> None:
+    snap = _admit()
+    task = _only_task(snap, "webapp.build")
+    svc = EpisodeService(WebappPack(), tmp_path)
+    try:
+        handle = svc.start_episode(snap, task.id)
+        agent_root = svc.agent_root(handle)
+        (agent_root / "result.json").write_text(
+            json.dumps({"endpoint_impl": api_list_reference()}),
+            encoding="utf-8",
+        )
+        report = svc.stop_episode(handle)
+    finally:
+        svc.close()
+    assert report.passed, report.episode_result.reason
+
+
+def test_pentest_episode_then_evolve(tmp_path: Path) -> None:
+    snap = _admit()
+    task = _only_task(snap, "webapp.pentest")
+    flag_value = snap.graph.nodes[task.goal_nodes[0]].attrs["value_ref"]
+
+    svc = EpisodeService(WebappPack(), tmp_path)
+    try:
+        handle = svc.start_episode(snap, task.id)
+        agent_root = svc.agent_root(handle)
+        (agent_root / "result.json").write_text(
+            json.dumps({"flag": flag_value}),
+            encoding="utf-8",
+        )
+        report = svc.stop_episode(handle)
+    finally:
+        svc.close()
+    assert report.passed, report.episode_result.reason
+
+    # A real passing report (pass-rate 1.0 → harden) drives the next world.
+    evolved = auto_evolve(snap, report, pack=WebappPack())
+    assert evolved is not None
+    assert evolved.snapshot_id != snap.snapshot_id
+    assert any(event.phase == "evolve" for event in evolved.history)

--- a/tests/test_episode_loop_smoke.py
+++ b/tests/test_episode_loop_smoke.py
@@ -77,7 +77,7 @@ def test_pentest_episode_then_evolve(tmp_path: Path) -> None:
         svc.close()
     assert report.passed, report.episode_result.reason
 
-    # A real passing report (pass-rate 1.0 → harden) drives the next world.
+    # One pass → "harden" direction; pentest has harden mutations to apply.
     evolved = auto_evolve(snap, report, pack=WebappPack())
     assert evolved is not None
     assert evolved.snapshot_id != snap.snapshot_id


### PR DESCRIPTION
## Summary

Closes the test gap between the episode loop and the curriculum loop. Each was well-unit-tested in isolation, but nothing exercised the **seam** between them.

- `check_success` (build + pentest) was only ever called with hand-built `final_state` dicts.
- `auto_evolve` was only ever driven by synthetic `EpisodeReport`s.

This smoke drives the **real** pipeline with a scripted agent (no LLM):

```
admit → start_episode → agent writes result.json → stop_episode
      → runtime.collect() → check_success → real EpisodeReport
      → auto_evolve → next snapshot (with evolve lineage)
```

## What it proves

- **build**: scripted agent submits the kind's reference handler into the episode's `agent_root`; the live `EpisodeService` → `runtime.collect()` → `check_success` path grades it `passed`. The build grader genuinely runs through the episode seam, not just when handed a dict.
- **pentest**: scripted agent submits the graph's flag value; episode grades `passed`; the **real** report (pass-rate 1.0 → harden) feeds `auto_evolve`, which produces a new snapshot whose `history` carries an `evolve` event.

## What it does NOT claim

The scripted agent stands in for an LLM. This is the **plumbing proof** — the integration seams connect — not an agent-capability claim. The Stage-2 live-agent exercise (real LLM iterating against the build grader, multi-turn) is still future work per ROADMAP.

## Test plan

- [x] `test_build_episode_grades_submitted_handler` — real episode, real subprocess grader
- [x] `test_pentest_episode_then_evolve` — real episode → real report → real auto_evolve
- [x] 511 pass (+2), mypy / ruff clean
- [x] No mocks/patches/fakes — real `admit`, real `EpisodeService`, real subprocess, real `auto_evolve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
