### PR TITLE
feat(eval): benchmark eval-runner seam with gym-identical surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Start with:
 - [Roadmap](ROADMAP.md) — direction, what we're working on, where contributors can help
 - [API lifecycle](docs/api.md)
 - [Dashboard](docs/dashboard.md)
+- [Benchmarks](docs/benchmarks.md) — external eval targets vs. the gym
 - [Contributing](CONTRIBUTING.md)
 
 ## Contributing

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,71 @@
+# Benchmarks
+
+OpenRange is the **gym** — synthesized, admission-checked, evolvable worlds you
+*train* on. A **benchmark** (XBOW, CVE-Bench, Cybench, …) is the opposite: a
+fixed external target you *evaluate transfer against*. The two never mix.
+
+| | gym world | benchmark |
+| --- | --- | --- |
+| built by | a pack builder, sampled fresh | shipped fixed, externally |
+| goes through | build → admit → evolve | none of it |
+| graded by | the pack's `TaskFamily.check_success` | the benchmark's own scorer |
+| you may | train on it | only evaluate — never train, never evolve |
+
+Putting a benchmark through admission would be a category error (you don't prove
+a fixed eval target "solvable by construction"), and letting a builder near one
+is contamination. So benchmarks run *outside* the build/admit/evolve pipeline,
+through a thin runner.
+
+## The one thing they share: the solver surface
+
+The whole point of measuring sim-to-real transfer is that a gap reflects
+*capability*, not a surface mismatch. So `run_benchmark` hands the solver the
+**same `EpisodeContext`** a gym episode does — a `base_url`, an editable `root`,
+and a `result.json` submission. One solver runs against both; the only thing
+that changes is what sits behind the URL.
+
+```python
+from openrange import run_benchmark
+
+result = run_benchmark(challenge, solver, root="runs/xbow-001")
+# result is an EpisodeResult — the same type a gym episode returns
+```
+
+## Writing an adapter
+
+A benchmark is anything satisfying the `Benchmark` protocol
+(`src/openrange/benchmark.py`):
+
+```python
+class Benchmark(Protocol):
+    instruction: str
+    def boot(self) -> Mapping[str, Any]: ...   # start target, return {"base_url": ...}
+    def score(self, surface, submission) -> EpisodeResult: ...
+    def stop(self) -> None: ...
+```
+
+`boot` starts the real challenge and returns its surface; the runner adds
+`solver_root`. `score` grades by the benchmark's own truth — a flag compared to
+the one it injected, or an exploit effect checked against `surface["base_url"]`.
+`stop` tears it down (called even after a failed boot).
+
+The differences between benchmarks live entirely in the adapter: XBOW compares
+an injected flag; CVE-Bench checks an exploit effect; a CTF compares a flag
+string. The runner stays benchmark-agnostic.
+
+## Status
+
+- **Process-backed targets work today.** A benchmark whose `boot` starts a local
+  HTTP service needs no extra infrastructure (see `tests/test_benchmark.py` for a
+  real one).
+- **Containerized targets are the next step.** XBOW, CVE-Bench, and PACEbench
+  ship as Docker challenges, so their adapters' `boot` spins up a container —
+  the same container runtime the high-fidelity gym backing needs
+  ([#252](https://github.com/vecna-labs/open-range/issues/252)). Build that once
+  and both ride on it.
+
+## Integrity
+
+Keep benchmarks out of any builder or training set; respect each benchmark's
+canary string; prefer cleaned, hint-free forks where they exist (e.g.
+`KeygraphHQ/xbow-validation-benchmarks`).

--- a/src/openrange/__init__.py
+++ b/src/openrange/__init__.py
@@ -21,6 +21,7 @@ from openrange.agent_backend import (
     CodexAgentBackend,
     StrandsAgentBackend,
 )
+from openrange.benchmark import Benchmark, run_benchmark
 from openrange.core import (
     PACKS,
     ActorTurn,
@@ -82,6 +83,7 @@ __all__ = [
     "AgentTurn",
     "AttrSpec",
     "AttrType",
+    "Benchmark",
     "CodexAgentBackend",
     "CodexBackend",
     "CurriculumPolicy",
@@ -129,6 +131,7 @@ __all__ = [
     "direction_from_reports",
     "episode_reward",
     "episode_trajectory",
+    "run_benchmark",
     "snapshot_to_dict",
     "to_jsonl",
     "validate",

--- a/src/openrange/benchmark.py
+++ b/src/openrange/benchmark.py
@@ -1,0 +1,98 @@
+"""Run a solver against an external benchmark with a gym-identical surface.
+
+A benchmark (XBOW, CVE-Bench, Cybench, ...) is a fixed eval target, not a gym
+world: it is never built, admitted, or evolved. ``run_benchmark`` boots the
+target, hands the same ``Solver`` the same ``EpisodeContext`` a gym episode
+would, and scores the submission with the benchmark's own scorer. Sharing the
+solver surface is the point — a transfer gap then reflects capability, not a
+surface mismatch between training and evaluation.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Protocol
+
+from openrange_pack_sdk import EpisodeResult, TaskSpec
+
+from openrange.runtime import EpisodeContext, Solver
+
+
+class Benchmark(Protocol):
+    """An external eval target. The adapter owns booting the real challenge
+    and scoring it; OpenRange never admits, snapshots, or evolves it.
+
+    Implementations exist per benchmark — a containerized XBOW challenge, a
+    CVE-Bench app, a Cybench task — but all expose this one shape, so the
+    runner stays benchmark-agnostic.
+    """
+
+    #: What the solver is asked to do, in the solver's own words.
+    instruction: str
+
+    def boot(self) -> Mapping[str, Any]:
+        """Start the target and return its solver-facing surface, including at
+        least a ``base_url``. The runner adds ``solver_root``. Must clean up
+        after itself on failure; ``stop`` is still called either way."""
+        ...
+
+    def score(
+        self,
+        surface: Mapping[str, Any],
+        submission: Mapping[str, Any],
+    ) -> EpisodeResult:
+        """Grade by the benchmark's own truth — a flag compared to the one it
+        injected, an exploit effect checked against ``surface["base_url"]``,
+        whatever the benchmark defines. Returns the same ``EpisodeResult`` a
+        gym episode does, so gym and benchmark outcomes are handled alike."""
+        ...
+
+    def stop(self) -> None:
+        """Tear the target down. Called once per run, including after a failed
+        boot, so it must tolerate a partial start."""
+        ...
+
+
+def run_benchmark(
+    benchmark: Benchmark,
+    solver: Solver,
+    *,
+    root: str | Path,
+) -> EpisodeResult:
+    """Run ``solver`` once against ``benchmark`` and return the benchmark's score.
+
+    The solver is handed the same ``EpisodeContext`` (``base_url``, ``root``,
+    a ``result.json`` submission) it gets from a gym episode, so the only thing
+    that differs between training and evaluation is what sits behind the URL.
+    """
+    workspace = Path(root)
+    workspace.mkdir(parents=True, exist_ok=True)
+    try:
+        surface = {**benchmark.boot(), "solver_root": str(workspace)}
+        task = _benchmark_task(benchmark.instruction)
+        solver(EpisodeContext(task=task, surface=surface))
+        return benchmark.score(surface, _read_submission(workspace))
+    finally:
+        benchmark.stop()
+
+
+def _benchmark_task(instruction: str) -> TaskSpec:
+    return TaskSpec(
+        id="benchmark",
+        instruction=instruction,
+        entrypoints=(),
+        goal_nodes=(),
+        feasibility_check="",
+        success_check="",
+    )
+
+
+def _read_submission(workspace: Path) -> Mapping[str, Any]:
+    result = workspace / "result.json"
+    if not result.exists():
+        return {}
+    parsed: Any = json.loads(result.read_text(encoding="utf-8"))
+    # A solver that writes a non-object result.json submitted nothing usable.
+    return parsed if isinstance(parsed, Mapping) else {}

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,158 @@
+"""Benchmark eval-runner: ``run_benchmark`` drives a solver against an external
+target with the same surface a gym episode exposes (§6.4 harness parity).
+
+The target here is a real process-backed web challenge — a live ``HTTPServer``
+serving an injected flag, scored by comparing the submitted flag. It stands in
+for a containerized XBOW challenge: same solver surface, cheaper backing. No
+admission, snapshot, or TaskFamily is involved — the benchmark owns its own
+truth.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from collections.abc import Mapping
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from threading import Thread
+from typing import Any
+
+import pytest
+from openrange_pack_sdk import EpisodeResult
+
+from openrange.benchmark import run_benchmark
+from openrange.runtime import EpisodeContext
+
+
+class _LocalFlagBenchmark:
+    """A real web-exploit target: serves an injected flag at ``GET /secret``
+    and scores the submitted flag. XBOW-shaped, process-backed."""
+
+    instruction = "Recover the flag from GET /secret and submit it as result.json."
+
+    def __init__(self, flag: str) -> None:
+        self._flag = flag
+        self._server: HTTPServer | None = None
+        self._thread: Thread | None = None
+        self.stopped = False
+
+    def boot(self) -> Mapping[str, Any]:
+        flag = self._flag
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                body = flag.encode() if self.path == "/secret" else b"not found"
+                self.send_response(200 if self.path == "/secret" else 404)
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_: Any) -> None:
+                pass
+
+        self._server = HTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        port = self._server.server_address[1]
+        return {"base_url": f"http://127.0.0.1:{port}"}
+
+    def score(
+        self, surface: Mapping[str, Any], submission: Mapping[str, Any]
+    ) -> EpisodeResult:
+        ok = submission.get("flag") == self._flag
+        return EpisodeResult(
+            success=ok,
+            subgoals={"matched_flag": ok},
+            reason="flag matched" if ok else "flag mismatch",
+        )
+
+    def stop(self) -> None:
+        self.stopped = True
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+
+def _fetch(url: str) -> str:
+    text: str = urllib.request.urlopen(url, timeout=5).read().decode()
+    return text
+
+
+def test_solver_recovers_flag_scores_success(tmp_path: Path) -> None:
+    bench = _LocalFlagBenchmark("FLAG{recovered}")
+
+    def solve(ctx: EpisodeContext) -> None:
+        flag = _fetch(ctx.base_url + "/secret")
+        (ctx.root / "result.json").write_text(json.dumps({"flag": flag}))
+
+    result = run_benchmark(bench, solve, root=tmp_path)
+    assert result.success is True
+    assert result.reason == "flag matched"
+    assert bench.stopped is True
+
+
+def test_wrong_flag_scores_failure(tmp_path: Path) -> None:
+    bench = _LocalFlagBenchmark("FLAG{real}")
+
+    def solve(ctx: EpisodeContext) -> None:
+        (ctx.root / "result.json").write_text(json.dumps({"flag": "FLAG{guess}"}))
+
+    result = run_benchmark(bench, solve, root=tmp_path)
+    assert result.success is False
+    assert bench.stopped is True
+
+
+def test_no_submission_scores_failure(tmp_path: Path) -> None:
+    bench = _LocalFlagBenchmark("FLAG{unsubmitted}")
+
+    def solve(ctx: EpisodeContext) -> None:
+        return None  # writes no result.json
+
+    result = run_benchmark(bench, solve, root=tmp_path)
+    assert result.success is False
+    assert bench.stopped is True
+
+
+def test_non_object_submission_scores_failure(tmp_path: Path) -> None:
+    bench = _LocalFlagBenchmark("FLAG{x}")
+
+    def solve(ctx: EpisodeContext) -> None:
+        (ctx.root / "result.json").write_text(json.dumps(["not", "an", "object"]))
+
+    result = run_benchmark(bench, solve, root=tmp_path)
+    assert result.success is False
+    assert bench.stopped is True
+
+
+def test_solver_exception_propagates_and_target_stops(tmp_path: Path) -> None:
+    bench = _LocalFlagBenchmark("FLAG{x}")
+
+    class SolverBoom(RuntimeError):
+        pass
+
+    def solve(ctx: EpisodeContext) -> None:
+        raise SolverBoom("solver failed")
+
+    with pytest.raises(SolverBoom, match="solver failed"):
+        run_benchmark(bench, solve, root=tmp_path)
+    assert bench.stopped is True  # finally tore the target down
+
+
+def test_surface_parity_with_gym_episode(tmp_path: Path) -> None:
+    # The solver gets the *same* EpisodeContext type a gym episode hands it,
+    # with a working base_url and an editable root — the §6.4 parity that lets
+    # one solver run against both training worlds and eval benchmarks.
+    seen: dict[str, Any] = {}
+    bench = _LocalFlagBenchmark("FLAG{parity}")
+
+    def solve(ctx: EpisodeContext) -> None:
+        seen["type"] = type(ctx)
+        seen["base_url"] = ctx.base_url
+        seen["root"] = ctx.root
+
+    run_benchmark(bench, solve, root=tmp_path)
+    assert seen["type"] is EpisodeContext
+    assert seen["base_url"].startswith("http://127.0.0.1:")
+    assert seen["root"] == tmp_path


### PR DESCRIPTION
## Self-Review

- [x] PR title uses a conventional commit style summary
- [x] Scope is focused and matches the linked issue or change theme
- [x] I reviewed the diff for architectural drift and unintended public API changes
- [x] Tests and docs were updated where behavior or workflows changed

## Summary

OpenRange is the **gym** — synthesized, admission-checked, evolvable worlds you *train* on. A **benchmark** (XBOW, CVE-Bench, Cybench, …) is a fixed external eval target you measure *transfer* against — never built, admitted, snapshotted, or evolved. The two were conceptually conflated; this adds the seam that keeps them separate.

- `openrange.benchmark`: a `Benchmark` protocol (`boot` / `score` / `stop`) and `run_benchmark(benchmark, solver, *, root)`.
- **Surface parity is the point.** The runner hands the solver the *same* `EpisodeContext` a gym episode does — `base_url`, an editable `root`, a `result.json` submission — so one solver runs against both training worlds and eval targets, and a transfer gap reflects capability rather than a surface mismatch (the harness control the sim-to-real study needs).
- Scoring is the benchmark's own truth (a flag it injected; an exploit effect against `base_url`), returned as an `EpisodeResult` — uniform with the gym. No admission, snapshot, or `TaskFamily` is involved.

## Testing

Proven end to end against a **real process-backed web-exploit target** — a live `HTTPServer` serving an injected flag, scored on the submitted flag (`tests/test_benchmark.py`, no mocks). Covers: flag recovered → success; wrong flag, no submission, and non-object `result.json` → failure; solver exception propagates *and* the target is still torn down; and the solver receives the same `EpisodeContext` type a gym episode hands it (the parity check). 100% branch coverage on the new module.

## Review Notes

- **Not a pack.** This is eval-side infrastructure (top-level `openrange.benchmark`, not `core/`); it imports no pack and names no domain. The core/pack boundary check stays clean.
- **Container targets are the documented next step.** XBOW / CVE-Bench / PACEbench ship as Docker challenges, so their adapters' `boot` spins up a container — the same runtime the high-fidelity gym backing needs ([#252](https://github.com/vecna-labs/open-range/issues/252)). Build that once; both ride on it. (Docker wasn't available in this environment, which is why the proof target is process-backed — deliberately the cheap rung, exactly as the gym's `PROCESS` backing is.)
- `docs/benchmarks.md` documents the gym-vs-benchmark boundary and the adapter contract; the benchmark-type survey (web-exploit vs. CTF vs. real-CVE, saturation notes) lives in the discussion, not the repo.
