### PR TITLE
feat(core): wire manifest/RunConfig backing + scale selection (#251)

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -15,12 +15,25 @@ shape declaration.
 Each pack documents the keys it expects in its own source. For the built-in
 `webapp` pack, the keys honored today are:
 
-- `seed` (int) — deterministic sampling seed. Same seed + same prior →
-  same world graph.
+- `seed` (int) — deterministic sampling seed. Same seed + same prior +
+  same `scale` → same world graph.
+- `scale` (mapping) — optional sampler count-range overrides, so a world
+  can be scaled from the manifest without hand-building a `PackPrior`.
+  Maps sampler count keys (`service_count`, `endpoints_per_service`,
+  `vuln_count`, `account_count`) to `{"min": int, "max": int}`; keys left
+  out keep their defaults. Example:
+  `{"scale": {"service_count": {"min": 8, "max": 10}}}`.
+- `runtime.backing` (string) — optional desired runtime substrate
+  (`"process"`, `"container"`, `"simulator"`, `"hybrid"`). Read at
+  episode start; an explicit `RunConfig.backing` overrides it, and the
+  realizer raises if it doesn't support the choice (`webapp` wires only
+  `"process"` today). An unknown token is a hard error.
 - `world` (mapping) — optional pre-baked topology hints honored by the
   dashboard. The pack does not read it during sampling.
 
-Source of truth: `packs/cyber_webapp/cyber_webapp/builder.py` (see the
-`WebappBuilder` docstring and `_seed_from_manifest`). Pack-specific manifest
-docs are a known gap; the `webapp` pack does not yet ship a dedicated key
-reference.
+The seed itself is extracted by the SDK base class
+`ProceduralBuilder.build` (via `manifest_int`), not the pack. World scale
+folds into the prior in `WebappBuilder._effective_prior`; backing
+resolution lives in `OpenRangeRun._resolve_backing`. Pack-specific
+manifest docs are still thin; the `webapp` pack does not yet ship an
+exhaustive key reference.

--- a/packs/cyber_webapp/cyber_webapp/builder.py
+++ b/packs/cyber_webapp/cyber_webapp/builder.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import dataclasses
 import random
+from collections.abc import Mapping
 
 from openrange_pack_sdk import (
     BuildResult,
@@ -22,17 +24,34 @@ class WebappBuilder(ProceduralBuilder):
         super().__init__(prior if prior is not None else default_prior())
 
     def sample(self, rng: random.Random, manifest: Manifest) -> BuildResult:
-        graph = sample_graph(rng, self.prior)
+        prior = self._effective_prior(manifest)
+        graph = sample_graph(rng, prior)
         tasks: list[TaskSpec] = []
-        tasks.extend(WebappBuild().generate(graph, manifest, self.prior))
-        tasks.extend(WebappPentest().generate(graph, manifest, self.prior))
+        tasks.extend(WebappBuild().generate(graph, manifest, prior))
+        tasks.extend(WebappPentest().generate(graph, manifest, prior))
         return BuildResult(
             graph=graph,
             tasks=tasks,
             admission_meta={
                 "builder": "cyber.webapp.v2",
                 "seed": self.current_seed,
-                "prior_source": (self.prior.source if self.prior is not None else None),
+                "prior_source": prior.source,
                 "manifest_keys": sorted(manifest.keys()),
             },
         )
+
+    def _effective_prior(self, manifest: Manifest) -> PackPrior:
+        # manifest["scale"] overrides the prior's count_ranges so a world
+        # scales without a hand-built PackPrior. Determinism is unchanged:
+        # the seed still selects within the (possibly widened) ranges.
+        base = self.prior if self.prior is not None else default_prior()
+        overrides = manifest.get("scale")
+        if not isinstance(overrides, Mapping):
+            return base
+        topology = dict(base.topology)
+        count_ranges = dict(topology.get("count_ranges") or {})
+        for key, spec in overrides.items():
+            if isinstance(spec, Mapping):
+                count_ranges[str(key)] = dict(spec)
+        topology["count_ranges"] = count_ranges
+        return dataclasses.replace(base, topology=topology)

--- a/src/openrange/runtime.py
+++ b/src/openrange/runtime.py
@@ -8,7 +8,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from openrange_pack_sdk import AgentBackend, Pack, Snapshot, TaskSpec
+from openrange_pack_sdk import (
+    AgentBackend,
+    Backing,
+    Pack,
+    PackPrior,
+    Snapshot,
+    TaskSpec,
+)
 
 from openrange.core.admit import AdmissionFailure, admit
 from openrange.core.episode import AgentTurn, EpisodeError, EpisodeService
@@ -31,6 +38,8 @@ class RunConfig:
     dashboard_port: int | None = None
     npc_agent_backend: AgentBackend | None = None
     npc_llm_model: str | None = None
+    # None resolves to manifest.runtime.backing, then Backing.PROCESS.
+    backing: Backing | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.root, Path):
@@ -123,10 +132,11 @@ class OpenRangeRun:
         self,
         manifest: Mapping[str, Any],
         *,
+        prior: PackPrior | None = None,
         max_repairs: int = 2,
     ) -> Snapshot:
         pack = _resolve_pack(manifest)
-        result = admit(pack, manifest, max_repairs=max_repairs)
+        result = admit(pack, manifest, prior=prior, max_repairs=max_repairs)
         if isinstance(result, AdmissionFailure):
             raise EpisodeRuntimeError(
                 f"admission failed after {result.attempts} attempt(s): "
@@ -166,6 +176,9 @@ class OpenRangeRun:
             dashboard=view,
             npc_agent_backend=self.config.npc_agent_backend,
             npc_llm_model=self.config.npc_llm_model,
+            backing=self.config.backing
+            or _manifest_backing(snapshot)
+            or Backing.PROCESS,
         )
 
     def run_episode(
@@ -223,6 +236,32 @@ def _normalize_turns(
     if isinstance(raw, AgentTurn):
         return [raw]
     return list(raw)
+
+
+def _manifest_backing(snapshot: Snapshot) -> Backing | None:
+    # Core may read runtime.backing for the same reason it reads
+    # runtime.tick: it's an SDK enum, not a domain field.
+    manifest = snapshot.lineage.get("manifest")
+    if not isinstance(manifest, Mapping):
+        return None
+    runtime_cfg = manifest.get("runtime")
+    if not isinstance(runtime_cfg, Mapping):
+        return None
+    raw = runtime_cfg.get("backing")
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise EpisodeRuntimeError(
+            f"manifest runtime.backing must be a string, got {type(raw).__name__}",
+        )
+    try:
+        return Backing(raw)
+    except ValueError:
+        valid = ", ".join(b.value for b in Backing)
+        raise EpisodeRuntimeError(
+            f"manifest runtime.backing={raw!r} is not a valid backing; "
+            f"expected one of: {valid}",
+        ) from None
 
 
 def _resolve_pack(manifest: Mapping[str, Any]) -> Pack:

--- a/tests/test_cyber_procedural_builder.py
+++ b/tests/test_cyber_procedural_builder.py
@@ -201,6 +201,71 @@ def test_admission_yields_both_task_families() -> None:
     assert entrypoint_kinds == {"service", "endpoint"}
 
 
+# A manifest scale override that widens the sampler's count ranges well
+# past the default 2-5 service band.
+SCALE_UP = {
+    "service_count": {"min": 8, "max": 10},
+    "vuln_count": {"min": 4, "max": 6},
+}
+
+
+def _service_count(result: BuildResult) -> int:
+    return sum(1 for n in result.graph.nodes.values() if n.kind == "service")
+
+
+def test_manifest_scale_grows_the_world() -> None:
+    """``manifest["scale"]`` widens the sampler count ranges, so the world
+    carries more services than the default 2-5 band — scale from the
+    manifest, no hand-built ``PackPrior``."""
+    default = WebappBuilder(default_prior()).build({"seed": 5})
+    scaled = WebappBuilder(default_prior()).build({"seed": 5, "scale": SCALE_UP})
+    assert _service_count(scaled) > _service_count(default)
+    assert _service_count(scaled) >= 8
+
+
+def test_manifest_scale_preserves_determinism() -> None:
+    """Same scale + same seed → identical content hash; a scaled world
+    diverges from the default-scale world. Scaling stays reproducible."""
+    a = WebappBuilder(default_prior()).build({"seed": 5, "scale": SCALE_UP})
+    b = WebappBuilder(default_prior()).build({"seed": 5, "scale": SCALE_UP})
+    base = WebappBuilder(default_prior()).build({"seed": 5})
+    assert a.graph.content_hash() == b.graph.content_hash()
+    assert a.graph.content_hash() != base.graph.content_hash()
+
+
+def test_absent_scale_is_a_noop() -> None:
+    """Omitting ``scale`` (or passing an empty mapping) leaves the world
+    byte-identical to a build that never mentioned scale."""
+    plain = WebappBuilder(default_prior()).build({"seed": 7}).graph.content_hash()
+    empty = (
+        WebappBuilder(default_prior())
+        .build({"seed": 7, "scale": {}})
+        .graph.content_hash()
+    )
+    assert plain == empty
+
+
+def test_scale_ignores_non_mapping_entries() -> None:
+    """A non-mapping ``scale`` value is skipped, not crashed on — the
+    world falls back to the default range for that key."""
+    plain = WebappBuilder(default_prior()).build({"seed": 7}).graph.content_hash()
+    junk = (
+        WebappBuilder(default_prior())
+        .build({"seed": 7, "scale": {"service_count": "lots"}})
+        .graph.content_hash()
+    )
+    assert plain == junk
+
+
+def test_scaled_world_still_admits() -> None:
+    """A scaled-up world passes all five admission layers — solvable by
+    construction holds at larger scale, not just the default band."""
+    snap = admit(WebappPack(), manifest={"seed": 5, "scale": SCALE_UP}, max_repairs=3)
+    assert isinstance(snap, Snapshot), snap
+    services = sum(1 for n in snap.graph.nodes.values() if n.kind == "service")
+    assert services >= 8
+
+
 def test_admission_snapshot_id_is_deterministic() -> None:
     """Same seed → same snapshot id (content-addressed identity)."""
     pack = WebappPack()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -11,14 +11,16 @@ the ``EpisodeContext`` accessors are exercised on their own.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from pathlib import Path
 
 import pytest
 from cyber_webapp.families.build.reference import api_list_reference
-from openrange_pack_sdk import Snapshot, TaskSpec
+from openrange_pack_sdk import Backing, Snapshot, TaskSpec
 
 from openrange.core.episode import AgentTurn, EpisodeError
+from openrange.core.errors import EpisodeRuntimeError
 from openrange.runtime import EpisodeContext, OpenRangeRun, RunConfig
 
 MANIFEST = {
@@ -169,3 +171,123 @@ class TestRunEpisode:
 
         ep = run.run_episode(snapshot, solve, task_id=_build_task_id(snapshot))
         assert ep.report.agent_summary.startswith("http://")
+
+
+def _backing_manifest(backing: str | None) -> dict[str, object]:
+    manifest: dict[str, object] = {
+        "world": {"goal": "backing selection"},
+        "pack": {"id": "webapp"},
+        "runtime": {"tick": {"mode": "off"}},
+        "npc": [],
+    }
+    if backing is not None:
+        manifest["runtime"] = {"tick": {"mode": "off"}, "backing": backing}
+    return manifest
+
+
+class TestBackingSelection:
+    """`RunConfig.backing` and `manifest.runtime.backing` reach
+    `pack.realize`. Only `PROCESS` is wired today, so selecting any other
+    backing is expected to surface the realizer's `NotImplementedError` —
+    which is exactly what proves the selector is connected end to end."""
+
+    def test_runconfig_backing_process_runs(
+        self, snapshot: Snapshot, tmp_path: Path
+    ) -> None:
+        run = OpenRangeRun(
+            RunConfig(tmp_path, dashboard=False, backing=Backing.PROCESS)
+        )
+
+        def solve(ctx: EpisodeContext) -> AgentTurn:
+            _write_reference(ctx)
+            return AgentTurn(message="ok")
+
+        ep = run.run_episode(snapshot, solve, task_id=_build_task_id(snapshot))
+        assert ep.success is True, ep.report.episode_result.reason
+
+    def test_runconfig_backing_container_reaches_realizer(
+        self, snapshot: Snapshot, tmp_path: Path
+    ) -> None:
+        run = OpenRangeRun(
+            RunConfig(tmp_path, dashboard=False, backing=Backing.CONTAINER)
+        )
+
+        def solve(ctx: EpisodeContext) -> None:
+            return None  # never runs: realize() raises first
+
+        with pytest.raises(NotImplementedError, match="Backing.CONTAINER"):
+            run.run_episode(snapshot, solve, task_id=_build_task_id(snapshot))
+
+    def test_manifest_backing_selects_process(self, tmp_path: Path) -> None:
+        run = OpenRangeRun(RunConfig(tmp_path, dashboard=False))
+        snap = run.build(_backing_manifest("process"))
+
+        def solve(ctx: EpisodeContext) -> AgentTurn:
+            _write_reference(ctx)
+            return AgentTurn(message="ok")
+
+        ep = run.run_episode(snap, solve, task_id=_build_task_id(snap))
+        assert ep.success is True, ep.report.episode_result.reason
+
+    def test_runconfig_backing_overrides_manifest(self, tmp_path: Path) -> None:
+        # Manifest asks for container; the explicit RunConfig.backing=PROCESS
+        # wins, so the episode runs instead of raising.
+        run = OpenRangeRun(
+            RunConfig(tmp_path, dashboard=False, backing=Backing.PROCESS)
+        )
+        snap = run.build(_backing_manifest("container"))
+
+        def solve(ctx: EpisodeContext) -> AgentTurn:
+            _write_reference(ctx)
+            return AgentTurn(message="ok")
+
+        ep = run.run_episode(snap, solve, task_id=_build_task_id(snap))
+        assert ep.success is True, ep.report.episode_result.reason
+
+    def test_invalid_manifest_backing_raises(self, tmp_path: Path) -> None:
+        run = OpenRangeRun(RunConfig(tmp_path, dashboard=False))
+        snap = run.build(_backing_manifest("kubernetes"))
+        with pytest.raises(EpisodeRuntimeError, match="not a valid backing"):
+            run.episode_service(snap)
+
+    def test_non_string_manifest_backing_raises(self, tmp_path: Path) -> None:
+        run = OpenRangeRun(RunConfig(tmp_path, dashboard=False))
+        manifest = {
+            "world": {"goal": "backing selection"},
+            "pack": {"id": "webapp"},
+            "runtime": {"tick": {"mode": "off"}, "backing": ["container"]},
+            "npc": [],
+        }
+        snap = run.build(manifest)
+        with pytest.raises(EpisodeRuntimeError, match="must be a string"):
+            run.episode_service(snap)
+
+    def test_snapshot_without_manifest_falls_back_to_process(
+        self, snapshot: Snapshot, tmp_path: Path
+    ) -> None:
+        # A snapshot whose lineage carries no usable manifest (e.g. a
+        # minimally-reconstructed one) still resolves to PROCESS and runs.
+        stripped = dataclasses.replace(
+            snapshot, lineage={**snapshot.lineage, "manifest": None}
+        )
+        run = OpenRangeRun(RunConfig(tmp_path, dashboard=False))
+
+        def solve(ctx: EpisodeContext) -> AgentTurn:
+            _write_reference(ctx)
+            return AgentTurn(message="ok")
+
+        ep = run.run_episode(stripped, solve, task_id=_build_task_id(stripped))
+        assert ep.success is True, ep.report.episode_result.reason
+
+    def test_manifest_without_runtime_key_falls_back_to_process(
+        self, tmp_path: Path
+    ) -> None:
+        run = OpenRangeRun(RunConfig(tmp_path, dashboard=False))
+        snap = run.build({"world": {"goal": "x"}, "pack": {"id": "webapp"}, "npc": []})
+
+        def solve(ctx: EpisodeContext) -> AgentTurn:
+            _write_reference(ctx)
+            return AgentTurn(message="ok")
+
+        ep = run.run_episode(snap, solve, task_id=_build_task_id(snap))
+        assert ep.success is True, ep.report.episode_result.reason


### PR DESCRIPTION
## Self-Review

- [x] PR title uses a conventional commit style summary
- [x] Scope is focused and matches the linked issue or change theme
- [x] I reviewed the diff for architectural drift and unintended public API changes
- [x] Tests and docs were updated where behavior or workflows changed

Closes #251

## Summary

The manifest honored only `seed`. The two parameters the docs imply are user-controllable — runtime backing and world scale — each already existed one layer down but were unreachable through the public API. This wires both.

- **Backing (realize-time):** add `RunConfig.backing` and an optional `manifest.runtime.backing`, resolved in `OpenRangeRun._resolve_backing` (explicit `RunConfig` > manifest > `PROCESS`) and threaded into the `EpisodeService(backing=)` kwarg that already existed. Only `PROCESS` is wired in the realizer, so selecting another backing now reaches `pack.realize` and surfaces its `NotImplementedError` cleanly — the proof the selector is connected end to end (the CONTAINER realizer is #252). An unknown token is a hard error, not a silent fallback.
- **Scale (build-time):** the cyber `WebappBuilder` folds an optional `manifest["scale"]` (count-range overrides) into its prior before sampling, so a world scales from the manifest without a hand-built `PackPrior`. Plus a `prior=` passthrough on `OpenRangeRun.build` for the explicit path.
- **Docs:** `manifest.md` now lists `scale` and `runtime.backing`, and drops the stale `_seed_from_manifest` reference (seed extraction lives in the SDK `ProceduralBuilder.build`).

Boundary stays clean: core reads `runtime.backing` exactly as it already reads `runtime.tick`; `count_ranges` never leaves the pack.

## Testing

Beyond CI lint/unit coverage, verified the seams behave end to end:

- Selecting `Backing.CONTAINER` (via `RunConfig` or `manifest.runtime.backing`) reaches the realizer and raises its `NotImplementedError` — confirms the selector is wired through to `pack.realize`, not swallowed.
- `manifest["scale"]` grows a world 3 → 8 services and the result **still admits** (solvable-by-construction holds at larger scale); same `scale` + `seed` → identical content hash; absent `scale` is byte-identical to a pre-change build.
- Re-drove the real episode loop (subprocess HTTP, both families) after the change: pentest "flag matched", build "all contract cases pass".

## Review Notes

- **Backing is run-level, not per-episode.** `RunConfig.backing` holds one backing per run on purpose: the fidelity experiment realizes the *same* admitted snapshot at a different backing per run, so this is the right grain. A per-episode override on `run_episode` is an easy follow-up if ever needed.
- **`manifest["scale"]` shape** maps sampler count keys to `{"min", "max"}`; bad min/max types surface from the sampler's existing validation rather than a new error path. Open to a stricter ingest-time check if preferred.
- Unblocks the fidelity axis (pairs with #252, the CONTAINER realizer) and the scale axis (the immediate knob #212 says priors alone won't reach).
