### PR TITLE
test(llm): de-flake codex backend tests (drop timeout=5 override)

### DIFF
--- a/tests/test_llm_and_dashboard.py
+++ b/tests/test_llm_and_dashboard.py
@@ -173,7 +173,7 @@ def test_codex_backend_runs_local_command_without_schema(tmp_path: Path) -> None
         print(sys.stdin.read().strip().upper())
         """,
     )
-    result = CodexBackend(command=command, model="local", timeout=5).complete(
+    result = CodexBackend(command=command, model="local").complete(
         LLMRequest("hello", system="system"),
     )
 
@@ -192,14 +192,14 @@ print(sys.stdin.read())
 
 def test_codex_backend_omits_model_flag_when_none(tmp_path: Path) -> None:
     command = executable(tmp_path, "argv_dumper.py", _ARGV_DUMPER)
-    CodexBackend(command=command, model=None, timeout=5).complete(LLMRequest("hi"))
+    CodexBackend(command=command, model=None).complete(LLMRequest("hi"))
     argv = json.loads((tmp_path / "argv.json").read_text(encoding="utf-8"))
     assert "--model" not in argv
 
 
 def test_codex_backend_passes_model_flag_when_set(tmp_path: Path) -> None:
     command = executable(tmp_path, "argv_dumper.py", _ARGV_DUMPER)
-    CodexBackend(command=command, model="gpt-x", timeout=5).complete(LLMRequest("hi"))
+    CodexBackend(command=command, model="gpt-x").complete(LLMRequest("hi"))
     argv = json.loads((tmp_path / "argv.json").read_text(encoding="utf-8"))
     assert "--model" in argv
     assert argv[argv.index("--model") + 1] == "gpt-x"
@@ -226,7 +226,7 @@ def test_codex_backend_reads_schema_output_from_local_command(
         print("ignored stdout")
         """,
     )
-    result = CodexBackend(command=command, model="local", timeout=5).complete(
+    result = CodexBackend(command=command, model="local").complete(
         LLMRequest("return json", json_schema={"type": "object"}),
     )
 
@@ -262,15 +262,15 @@ def test_codex_backend_reports_process_failures(tmp_path: Path) -> None:
     )
 
     with pytest.raises(LLMBackendError, match="boom") as stderr_error:
-        CodexBackend(command=stderr_command, model="local", timeout=5).complete(
+        CodexBackend(command=stderr_command, model="local").complete(
             LLMRequest("hello"),
         )
     with pytest.raises(LLMBackendError, match="bad stdout"):
-        CodexBackend(command=stdout_command, model="local", timeout=5).complete(
+        CodexBackend(command=stdout_command, model="local").complete(
             LLMRequest("hello"),
         )
     with pytest.raises(LLMBackendError, match="no output"):
-        CodexBackend(command=silent_command, model="local", timeout=5).complete(
+        CodexBackend(command=silent_command, model="local").complete(
             LLMRequest("hello"),
         )
 
@@ -289,7 +289,7 @@ def test_codex_backend_requires_schema_output_file(tmp_path: Path) -> None:
     )
 
     with pytest.raises(LLMBackendError, match="did not write"):
-        CodexBackend(command=command, model="local", timeout=5).complete(
+        CodexBackend(command=command, model="local").complete(
             LLMRequest("return json", json_schema={"type": "object"}),
         )
 


### PR DESCRIPTION
## Summary
De-flakes the codex backend tests. The happy-path `CodexBackend(...).complete()` tests run a fast **local stub** script but overrode `CodexBackend`'s sensible **120 s default** down to `timeout=5`. Under host load (a busy CI runner, or a dev box running several agents at once), cold subprocess / interpreter startup occasionally exceeds 5 s → `LLMBackendError("codex timed out after 5 seconds")` → the test fails, then passes on retry.

## Root cause + fix
The tight override **is** the root cause — these tests don't exercise timeout behaviour, so there's no reason to constrain the wall clock. Remove the `timeout=5` override from the 8 happy-path `.complete()` calls so they use the 120 s default. The deliberate timeout test (`run_codex` with a 5 s sleeper + `timeout=0.01`) is **left intact**, so the `TimeoutExpired` branch stays covered.

Test-only, **coverage-neutral** — it removes a kwarg, touches no source branch.

## Verification (impacted tests only, per `.rules`)
- `ruff` + `mypy` — clean on the changed file.
- `pytest tests/test_llm_and_dashboard.py tests/test_agent_backend.py` — **32 passed, 2 skipped**.
- `run_codex`'s timeout / OS-error branches remain covered by the untouched deliberate test.

Branches off `main`, independent of #245 / #249. Touches the codex backend introduced in #225 / #231; closes no issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
