### PR TITLE
Name the solver role: agent_root → solver_root + role glossary

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -813,20 +813,20 @@ the episode lifecycle.
 | `reset()`         | None                          | At episode start, after `realize()` | Boot the world — start subprocesses, materialize artifact files, seed databases. |
 | `surface()`       | `Mapping[str, Any]`           | After `reset()`, cached for the episode | The agent-facing IO bundle. Pack-defined keys: HTTP base URL, file roots, MCP endpoints, NPC adapter dicts. The harness binds against the keys it expects. |
 | `poll_events()`   | `tuple[Mapping[str, Any], ...]` | Each tick | Drain side-effect events (HTTP requests, file writes, log entries) the world produced since the last poll. Forwarded to the dashboard. |
-| `terminal()`      | `(bool, str \| None)`         | Each tick | Has the agent finished? `(True, reason)` ends the episode; `(False, None)` continues. |
+| `terminal()`      | `(bool, str \| None)`         | Each tick | Has the solver finished? `(True, reason)` ends the episode; `(False, None)` continues. |
 | `checkpoint()`    | `Any` (opaque)                | On `EpisodeService.checkpoint` / `fork` | Capture an opaque pack-defined state snapshot for counterfactual replay. |
 | `restore(state)`  | None                          | On `EpisodeService.restore` / `fork` | Replay an opaque payload. Process-state semantics are the pack's call. |
 | `collect()`       | `Mapping[str, Any]`           | At episode stop, before `stop()` | Structured final state. The family's `check_success` reads this. |
 | `stop()`          | None                          | At episode stop | Tear down running processes / services. Must be idempotent. |
 
 `surface()` is **not** just `base_url` — it is the full IO bundle.
-Some keys are stringly-typed (`base_url`, `agent_root`); others may be
+Some keys are stringly-typed (`base_url`, `solver_root`); others may be
 callables (`http_get`, `http_get_json`). The episode layer's
 `_observation_metadata` is what selects the stringly-typed slice for
 the dashboard's JSON serializer.
 
 Per-pack contract: the cyber pack's `WebappRuntimeHandle.surface()`
-returns `{base_url, http_get, http_get_json, agent_root}`. The
+returns `{base_url, http_get, http_get_json, solver_root}`. The
 harness and NPCs that expect those keys are written against that
 shape.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -13,6 +13,36 @@ No marketing. The interesting content is the alternatives that lost.
 
 ---
 
+## Vocabulary
+
+Three roles, named by what they do — never "agent" (that word is reserved for a
+*mechanism*, below):
+
+- **builder** — makes and evolves the world graph (procedural, or LLM-backed: a
+  "builder LLM"). `Pack.make_builder`, `Builder`, `auto_evolve`.
+- **solver** — the model under evaluation. It plays an *episode* against a
+  realized world and emits a *submission*; its workspace is `solver_root`.
+- **NPC** — an LLM-backed inhabitant of the world (a browsing user, an office
+  persona). It populates the world the solver acts in; it is never graded.
+
+The mechanical parts are not agents and don't borrow the word:
+
+- **submission** — the artifact the solver emits (e.g. a `decide` / `handle`
+  function written to `result.json`).
+- **grader** — runs the submission against a held-out contract / replay and
+  scores it (`run_submission`, `TaskFamily.check_success`).
+- **admission** — the five-layer gate that proves a built world is valid and
+  solvable (`admit`).
+- **curriculum** — moves difficulty toward the solver's frontier (`auto_evolve`).
+
+"agent" names a *mechanism*, not a role: an **agent loop** is a tool-using LLM
+loop (`AgentBackend`, `AgentNPC`), as opposed to a raw `LLMBackend` transport.
+NPCs are built on agent loops; a solver could be too. So builder / solver / NPC
+are roles, `LLMBackend` / `AgentBackend` are mechanisms, and "agent" alone is
+never a role.
+
+---
+
 ## 1. The bet
 
 OpenRange exists to test a falsifiable claim:
@@ -479,10 +509,10 @@ substrate:
   rendering source) without paying the I/O cost of starting a
   subprocess. The episode loop calls `reset()` when it actually
   wants the world running.
-- `surface()` — the agent-facing IO bundle. Critically, this is not
+- `surface()` — the solver-facing IO bundle. Critically, this is not
   just `base_url`. The cyber pack returns
-  `{base_url, http_get, http_get_json, agent_root}`. NPCs need the
-  callables; the agent needs the URL and the working dir; the
+  `{base_url, http_get, http_get_json, solver_root}`. NPCs need the
+  callables; the solver needs the URL and the working dir; the
   dashboard wants the strings. One method returns the whole bundle;
   the caller picks what it needs.
 - `poll_events()` — drain side-effect events. The episode loop

--- a/examples/codex_eval.py
+++ b/examples/codex_eval.py
@@ -170,7 +170,7 @@ def _run_task(
     handle = svc.start_episode(snapshot, task.id)
     try:
         try:
-            result = harness.run(task.instruction, svc.agent_root(handle))
+            result = harness.run(task.instruction, svc.solver_root(handle))
             svc.record_turn(handle, AgentTurn(message=result.text))
         except LLMBackendError as exc:
             # A failed call is a failed episode, not a reason to abort the

--- a/examples/strands_eval.py
+++ b/examples/strands_eval.py
@@ -74,7 +74,7 @@ def run_task(
     svc = run.episode_service(snapshot)
     handle = svc.start_episode(snapshot, task.id)
     try:
-        agent_result = harness.run(task.instruction, svc.agent_root(handle))
+        agent_result = harness.run(task.instruction, svc.solver_root(handle))
         svc.record_turn(handle, AgentTurn(message=agent_result.text))
         episode_report = svc.stop_episode(handle)
     finally:

--- a/packages/openrange-pack-sdk/src/openrange_pack_sdk/_runtime.py
+++ b/packages/openrange-pack-sdk/src/openrange_pack_sdk/_runtime.py
@@ -4,11 +4,11 @@ These are optional. Packs can implement the ``RuntimeHandle`` Protocol
 directly. Use one of these when your runtime fits the pattern.
 
 Two siblings share a filesystem-lifecycle base (``env_root`` /
-``agent_root`` / ``pack_root``, file-snapshot checkpoint/restore,
+``solver_root`` / ``pack_root``, file-snapshot checkpoint/restore,
 ``result.json`` terminal signal):
 
 * :class:`SubprocessRuntime` — spawns and supervises a
-  long-running child the agent interacts with (e.g. a webapp, a
+  long-running child the solver interacts with (e.g. a webapp, a
   simulator). Owns the SIGTERM→SIGKILL grace period and the startup
   handshake.
 
@@ -41,9 +41,9 @@ from openrange_pack_sdk._helpers import write_tree
 class _FilesystemRuntime(ABC):
     """Shared lifecycle base for filesystem-backed RuntimeHandles.
 
-    Owns the tempdir trio (``env_root``, ``agent_root``, ``pack_root``;
+    Owns the tempdir trio (``env_root``, ``solver_root``, ``pack_root``;
     each ``None`` before the first ``reset()`` and after ``stop()``),
-    file-snapshot ``checkpoint`` / ``restore`` of the agent's workspace,
+    file-snapshot ``checkpoint`` / ``restore`` of the solver's workspace,
     ``terminal()`` via ``result.json``, and the default ``collect()``
     shape. Packs subclass one of the public siblings, not this directly.
     """
@@ -53,7 +53,7 @@ class _FilesystemRuntime(ABC):
     def __init__(self, graph: WorldGraph) -> None:
         self._graph = graph
         self._env_root: Path | None = None
-        self._agent_root: Path | None = None
+        self._solver_root: Path | None = None
         self._pack_root: Path | None = None
         self._checkpoint_dirs: list[Path] = []
 
@@ -62,8 +62,8 @@ class _FilesystemRuntime(ABC):
         return self._env_root
 
     @property
-    def agent_root(self) -> Path | None:
-        return self._agent_root
+    def solver_root(self) -> Path | None:
+        return self._solver_root
 
     @property
     def pack_root(self) -> Path | None:
@@ -96,68 +96,68 @@ class _FilesystemRuntime(ABC):
         and drop ``_checkpoint_dirs``."""
 
     def surface(self) -> Mapping[str, Any]:
-        if self._agent_root is None:
+        if self._solver_root is None:
             raise OpenRangeError("surface() called before reset()")
         return {
-            "agent_root": str(self._agent_root),
+            "solver_root": str(self._solver_root),
             **self.surface_extras(),
         }
 
     def terminal(self) -> tuple[bool, str | None]:
-        if self._agent_root is None:
+        if self._solver_root is None:
             return False, None
-        if (self._agent_root / self.RESULT_FILE).exists():
-            return True, "agent wrote result"
+        if (self._solver_root / self.RESULT_FILE).exists():
+            return True, "solver wrote result"
         return False, None
 
     def checkpoint(self) -> Any:
-        if self._agent_root is None:
+        if self._solver_root is None:
             raise OpenRangeError("checkpoint() called before reset()")
         snap = Path(tempfile.mkdtemp(prefix=f"{self._tempdir_prefix()}-ckpt-"))
-        shutil.copytree(self._agent_root, snap / "agent", dirs_exist_ok=True)
+        shutil.copytree(self._solver_root, snap / "solver", dirs_exist_ok=True)
         self._checkpoint_dirs.append(snap)
-        return {"agent_root_snapshot": str(snap)}
+        return {"solver_root_snapshot": str(snap)}
 
     def restore(self, state: Any) -> None:
         if not isinstance(state, Mapping):
             raise OpenRangeError(
                 f"restore() expects a mapping, got {type(state).__name__}"
             )
-        snap_path = state.get("agent_root_snapshot")
+        snap_path = state.get("solver_root_snapshot")
         if not isinstance(snap_path, str):
             raise OpenRangeError(
-                "restore() payload missing 'agent_root_snapshot' (str)"
+                "restore() payload missing 'solver_root_snapshot' (str)"
             )
-        agent_snap = Path(snap_path) / "agent"
-        if not agent_snap.exists():
-            raise OpenRangeError(f"restore() snapshot missing: {agent_snap}")
-        if self._agent_root is None:
+        solver_snap = Path(snap_path) / "solver"
+        if not solver_snap.exists():
+            raise OpenRangeError(f"restore() snapshot missing: {solver_snap}")
+        if self._solver_root is None:
             raise OpenRangeError("restore() called before reset()")
-        for child in self._agent_root.iterdir():
+        for child in self._solver_root.iterdir():
             if child.is_dir():
                 shutil.rmtree(child)
             else:
                 child.unlink()
-        shutil.copytree(agent_snap, self._agent_root, dirs_exist_ok=True)
+        shutil.copytree(solver_snap, self._solver_root, dirs_exist_ok=True)
 
     def collect(self) -> Mapping[str, Any]:
-        if self._agent_root is None:
+        if self._solver_root is None:
             return {}
         result = self._read_result()
         return {
-            "agent_root": str(self._agent_root),
+            "solver_root": str(self._solver_root),
             "result": dict(result),
             **self.collect_extras(),
         }
 
     def _init_env(self) -> None:
         env_root = Path(tempfile.mkdtemp(prefix=f"{self._tempdir_prefix()}-"))
-        agent_root = env_root / "agent"
-        agent_root.mkdir(parents=True, exist_ok=True)
+        solver_root = env_root / "solver"
+        solver_root.mkdir(parents=True, exist_ok=True)
         pack_root = env_root / "pack"
         pack_root.mkdir(parents=True, exist_ok=True)
         self._env_root = env_root
-        self._agent_root = agent_root
+        self._solver_root = solver_root
         self._pack_root = pack_root
         write_tree(pack_root, self.prepare_env_files(self._graph))
 
@@ -165,7 +165,7 @@ class _FilesystemRuntime(ABC):
         if self._env_root is not None and self._env_root.exists():
             shutil.rmtree(self._env_root, ignore_errors=True)
         self._env_root = None
-        self._agent_root = None
+        self._solver_root = None
         self._pack_root = None
 
     def _drop_checkpoints(self) -> None:
@@ -174,8 +174,8 @@ class _FilesystemRuntime(ABC):
         self._checkpoint_dirs.clear()
 
     def _read_result(self) -> Mapping[str, Any]:
-        assert self._agent_root is not None
-        result_path = self._agent_root / self.RESULT_FILE
+        assert self._solver_root is not None
+        result_path = self._solver_root / self.RESULT_FILE
         if not result_path.exists():
             return {}
         try:
@@ -191,7 +191,7 @@ class _FilesystemRuntime(ABC):
 class OnDemandRuntime(_FilesystemRuntime):
     """RuntimeHandle for packs with no persistent subprocess.
 
-    Pattern: the agent acts on files under ``agent_root``; the pack
+    Pattern: the solver acts on files under ``solver_root``; the pack
     exposes on-demand callables (e.g. ``run_tests(name)``,
     ``run_cmd(argv)``) via ``surface_extras`` that shell out per call.
 
@@ -205,7 +205,7 @@ class OnDemandRuntime(_FilesystemRuntime):
 
     Packs override (as needed):
 
-    * ``surface_extras()`` — add callables the agent can invoke.
+    * ``surface_extras()`` — add callables the solver can invoke.
     * ``collect_extras()`` — add computed-from-workspace keys to
       ``collect()``.
     * ``poll_events()`` — per-tick events (default = no events).
@@ -227,17 +227,17 @@ class OnDemandRuntime(_FilesystemRuntime):
 
 class SubprocessRuntime(_FilesystemRuntime):
     """RuntimeHandle scaffold for packs whose realized world is a child
-    subprocess the agent interacts with.
+    subprocess the solver interacts with.
 
     Domains this fits naturally: a webapp serving HTTP, a simulator
     exposing a broker API, an in-pack mock service. Common structure:
     spawn a process, optionally exchange a small startup descriptor
-    (URL, port, fd), let the agent act, capture results from the
-    agent's filesystem at the end.
+    (URL, port, fd), let the solver act, capture results from the
+    solver's filesystem at the end.
 
     The class owns:
 
-    * The shared filesystem lifecycle (``env_root`` / ``agent_root`` /
+    * The shared filesystem lifecycle (``env_root`` / ``solver_root`` /
       ``pack_root``, ``checkpoint`` / ``restore``, terminal-via-result.json).
     * Subprocess spawn with ``start_new_session=True`` so process-group
       signals reach the child without affecting the harness.
@@ -249,7 +249,7 @@ class SubprocessRuntime(_FilesystemRuntime):
 
     * ``prepare_env_files(graph)`` → ``{relative_path: contents}`` for
       ``pack_root`` (e.g., the codegen-rendered app source).
-    * ``subprocess_command(env_root, agent_root)`` → the command to spawn.
+    * ``subprocess_command(env_root, solver_root)`` → the command to spawn.
 
     Packs override (as needed):
 
@@ -260,7 +260,7 @@ class SubprocessRuntime(_FilesystemRuntime):
       ``stdin=subprocess.PIPE`` for two-way comms). Additive; don't
       override ``stdout``/``stderr``/``start_new_session`` — the SDK
       relies on those.
-    * ``surface_extras()`` — extra keys the agent reads (callables, URLs).
+    * ``surface_extras()`` — extra keys the solver reads (callables, URLs).
     * ``poll_events()`` — per-tick event drain (default = no events).
     * ``collect_extras()`` — per-pack final-state keys.
 
@@ -270,7 +270,7 @@ class SubprocessRuntime(_FilesystemRuntime):
     ``poll_events`` / ``collect_extras``.
 
     Contract: the spawned subprocess MUST emit at least one newline on
-    stdout before the agent acts. ``reset()`` blocks on ``readline()``
+    stdout before the solver acts. ``reset()`` blocks on ``readline()``
     (bounded by ``STARTUP_TIMEOUT_SECONDS``) to capture optional startup
     info. Packs with no startup info to advertise should print a single
     ``\\n`` immediately.
@@ -293,7 +293,7 @@ class SubprocessRuntime(_FilesystemRuntime):
     def subprocess_command(
         self,
         env_root: Path,
-        agent_root: Path,
+        solver_root: Path,
     ) -> Sequence[str]:
         """The argv to ``subprocess.Popen``."""
 
@@ -326,8 +326,8 @@ class SubprocessRuntime(_FilesystemRuntime):
         self._teardown_subprocess()
         self._teardown_env()
         self._init_env()
-        assert self._env_root is not None and self._agent_root is not None
-        self._process = self._spawn(self._env_root, self._agent_root)
+        assert self._env_root is not None and self._solver_root is not None
+        self._process = self._spawn(self._env_root, self._solver_root)
         assert self._process.stdout is not None
         first_line = _readline_with_timeout(self._process, self.STARTUP_TIMEOUT_SECONDS)
         if first_line:
@@ -356,9 +356,9 @@ class SubprocessRuntime(_FilesystemRuntime):
     def _spawn(
         self,
         env_root: Path,
-        agent_root: Path,
+        solver_root: Path,
     ) -> subprocess.Popen[str]:
-        cmd = list(self.subprocess_command(env_root, agent_root))
+        cmd = list(self.subprocess_command(env_root, solver_root))
         kwargs: dict[str, Any] = {
             "stdout": subprocess.PIPE,
             "stderr": subprocess.PIPE,

--- a/packages/openrange-pack-sdk/tests/test_sdk.py
+++ b/packages/openrange-pack-sdk/tests/test_sdk.py
@@ -930,10 +930,10 @@ def _make_simple_subprocess_runtime() -> Any:
             del graph
             return {"ready.txt": "ok"}
 
-        def subprocess_command(self, env_root: Any, agent_root: Any) -> Sequence[str]:
+        def subprocess_command(self, env_root: Any, solver_root: Any) -> Sequence[str]:
             import sys
 
-            del env_root, agent_root
+            del env_root, solver_root
             return [sys.executable, "-c", _SUBPROCESS_SCRIPT]
 
         def parse_startup(self, stdout_line: str) -> Mapping[str, Any]:
@@ -960,10 +960,10 @@ def _make_silent_subprocess_runtime() -> Any:
             del graph
             return {}
 
-        def subprocess_command(self, env_root: Any, agent_root: Any) -> Sequence[str]:
+        def subprocess_command(self, env_root: Any, solver_root: Any) -> Sequence[str]:
             import sys
 
-            del env_root, agent_root
+            del env_root, solver_root
             return [
                 sys.executable,
                 "-c",
@@ -985,9 +985,9 @@ class TestSubprocessRuntime:
             runtime.reset()
             surface = runtime.surface()
             assert surface["ready"] is True
-            assert "agent_root" in surface
+            assert "solver_root" in surface
             assert surface["hello"] == "from pack"
-            assert Path(surface["agent_root"]).is_dir()
+            assert Path(surface["solver_root"]).is_dir()
         finally:
             runtime.stop()
 
@@ -1013,10 +1013,10 @@ class TestSubprocessRuntime:
         try:
             runtime.reset()
             surface = runtime.surface()
-            (Path(surface["agent_root"]) / "result.json").write_text("{}")
+            (Path(surface["solver_root"]) / "result.json").write_text("{}")
             ok, reason = runtime.terminal()
             assert ok is True
-            assert reason == "agent wrote result"
+            assert reason == "solver wrote result"
         finally:
             runtime.stop()
 
@@ -1030,12 +1030,12 @@ class TestSubprocessRuntime:
         runtime = _make_simple_subprocess_runtime()
         try:
             runtime.reset()
-            agent_root = Path(runtime.surface()["agent_root"])
-            (agent_root / "result.json").write_text('{"x": 1}')
+            solver_root = Path(runtime.surface()["solver_root"])
+            (solver_root / "result.json").write_text('{"x": 1}')
             collected = runtime.collect()
             assert collected["result"] == {"x": 1}
             assert collected["finalized_by"] == "test"
-            assert "agent_root" in collected
+            assert "solver_root" in collected
         finally:
             runtime.stop()
 
@@ -1045,8 +1045,8 @@ class TestSubprocessRuntime:
         runtime = _make_simple_subprocess_runtime()
         try:
             runtime.reset()
-            agent_root = Path(runtime.surface()["agent_root"])
-            (agent_root / "result.json").write_text("{not valid")
+            solver_root = Path(runtime.surface()["solver_root"])
+            (solver_root / "result.json").write_text("{not valid")
             collected = runtime.collect()
             assert collected["result"] == {}
         finally:
@@ -1058,25 +1058,25 @@ class TestSubprocessRuntime:
         runtime = _make_simple_subprocess_runtime()
         try:
             runtime.reset()
-            agent_root = Path(runtime.surface()["agent_root"])
-            (agent_root / "result.json").write_text("[1, 2]")
+            solver_root = Path(runtime.surface()["solver_root"])
+            (solver_root / "result.json").write_text("[1, 2]")
             collected = runtime.collect()
             assert collected["result"] == {}
         finally:
             runtime.stop()
 
-    def test_checkpoint_then_restore_round_trips_agent_root(self) -> None:
+    def test_checkpoint_then_restore_round_trips_solver_root(self) -> None:
         from pathlib import Path
 
         runtime = _make_simple_subprocess_runtime()
         try:
             runtime.reset()
-            agent_root = Path(runtime.surface()["agent_root"])
-            (agent_root / "scratch.txt").write_text("hello")
+            solver_root = Path(runtime.surface()["solver_root"])
+            (solver_root / "scratch.txt").write_text("hello")
             ckpt = runtime.checkpoint()
-            (agent_root / "scratch.txt").write_text("modified")
+            (solver_root / "scratch.txt").write_text("modified")
             runtime.restore(ckpt)
-            assert (agent_root / "scratch.txt").read_text() == "hello"
+            assert (solver_root / "scratch.txt").read_text() == "hello"
         finally:
             runtime.stop()
 
@@ -1093,7 +1093,7 @@ class TestSubprocessRuntime:
         runtime = _make_simple_subprocess_runtime()
         try:
             runtime.reset()
-            with pytest.raises(Exception, match="agent_root_snapshot"):
+            with pytest.raises(Exception, match="solver_root_snapshot"):
                 runtime.restore({"wrong_key": "x"})
         finally:
             runtime.stop()
@@ -1103,7 +1103,7 @@ class TestSubprocessRuntime:
         try:
             runtime.reset()
             with pytest.raises(Exception, match="snapshot missing"):
-                runtime.restore({"agent_root_snapshot": "/nonexistent/path"})
+                runtime.restore({"solver_root_snapshot": "/nonexistent/path"})
         finally:
             runtime.stop()
 
@@ -1111,10 +1111,10 @@ class TestSubprocessRuntime:
         runtime = _make_simple_subprocess_runtime()
         try:
             runtime.reset()
-            first_agent_root = runtime.surface()["agent_root"]
+            first_solver_root = runtime.surface()["solver_root"]
             runtime.reset()
-            second_agent_root = runtime.surface()["agent_root"]
-            assert first_agent_root != second_agent_root
+            second_solver_root = runtime.surface()["solver_root"]
+            assert first_solver_root != second_solver_root
         finally:
             runtime.stop()
 
@@ -1130,7 +1130,7 @@ class TestSubprocessRuntime:
         try:
             runtime.reset()
             surface = runtime.surface()
-            assert "agent_root" in surface
+            assert "solver_root" in surface
             assert "ready" not in surface
         finally:
             runtime.stop()
@@ -1152,11 +1152,11 @@ class TestSubprocessRuntime:
                 return {}
 
             def subprocess_command(
-                self, env_root: Any, agent_root: Any
+                self, env_root: Any, solver_root: Any
             ) -> Sequence[str]:
                 import sys
 
-                del env_root, agent_root
+                del env_root, solver_root
                 # Closes stdout without writing → reset's readline returns "".
                 return [sys.executable, "-c", "import sys; sys.stdout.close()"]
 
@@ -1164,23 +1164,23 @@ class TestSubprocessRuntime:
         try:
             runtime.reset()
             surface = runtime.surface()
-            assert "agent_root" in surface
+            assert "solver_root" in surface
         finally:
             runtime.stop()
 
-    def test_restore_replaces_directory_under_agent_root(self) -> None:
+    def test_restore_replaces_directory_under_solver_root(self) -> None:
         from pathlib import Path
 
         runtime = _make_simple_subprocess_runtime()
         try:
             runtime.reset()
-            agent_root = Path(runtime.surface()["agent_root"])
-            (agent_root / "sub").mkdir()
-            (agent_root / "sub" / "f.txt").write_text("snapshot")
+            solver_root = Path(runtime.surface()["solver_root"])
+            (solver_root / "sub").mkdir()
+            (solver_root / "sub" / "f.txt").write_text("snapshot")
             ckpt = runtime.checkpoint()
-            (agent_root / "sub" / "f.txt").write_text("modified")
+            (solver_root / "sub" / "f.txt").write_text("modified")
             runtime.restore(ckpt)
-            assert (agent_root / "sub" / "f.txt").read_text() == "snapshot"
+            assert (solver_root / "sub" / "f.txt").read_text() == "snapshot"
         finally:
             runtime.stop()
 
@@ -1191,10 +1191,10 @@ class TestSubprocessRuntime:
         runtime = _make_simple_subprocess_runtime()
         # Build a valid-looking snapshot on disk without ever calling reset.
         snap = Path(tempfile.mkdtemp(prefix="ckpt-fake-"))
-        (snap / "agent").mkdir()
+        (snap / "solver").mkdir()
         try:
             with pytest.raises(Exception, match="before reset"):
-                runtime.restore({"agent_root_snapshot": str(snap)})
+                runtime.restore({"solver_root_snapshot": str(snap)})
         finally:
             import shutil
 
@@ -1209,11 +1209,11 @@ class TestSubprocessRuntime:
                 return {}
 
             def subprocess_command(
-                self, env_root: Any, agent_root: Any
+                self, env_root: Any, solver_root: Any
             ) -> Sequence[str]:
                 import sys
 
-                del env_root, agent_root
+                del env_root, solver_root
                 return [
                     sys.executable,
                     "-c",
@@ -1225,10 +1225,10 @@ class TestSubprocessRuntime:
         try:
             runtime.reset()
             collected = runtime.collect()
-            assert "agent_root" in collected
+            assert "solver_root" in collected
             assert collected["result"] == {}
-            # collect_extras default → no extra keys beyond agent_root + result.
-            assert set(collected.keys()) == {"agent_root", "result"}
+            # collect_extras default → no extra keys beyond solver_root + result.
+            assert set(collected.keys()) == {"solver_root", "result"}
         finally:
             runtime.stop()
 
@@ -1243,11 +1243,11 @@ class TestSubprocessRuntime:
                 return {}
 
             def subprocess_command(
-                self, env_root: Any, agent_root: Any
+                self, env_root: Any, solver_root: Any
             ) -> Sequence[str]:
                 import sys
 
-                del env_root, agent_root
+                del env_root, solver_root
                 return [
                     sys.executable,
                     "-c",
@@ -1291,18 +1291,18 @@ class TestSubprocessRuntime:
         runtime = _make_simple_subprocess_runtime()
         try:
             runtime.reset()
-            agent_root = Path(runtime.surface()["agent_root"])
-            (agent_root / "scratch.txt").write_text("before-restart")
+            solver_root = Path(runtime.surface()["solver_root"])
+            (solver_root / "scratch.txt").write_text("before-restart")
             ckpt = runtime.checkpoint()
-            snap_path = Path(ckpt["agent_root_snapshot"])
+            snap_path = Path(ckpt["solver_root_snapshot"])
             assert snap_path.exists()
             # reset() must NOT wipe the snapshot dir — restore() flows
             # like the webapp pack's call reset() before super().restore().
             runtime.reset()
             assert snap_path.exists()
             runtime.restore(ckpt)
-            new_agent_root = Path(runtime.surface()["agent_root"])
-            assert (new_agent_root / "scratch.txt").read_text() == "before-restart"
+            new_solver_root = Path(runtime.surface()["solver_root"])
+            assert (new_solver_root / "scratch.txt").read_text() == "before-restart"
         finally:
             runtime.stop()
 
@@ -1328,7 +1328,7 @@ class TestSubprocessRuntime:
     def test_public_properties_are_none_before_reset(self) -> None:
         runtime = _make_simple_subprocess_runtime()
         assert runtime.env_root is None
-        assert runtime.agent_root is None
+        assert runtime.solver_root is None
         assert runtime.pack_root is None
         assert runtime.process is None
 
@@ -1339,7 +1339,7 @@ class TestSubprocessRuntime:
         try:
             runtime.reset()
             assert isinstance(runtime.env_root, Path)
-            assert isinstance(runtime.agent_root, Path)
+            assert isinstance(runtime.solver_root, Path)
             assert isinstance(runtime.pack_root, Path)
             assert runtime.process is not None
             assert runtime.process.pid > 0
@@ -1357,11 +1357,11 @@ class TestSubprocessRuntime:
                 return {}
 
             def subprocess_command(
-                self, env_root: Any, agent_root: Any
+                self, env_root: Any, solver_root: Any
             ) -> Sequence[str]:
                 import sys
 
-                del env_root, agent_root
+                del env_root, solver_root
                 # Sleeps without writing → readline must time out.
                 return [sys.executable, "-c", "import time; time.sleep(5)"]
 
@@ -1383,11 +1383,11 @@ class TestSubprocessRuntime:
                 return {}
 
             def subprocess_command(
-                self, env_root: Any, agent_root: Any
+                self, env_root: Any, solver_root: Any
             ) -> Sequence[str]:
                 import sys
 
-                del env_root, agent_root
+                del env_root, solver_root
                 return [
                     sys.executable,
                     "-c",
@@ -1419,11 +1419,11 @@ class TestSubprocessRuntime:
                 return {}
 
             def subprocess_command(
-                self, env_root: Any, agent_root: Any
+                self, env_root: Any, solver_root: Any
             ) -> Sequence[str]:
                 import sys
 
-                del env_root, agent_root
+                del env_root, solver_root
                 # Reads one JSON line from stdin, echoes it on stdout
                 # with an "echoed" marker; prints startup line first.
                 return [
@@ -1480,10 +1480,10 @@ class TestOnDemandRuntime:
         try:
             runtime.reset()
             surface = runtime.surface()
-            assert "agent_root" in surface
+            assert "solver_root" in surface
             assert surface["hello"] == "from on-demand pack"
-            agent_root = Path(surface["agent_root"])
-            assert agent_root.is_dir()
+            solver_root = Path(surface["solver_root"])
+            assert solver_root.is_dir()
             pack_root = runtime.pack_root
             assert pack_root is not None
             assert (pack_root / "README.md").read_text() == "# project"
@@ -1505,11 +1505,11 @@ class TestOnDemandRuntime:
         runtime = _make_simple_ondemand_runtime()
         try:
             runtime.reset()
-            agent_root = Path(runtime.surface()["agent_root"])
-            (agent_root / "result.json").write_text('{"status": "ok"}')
+            solver_root = Path(runtime.surface()["solver_root"])
+            (solver_root / "result.json").write_text('{"status": "ok"}')
             ok, reason = runtime.terminal()
             assert ok is True
-            assert reason == "agent wrote result"
+            assert reason == "solver wrote result"
         finally:
             runtime.stop()
 
@@ -1517,8 +1517,8 @@ class TestOnDemandRuntime:
         runtime = _make_simple_ondemand_runtime()
         try:
             runtime.reset()
-            agent_root = Path(runtime.surface()["agent_root"])
-            (agent_root / "result.json").write_text('{"passed": 3, "failed": 1}')
+            solver_root = Path(runtime.surface()["solver_root"])
+            (solver_root / "result.json").write_text('{"passed": 3, "failed": 1}')
             collected = runtime.collect()
             assert collected["result"] == {"passed": 3, "failed": 1}
             assert collected["finalized_by"] == "ondemand"
@@ -1529,12 +1529,12 @@ class TestOnDemandRuntime:
         runtime = _make_simple_ondemand_runtime()
         try:
             runtime.reset()
-            agent_root = Path(runtime.surface()["agent_root"])
-            (agent_root / "scratch.txt").write_text("v1")
+            solver_root = Path(runtime.surface()["solver_root"])
+            (solver_root / "scratch.txt").write_text("v1")
             ckpt = runtime.checkpoint()
-            (agent_root / "scratch.txt").write_text("v2")
+            (solver_root / "scratch.txt").write_text("v2")
             runtime.restore(ckpt)
-            assert (agent_root / "scratch.txt").read_text() == "v1"
+            assert (solver_root / "scratch.txt").read_text() == "v1"
         finally:
             runtime.stop()
 
@@ -1542,7 +1542,7 @@ class TestOnDemandRuntime:
         runtime = _make_simple_ondemand_runtime()
         runtime.reset()
         ckpt = runtime.checkpoint()
-        snap_path = Path(ckpt["agent_root_snapshot"])
+        snap_path = Path(ckpt["solver_root_snapshot"])
         assert snap_path.exists()
         runtime.stop()
         assert not snap_path.exists()
@@ -1552,7 +1552,7 @@ class TestOnDemandRuntime:
         try:
             runtime.reset()
             ckpt = runtime.checkpoint()
-            snap_path = Path(ckpt["agent_root_snapshot"])
+            snap_path = Path(ckpt["solver_root_snapshot"])
             assert snap_path.exists()
             runtime.reset()
             assert snap_path.exists()
@@ -1569,7 +1569,7 @@ class TestOnDemandRuntime:
 
     def test_swe_style_run_cmd_callable(self, tmp_path: Path) -> None:
         """End-to-end exercise of the SWE-pack pattern: harness exposes
-        a run_cmd callable that shells out against the agent_root."""
+        a run_cmd callable that shells out against the solver_root."""
         import subprocess as _subprocess
 
         from openrange_pack_sdk import OnDemandRuntime
@@ -1580,12 +1580,12 @@ class TestOnDemandRuntime:
                 return {}
 
             def surface_extras(self) -> Mapping[str, Any]:
-                agent_root = self.agent_root
+                solver_root = self.solver_root
 
                 def run_cmd(argv: Sequence[str]) -> Mapping[str, Any]:
                     completed = _subprocess.run(
                         list(argv),
-                        cwd=agent_root,
+                        cwd=solver_root,
                         capture_output=True,
                         text=True,
                         timeout=5,
@@ -1601,8 +1601,8 @@ class TestOnDemandRuntime:
         runtime = _SWEPack(_empty_graph())
         try:
             runtime.reset()
-            agent_root = Path(runtime.surface()["agent_root"])
-            (agent_root / "hello.py").write_text("print('hello')")
+            solver_root = Path(runtime.surface()["solver_root"])
+            (solver_root / "hello.py").write_text("print('hello')")
             run_cmd = runtime.surface()["run_cmd"]
             result = run_cmd(["python3", "hello.py"])
             assert result["rc"] == 0

--- a/packs/cyber_webapp/cyber_webapp/realize.py
+++ b/packs/cyber_webapp/cyber_webapp/realize.py
@@ -60,9 +60,9 @@ class WebappRuntime(SubprocessRuntime):
     def subprocess_command(
         self,
         env_root: Path,
-        agent_root: Path,
+        solver_root: Path,
     ) -> list[str]:
-        del agent_root
+        del solver_root
         app_path = env_root / "pack" / APP_FILE_NAME
         if not app_path.exists():
             raise WebappRuntimeError(

--- a/packs/trading/trading/realize.py
+++ b/packs/trading/trading/realize.py
@@ -37,8 +37,8 @@ class TradingRuntime(OnDemandRuntime):
 
     def reset(self) -> None:
         super().reset()
-        assert self.agent_root is not None
-        (self.agent_root / "bars.json").write_text(
+        assert self.solver_root is not None
+        (self.solver_root / "bars.json").write_text(
             _bars_json(self._graph), encoding="utf-8"
         )
 

--- a/src/openrange/core/episode.py
+++ b/src/openrange/core/episode.py
@@ -1,4 +1,4 @@
-"""EpisodeService — the agent harness's seam into running worlds."""
+"""EpisodeService — the solver harness's seam into running worlds."""
 
 from __future__ import annotations
 
@@ -279,7 +279,7 @@ class EpisodeService:
         try:
             running.runtime.stop()
         except Exception as exc:  # noqa: BLE001
-            # A failed stop must not mask the agent's result.
+            # A failed stop must not mask the solver's result.
             self._record_system(
                 running,
                 {"stop_error": type(exc).__name__},
@@ -311,7 +311,7 @@ class EpisodeService:
         return self._require(episode).surface_cache
 
     def base_url(self, episode: EpisodeHandle) -> str:
-        """The base URL of the agent-facing IO surface, when one is declared."""
+        """The base URL of the solver-facing IO surface, when one is declared."""
         surface = self._require(episode).surface_cache
         value = surface.get("base_url")
         if not isinstance(value, str):
@@ -320,13 +320,13 @@ class EpisodeService:
             )
         return value
 
-    def agent_root(self, episode: EpisodeHandle) -> Path:
-        """The agent's working directory, when the surface declares one."""
+    def solver_root(self, episode: EpisodeHandle) -> Path:
+        """The solver's working directory, when the surface declares one."""
         surface = self._require(episode).surface_cache
-        value = surface.get("agent_root")
+        value = surface.get("solver_root")
         if not isinstance(value, (str, Path)):
             raise EpisodeError(
-                f"episode {episode.id!r} surface does not expose 'agent_root'",
+                f"episode {episode.id!r} surface does not expose 'solver_root'",
             )
         return Path(value)
 
@@ -676,7 +676,7 @@ def _resolve_task(snapshot: Snapshot, task_id: str | None) -> TaskSpec:
 def _observation_metadata(surface: Mapping[str, Any]) -> Mapping[str, Any]:
     # Surface may carry callables the dashboard JSON serializer can't handle.
     out: dict[str, Any] = {}
-    for key in ("base_url", "agent_root"):
+    for key in ("base_url", "solver_root"):
         value = surface.get(key)
         if isinstance(value, str):
             out[key] = value

--- a/tests/test_cyber_codegen.py
+++ b/tests/test_cyber_codegen.py
@@ -134,15 +134,15 @@ def test_handle_reset_materializes_files_and_starts_process() -> None:
         surface = handle.surface()
         base_url = cast(str, surface["base_url"])
         assert base_url.startswith("http://127.0.0.1:")
-        # The agent_root the surface reports must be a real directory.
-        agent_root = cast(str, surface["agent_root"])
+        # The solver_root the surface reports must be a real directory.
+        solver_root = cast(str, surface["solver_root"])
         from pathlib import Path  # noqa: PLC0415
 
-        assert Path(agent_root).is_dir()
+        assert Path(solver_root).is_dir()
         # The pack root sits next to the agent root with app.py + seed.
         # We don't assert the seed.json still exists on disk (the
         # generated app unlinks it after loading), but app.py must.
-        env_root = Path(agent_root).parent
+        env_root = Path(solver_root).parent
         assert (env_root / "pack" / APP_FILE_NAME).exists()
         # The request log is pre-touched so poll_events() before any HTTP
         # traffic returns () instead of erroring. SubprocessRuntimeHandle
@@ -203,7 +203,7 @@ def test_handle_collect_reports_smoke_test_signal() -> None:
 def test_handle_collect_returns_empty_before_reset() -> None:
     """Before reset(), collect() returns an empty mapping rather than crashing."""
     handle = WebappPack().realize(_sample_graph(), Backing.PROCESS)
-    # No reset(); no process; no agent_root.
+    # No reset(); no process; no solver_root.
     collected = handle.collect()
     assert dict(collected) == {}
 
@@ -221,14 +221,14 @@ def test_handle_terminal_flips_when_result_file_appears() -> None:
         # Simulate the agent finishing: drop a result.json next to where
         # the handle expects it.
         surface = handle.surface()
-        agent_root = Path(cast(str, surface["agent_root"]))
-        (agent_root / RESULT_FILE_NAME).write_text(
+        solver_root = Path(cast(str, surface["solver_root"]))
+        (solver_root / RESULT_FILE_NAME).write_text(
             json.dumps({"flag": "x"}),
             encoding="utf-8",
         )
         done, reason = handle.terminal()
         assert done is True
-        assert reason == "agent wrote result"
+        assert reason == "solver wrote result"
     finally:
         handle.stop()
 
@@ -253,14 +253,14 @@ def test_handle_stop_cleans_up_tempdirs() -> None:
     assert env_root is not None and env_root.exists()
     state = handle.checkpoint()
     checkpoint_dir = Path(
-        cast(str, cast(Mapping[str, object], state)["agent_root_snapshot"]),
+        cast(str, cast(Mapping[str, object], state)["solver_root_snapshot"]),
     )
     assert checkpoint_dir.exists()
     handle.stop()
     assert not env_root.exists()
     assert not checkpoint_dir.exists()
     assert handle._env_root is None
-    assert handle._agent_root is None
+    assert handle._solver_root is None
     assert handle._pack_root is None
 
 

--- a/tests/test_cyber_npcs.py
+++ b/tests/test_cyber_npcs.py
@@ -2,7 +2,7 @@
 
 The NPCs receive an ``interface`` mapping matching the shape produced
 by ``WebappRuntime.surface()``:
-``{base_url, http_get, http_get_json, agent_root}``. Tests use a fake
+``{base_url, http_get, http_get_json, solver_root}``. Tests use a fake
 interface that records GET calls so we can assert on cadence,
 rotation, and graceful error handling — no real subprocess needed.
 """
@@ -42,7 +42,7 @@ class _RuntimeSurface(dict[str, Any]):
         self["base_url"] = "http://test.local"
         self["http_get"] = http_get
         self["http_get_json"] = http_get_json
-        self["agent_root"] = "/tmp/fake-agent-root"
+        self["solver_root"] = "/tmp/fake-agent-root"
 
 
 def test_browsing_user_acts_on_first_step_then_obeys_cadence() -> None:

--- a/tests/test_episode_loop_smoke.py
+++ b/tests/test_episode_loop_smoke.py
@@ -48,8 +48,8 @@ def test_build_episode_grades_submitted_handler(tmp_path: Path) -> None:
     svc = EpisodeService(WebappPack(), tmp_path)
     try:
         handle = svc.start_episode(snap, task.id)
-        agent_root = svc.agent_root(handle)
-        (agent_root / "result.json").write_text(
+        solver_root = svc.solver_root(handle)
+        (solver_root / "result.json").write_text(
             json.dumps({"endpoint_impl": api_list_reference(1)}),
             encoding="utf-8",
         )
@@ -67,8 +67,8 @@ def test_pentest_episode_then_evolve(tmp_path: Path) -> None:
     svc = EpisodeService(WebappPack(), tmp_path)
     try:
         handle = svc.start_episode(snap, task.id)
-        agent_root = svc.agent_root(handle)
-        (agent_root / "result.json").write_text(
+        solver_root = svc.solver_root(handle)
+        (solver_root / "result.json").write_text(
             json.dumps({"flag": flag_value}),
             encoding="utf-8",
         )

--- a/tests/test_llm_and_dashboard.py
+++ b/tests/test_llm_and_dashboard.py
@@ -768,10 +768,10 @@ def test_openrange_run_can_disable_dashboard_artifacts(tmp_path: Path) -> None:
 
     try:
         handle = svc.start_episode(snapshot, task.id)
-        agent_root = svc.agent_root(handle)
+        solver_root = svc.solver_root(handle)
         # Captured while the episode is live; ``svc.close()`` cleans
         # the runtime tempdir, so this check has to happen pre-close.
-        assert agent_root.exists()
+        assert solver_root.exists()
     finally:
         svc.close()
 
@@ -818,12 +818,12 @@ def test_episode_each_start_gives_fresh_roots(tmp_path: Path) -> None:
     # never realize a snapshot built by a different pack.
     svc = EpisodeService(WebappPack(), run_root, dashboard=dashboard)
     first = svc.start_episode(snapshot, task.id)
-    first_root = svc.agent_root(first)
+    first_root = svc.solver_root(first)
     marker = first_root / "old.txt"
     marker.write_text("old", encoding="utf-8")
     try:
         second = svc.start_episode(snapshot, task.id)
-        second_root = svc.agent_root(second)
+        second_root = svc.solver_root(second)
         # Both runtimes are live; assert while still active because
         # ``svc.close()`` now cleans up each runtime's tempdir.
         assert second_root.exists()
@@ -885,7 +885,7 @@ def test_restore_failure_does_not_leak_handle(tmp_path: Path) -> None:
             episode_id=ckpt.episode_id,
             snapshot_id=ckpt.snapshot_id,
             task_id=ckpt.task_id,
-            state={"agent_root_snapshot": 42},
+            state={"solver_root_snapshot": 42},
         )
         before = set(svc._episodes)
         with pytest.raises(OpenRangeError):

--- a/tests/test_office_persona.py
+++ b/tests/test_office_persona.py
@@ -121,7 +121,7 @@ def _interface(http_calls: list[str]) -> dict[str, Any]:
         "base_url": "http://test.local",
         "http_get": http_get,
         "http_get_json": http_get_json,
-        "agent_root": "/tmp/fake-agent-root",
+        "solver_root": "/tmp/fake-agent-root",
     }
 
 

--- a/tests/test_trading_episode_smoke.py
+++ b/tests/test_trading_episode_smoke.py
@@ -72,13 +72,13 @@ def test_trading_episode_grades_strategy_and_evolves(tmp_path: Path) -> None:
     svc = EpisodeService(TradingPack(), tmp_path / "runs")
     try:
         handle = svc.start_episode(snap, task.id)
-        agent_root = svc.agent_root(handle)
+        solver_root = svc.solver_root(handle)
         # the realizer handed the agent the price window to study
-        bars = json.loads((agent_root / "bars.json").read_text(encoding="utf-8"))
+        bars = json.loads((solver_root / "bars.json").read_text(encoding="utf-8"))
         assert len(bars) >= 2
         assert "close" in bars[0]
         # scripted "agent": a buy-and-hold strategy
-        (agent_root / "result.json").write_text(
+        (solver_root / "result.json").write_text(
             json.dumps({"strategy": "def decide(history):\n    return 1.0\n"}),
             encoding="utf-8",
         )


### PR DESCRIPTION
## Summary

Disambiguates the overloaded "agent". It meant the *solver's workspace*
(`agent_root`) in one place and the NPC's *tool-using LLM loop* (`AgentBackend`)
in another. This reserves "agent" for the loop **mechanism** and names the
**role** explicitly.

- **`agent_root` → `solver_root`** everywhere: the `RuntimeHandle` property, the
  `surface()`/`collect()` key, the snapshot subdir, `EpisodeService.solver_root`,
  and every consumer + test.
- **`AgentBackend` / `AgentNPC` kept** — they're the tool-using loop mechanism
  (distinct from a raw `LLMBackend`; a solver could use one too), not the solver.
- **`DESIGN.md` gains a Vocabulary section**: builder / solver / NPC are roles;
  `LLMBackend` / `AgentBackend` are mechanisms; "agent" alone is never a role.
  The `CONTRACTS.md`/`DESIGN.md` surface-key docs follow.

Pervasive solver-meaning "agent" prose in pack docstrings / ontology descriptions
is left for a follow-up — the glossary disambiguates it in the meantime.

**Base:** stacked on `feat/trading-pack` (#232) because it renames symbols that
PR introduces; it retargets to `main` once #232 merges.

## Test plan
- [x] 565 pass; mypy `--strict` clean; ruff clean; import boundaries hold
- [x] `PACKS` + NPC entry points still resolve
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
