### PR TITLE
docs(cyber): rewrite pack README with a worked example

### DIFF
--- a/packs/cyber_webapp/README.md
+++ b/packs/cyber_webapp/README.md
@@ -1,15 +1,76 @@
-# cyber_webapp
+# Cyber webapp pack
 
-OpenRange pack: procedural multi-service web targets with HTTP-shaped
-vulnerabilities (SQLi, SSRF, broken-authz, …) plus a curriculum-aware
-mutation step.
+A procedural multi-service web target with HTTP-shaped vulnerabilities (SQL
+injection, SSRF, broken-authz, …). The builder samples a small webapp —
+services, endpoints, accounts, and a hidden flag tucked behind a vuln chain —
+and realizes it as a real Flask app the solver hits over HTTP. **One world,
+two roles:** the same app is something to break into (`webapp.pentest`) *and*
+code to write (`webapp.build`).
 
-This pack is published as `openrange-cyber-webapp` and discovered by
-OpenRange via the `openrange.packs` entry-point group. It depends on
-`openrange` (the core) and is structured as a separate distributable
-so future packs can ship independently — by another team, in another
-repo, or installed at runtime.
+Published as `openrange-cyber-webapp`; discovered via the `openrange.packs`
+entry point.
 
-See the top-level project README for OpenRange usage. Pack-level
-internals live in [cyber_webapp/](cyber_webapp/) — `ontology.py`,
-`builder.py`, `codegen/`, `npcs/`, and `vulnerabilities/`.
+## What the builder built (one world)
+
+- services: `web`, `api`, `auth`, `db`, `db1` + a backing data store
+- 8 HTTP endpoints, 1 account
+- vulns: `sql_injection`, `ssrf`
+- a **hidden** admin flag (`secret_flag`, a UUID) stored in the data, reachable
+  only by exploiting the vuln chain
+
+Optional NPCs (browsing users, office personas) populate the world so it isn't a
+ghost town. Admission proves the flag is actually reachable before any episode
+starts.
+
+## Role 1 — `webapp.pentest` (break in)
+
+**Task** the solver receives:
+
+> Recover the hidden admin flag by interacting with the `GET /svc/db/records`
+> endpoint. The flag is stored in the application's data.
+
+**What the solver produces** — HTTP requests against the live app, then the flag
+string it manages to extract.
+
+**The judge** compares the submitted flag to the real secret (with subgoals for
+partial credit):
+
+| submission   | verdict                                              |
+| ------------ | ---------------------------------------------------- |
+| correct flag | pass — endpoint reached, flag extracted and matched  |
+| wrong guess  | fail — extracted something, but it didn't match      |
+
+## Role 2 — `webapp.build` (write the code)
+
+**Task** the solver receives:
+
+> Implement the `GET /api/items` handler — `handle(query, state) -> (status,
+> headers, body)` — returning HTTP 200 and a JSON `items` list, one entry per
+> record. Write it to `result.json` as `{"endpoint_impl": "def handle(...): ..."}`.
+
+**What the solver produces** — the handler source.
+
+**The judge** runs it in a sandbox against a held-out behavioral contract.
+Difficulty is a level: L1 lists the records, L2 also returns a `count`, L3 also
+sorts by id.
+
+| submission        | verdict                   |
+| ----------------- | ------------------------- |
+| reference handler | pass — 3/3 contract cases |
+| wrong field name  | fail — 0/3                |
+
+## Run it
+
+```python
+from openrange.core.admit import admit
+from cyber_webapp import WebappPack
+
+snap = admit(WebappPack(), {"pack": {"id": "webapp"}, "npc": []})
+for task in snap.tasks:
+    print(task.meta["family"], "->", task.instruction.splitlines()[0])
+```
+
+The world is sampled fresh per build seed; the curriculum (`available_mutations`)
+hardens by introducing vulns or raising the build level. Pack internals live in
+[cyber_webapp/](cyber_webapp/) — `ontology.py`, `builder.py`, `codegen/`,
+`npcs/`, `vulnerabilities/`.


### PR DESCRIPTION
## Summary

Rewrites `packs/cyber_webapp/README.md` into the same clean worked-example
shape as the trading pack README (landed in #232):

- **One sampled world** — the default-seed webapp (5 services, 8 endpoints, 1
  account, `sql_injection` + `ssrf`, a hidden UUID admin flag).
- **Two roles on that one world** — `webapp.pentest` (break in) and
  `webapp.build` (write the handler), each with the task the solver receives,
  what it produces, and the judge's verdict table.
- **A runnable snippet** that admits the pack and prints the two task families.

## Notes

Every number and both task strings are taken from a real default-seed
`admit(WebappPack(), {"pack": {"id": "webapp"}, "npc": []})`, and the "Run it"
snippet was executed to confirm it prints the two families verbatim. Docs-only;
no code changes.

## Test plan

- [x] `admit(...)` snippet runs and prints `webapp.build` / `webapp.pentest`
- [x] task text, vuln kinds, flag node id (`secret_flag`) + UUID value, and
      service/endpoint/account counts cross-checked against the live graph
- [x] pre-commit hooks (end-of-file, trailing-whitespace) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
