### PR TITLE
Cyber: real networked SSRF — public pivot to an internal flag, across containers

### DIFF
--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -41,7 +41,7 @@ from typing import Any
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
-from openrange_pack_sdk import EpisodeReportLike, Pack, Snapshot, TaskSpec
+from openrange_pack_sdk import Backing, EpisodeReportLike, Pack, Snapshot, TaskSpec
 
 from openrange.core.curriculum import Direction
 from openrange.core.episode import (
@@ -523,13 +523,16 @@ def _make_factory[E: EpisodeEnv](
     run_root: str | Path,
     reward_fn: Callable[[EpisodeReport], Reward],
     env_cls: type[E],
+    backing: Backing,
 ) -> Callable[[], E]:
     snap_map = {s.snapshot_id: s for s in snapshots}
     base = Path(run_root)
     base.mkdir(parents=True, exist_ok=True)
 
     def factory() -> E:
-        service = EpisodeService(pack, base / f"env-{uuid.uuid4().hex[:8]}")
+        service = EpisodeService(
+            pack, base / f"env-{uuid.uuid4().hex[:8]}", backing=backing
+        )
         return env_cls(service=service, snapshots=snap_map, reward_fn=reward_fn)
 
     return factory
@@ -541,6 +544,7 @@ def make_environment_factory(
     run_root: str | Path,
     *,
     reward_fn: Callable[[EpisodeReport], Reward] = episode_reward,
+    backing: Backing = Backing.PROCESS,
 ) -> Callable[[], OpenRangeEnv]:
     """Build the zero-arg factory TRL calls once per rollout slot.
 
@@ -548,9 +552,10 @@ def make_environment_factory(
     envs in a GRPO generation batch are fully isolated. The factory closes over
     one round's ``snapshots`` (often a single, current world); the curriculum
     re-roots the next round by re-building the dataset + factory against the
-    evolved snapshot.
+    evolved snapshot. ``backing`` picks how each rollout realizes its world —
+    PROCESS by default; CONTAINER trains against the real containerized runtime.
     """
-    return _make_factory(pack, snapshots, run_root, reward_fn, OpenRangeEnv)
+    return _make_factory(pack, snapshots, run_root, reward_fn, OpenRangeEnv, backing)
 
 
 def make_web_environment_factory(
@@ -559,15 +564,18 @@ def make_web_environment_factory(
     run_root: str | Path,
     *,
     reward_fn: Callable[[EpisodeReport], Reward] = episode_reward,
+    backing: Backing = Backing.PROCESS,
 ) -> Callable[[], WebTargetEnv]:
     """Like ``make_environment_factory`` but yields ``WebTargetEnv`` rollouts.
 
     For packs whose episode realizes a live web target (e.g. the cyber webapp
     pack): each rollout boots its own isolated service + HTTP server, and the
     policy acts through ``http_get`` / ``submit``. Pair with
-    ``build_grpo_dataset(..., tool_guide=WEB_TOOL_GUIDE)``.
+    ``build_grpo_dataset(..., tool_guide=WEB_TOOL_GUIDE)``. ``backing`` picks the
+    runtime — PROCESS by default; CONTAINER (incl. the networked multi-service
+    runtime) trains the policy against the real containerized target.
     """
-    return _make_factory(pack, snapshots, run_root, reward_fn, WebTargetEnv)
+    return _make_factory(pack, snapshots, run_root, reward_fn, WebTargetEnv, backing)
 
 
 def env_trajectory(env: EpisodeEnv) -> Trajectory:

--- a/packs/cyber_webapp/DESIGN.md
+++ b/packs/cyber_webapp/DESIGN.md
@@ -625,57 +625,34 @@ runs real RCE (resource/privilege limits, egress, flag-out-of-image) is
 
 The single-container backing (§9) runs the whole world in one container, every service
 mounted by path prefix — so "internal" services are just `/svc/<name>` paths on the same
-server and SSRF is emulated in-process. The graph already carries the topology primitives
-(`service.exposure` public/internal, `host.zone`, `network.isolation`, `connected_to`),
-but the runtime doesn't enforce them. This stage makes network position **real**, on the
-runtime-first track (#252 per-service realizer; the scale generation that feeds it is #212
-/ #235).
+server and SSRF is emulated in-process. This stage makes network position **real**.
 
 **The shape.** A real SSRF world is: a **public** service (the agent's only entry,
 published) holds the SSRF; an **internal** service (no published port, reachable only on
 the container network) holds the flag. The flag is reachable **only** by pivoting — the
-agent exploits SSRF on the public service to make it fetch the internal service's URL,
-which returns the flag. That is genuine networked exploitation, not a path lookup.
+agent exploits the SSRF to make the public service fetch the internal service's URL,
+which returns the flag. Genuine networked exploitation, not a path lookup.
 
-**What it takes (increments):**
+**How it works.**
 
-1. **Per-service realization.** Split the one generated app into one app per `service`
-   node — each carries only its own endpoints and only its own state (the secrets/records/
-   files of the data_stores it is `backed_by`). The flag stays in its owning internal
-   service; the public service never holds it (so it is never in the public image).
-2. **Networked runtime.** One container per service on a real docker network, each named
-   by its service so they resolve each other by name; publish only the public/entrypoint
-   service to the host; surface its `base_url`. The leak signal is **aggregated across all
-   services' request logs** — the internal service detects it leaking its own flag when it
-   serves it (it has the flag in its own guarded set; the public service does not).
-3. **Real SSRF.** The SSRF handler, in networked mode, actually `urlopen`s the target URL
-   across the network; the world is shaped so the SSRF's internal target is the internal
-   flag service. Recovering the flag requires the pivot; the internal service is not
-   directly reachable from the host.
-4. **Cross-backing parity.** The same SSRF world grades identically on `PROCESS`
-   (emulated, one app) and the networked `CONTAINER` — only fidelity changes.
+- **Per-service realization** (`realize_services`) splits the world into one container per
+  `service` node, each carrying only its own endpoints and the state of the data_stores it
+  is `backed_by`. The flag stays in its owning internal service and never enters the public
+  image.
+- **The networked runtime** (`NetworkedContainerWebappRuntime`) runs those containers on a
+  real docker network, each reachable by name, publishing only the public service. The leak
+  signal aggregates across every service's request log, so the internal service detects
+  itself serving its own flag. `WebappPack.realize` routes here when a world is networked-
+  shaped (`_is_networked`).
+- **Generation** re-homes the SSRF onto the public service's endpoint and adds the internal
+  half — a `metadata_credential_leak` endpoint that serves the flag, which the SSRF
+  `enables`. Feasibility and entrypoint selection follow that pivot, so the agent starts at
+  the public endpoint and the internal flag service counts as reachable.
+- **The exploit is real.** Under `OPENRANGE_NETWORKED` the SSRF handler `urlopen`s the
+  internal host across the network. Docker-gated tests recover the flag only through the
+  pivot (a benign fetch and a direct hit on the internal path leak nothing) and confirm the
+  same exploit grades identically on `PROCESS` (in-process read) and the networked
+  `CONTAINER` (real fetch) — only fidelity changes.
 
 Later: real lateral movement / credential reuse, then enterprise scale (#212) + lazy
-realization (#235) on top of this runtime, then k8s (#189).
-
-**Status.** All four increments are **done and proven**:
-
-- **Per-service realization + networked runtime.** `realize_services` splits a world into
-  per-service build contexts (the flag confined to its owning internal service);
-  `NetworkedContainerWebappRuntime` runs one container per service on a real docker network,
-  each reachable by name, publishing only the public service. A docker-gated test shows real
-  network position — the public service is reachable from the host, an internal service only
-  from inside the network.
-- **Networked-shaped generation.** An SSRF world is now networked by construction: the
-  sampler re-homes the SSRF onto the public service's endpoint and adds the internal half on
-  the flag's own service — a `metadata_credential_leak` endpoint that serves the flag, which
-  the SSRF `enables`. Feasibility and entrypoint selection follow that pivot, so the flag-
-  bearing internal service counts as reachable and the agent starts at the public endpoint.
-  `WebappPack.realize` routes these worlds to the networked runtime (`_is_networked`).
-- **Real cross-container SSRF.** Under `OPENRANGE_NETWORKED` the SSRF handler actually
-  `urlopen`s the internal host over the network. A docker-gated test recovers the flag only
-  through the pivot — a benign fetch and a direct hit on the internal path both leak nothing,
-  and the internal service is never reachable from the host.
-- **Cross-backing parity.** The same SSRF world is solved by the same exploit on both
-  backings: `PROCESS` reads the shared secret in place, the networked `CONTAINER` fetches it
-  across the network — same flag, only the runtime fidelity differs.
+realization (#235) on this runtime, then k8s (#189).

--- a/packs/cyber_webapp/DESIGN.md
+++ b/packs/cyber_webapp/DESIGN.md
@@ -655,21 +655,27 @@ which returns the flag. That is genuine networked exploitation, not a path looku
 4. **Cross-backing parity.** The same SSRF world grades identically on `PROCESS`
    (emulated, one app) and the networked `CONTAINER` — only fidelity changes.
 
-Later: real lateral movement / credential reuse / `metadata_credential_leak` (currently
-referenced but undefined), then enterprise scale (#212) + lazy realization (#235) on top
-of this runtime, then k8s (#189).
+Later: real lateral movement / credential reuse, then enterprise scale (#212) + lazy
+realization (#235) on top of this runtime, then k8s (#189).
 
-**Status.** Increments 1–2 are **done and proven**: `realize_services` splits a world
-into per-service build contexts (the flag confined to its owning internal service);
-`NetworkedContainerWebappRuntime` runs one container per service on a real docker network
-and a docker-gated test shows real network position — the public service is reachable from
-the host, an internal service only from inside the network, by name. `WebappPack.realize`
-routes a world here only when it is genuinely networked-shaped (`_is_networked`: an SSRF on
-a *public* service).
+**Status.** All four increments are **done and proven**:
 
-Increments 3–4 need one generation change first, and that's the next step: today's sampler
-co-locates the SSRF with the flag on a single internal service, so no world is yet
-networked-shaped. Making the SSRF land on the public service, feeding an internal service
-that *serves* the flag (a metadata-style leak) with `internal_host` wired to that service,
-turns on the real cross-container SSRF (the handler gains a gated `urlopen` mode) and the
-cross-backing parity check — and makes real worlds auto-route to this runtime.
+- **Per-service realization + networked runtime.** `realize_services` splits a world into
+  per-service build contexts (the flag confined to its owning internal service);
+  `NetworkedContainerWebappRuntime` runs one container per service on a real docker network,
+  each reachable by name, publishing only the public service. A docker-gated test shows real
+  network position — the public service is reachable from the host, an internal service only
+  from inside the network.
+- **Networked-shaped generation.** An SSRF world is now networked by construction: the
+  sampler re-homes the SSRF onto the public service's endpoint and adds the internal half on
+  the flag's own service — a `metadata_credential_leak` endpoint that serves the flag, which
+  the SSRF `enables`. Feasibility and entrypoint selection follow that pivot, so the flag-
+  bearing internal service counts as reachable and the agent starts at the public endpoint.
+  `WebappPack.realize` routes these worlds to the networked runtime (`_is_networked`).
+- **Real cross-container SSRF.** Under `OPENRANGE_NETWORKED` the SSRF handler actually
+  `urlopen`s the internal host over the network. A docker-gated test recovers the flag only
+  through the pivot — a benign fetch and a direct hit on the internal path both leak nothing,
+  and the internal service is never reachable from the host.
+- **Cross-backing parity.** The same SSRF world is solved by the same exploit on both
+  backings: `PROCESS` reads the shared secret in place, the networked `CONTAINER` fetches it
+  across the network — same flag, only the runtime fidelity differs.

--- a/packs/cyber_webapp/DESIGN.md
+++ b/packs/cyber_webapp/DESIGN.md
@@ -658,3 +658,18 @@ which returns the flag. That is genuine networked exploitation, not a path looku
 Later: real lateral movement / credential reuse / `metadata_credential_leak` (currently
 referenced but undefined), then enterprise scale (#212) + lazy realization (#235) on top
 of this runtime, then k8s (#189).
+
+**Status.** Increments 1–2 are **done and proven**: `realize_services` splits a world
+into per-service build contexts (the flag confined to its owning internal service);
+`NetworkedContainerWebappRuntime` runs one container per service on a real docker network
+and a docker-gated test shows real network position — the public service is reachable from
+the host, an internal service only from inside the network, by name. `WebappPack.realize`
+routes a world here only when it is genuinely networked-shaped (`_is_networked`: an SSRF on
+a *public* service).
+
+Increments 3–4 need one generation change first, and that's the next step: today's sampler
+co-locates the SSRF with the flag on a single internal service, so no world is yet
+networked-shaped. Making the SSRF land on the public service, feeding an internal service
+that *serves* the flag (a metadata-style leak) with `internal_host` wired to that service,
+turns on the real cross-container SSRF (the handler gains a gated `urlopen` mode) and the
+cross-backing parity check — and makes real worlds auto-route to this runtime.

--- a/packs/cyber_webapp/DESIGN.md
+++ b/packs/cyber_webapp/DESIGN.md
@@ -467,79 +467,29 @@ a property you never stated. That is real and far-off: consequence instrumentati
 reaches novel *instances and chains* of known property-violations (most of real
 pentesting); new categories stay human-seeded. A fine place for the wall.
 
-### 8.8 First step — the experiment that earns the design
+### 8.8 What the indictment experiment showed
 
-Before trusting any of this, prove the verifier is worth trusting, then use it to
-indict the naive loop:
+A one-off experiment (2026-06-11, scaffolding not kept) validated a consequence verifier
+against known-good worlds, then used it to audit 89 LLM-generated worlds (world + solver
++ self-checker) across four classes, guided and unguided. The durable finding: the
+self-check is a strong, necessary filter — it catches the dominant failure, *unsolvable*
+worlds — but leaves a small, consistent tail (**~2–4% of shipped worlds**) that it passes
+and an independent verifier rejects as trivial or unfaithful. The tail did not widen with
+harder classes, bigger N, or real LLM checkers. The genuinely hard part is the independent
+verifier itself: it mis-fires in both directions, and the reliable signals are
+**triviality** and **faked-engine**, not the generator's own wrong-vector. The tail still
+matters — a `command_injection` set even 2% arbitrary-file-read biases a per-class transfer
+number — which is the verifier's job to measure.
 
-1. **Build + validate the consequence verifier on one class** (e.g.
-   `command_injection`): generalize `check_success` to "any `HIDDEN` value leaked,"
-   and confirm it against worlds we already trust — it must pass every existing
-   faithful exploit and reject every trivial/neutralized negative in
-   `test_cyber_staged_generation.py`. *The verifier is validated against known
-   ground truth before it audits anything.*
-2. **Run the indictment:** have an LLM generate world + solver + self-checker for
-   that class, N times. Grade each by (a) its own self-check and (b) the validated
-   verifier. **Measure the admit-gap** — worlds the self-check passes that the
-   independent verifier rejects as trivially-solvable or unfaithful — and let the
-   number be what it is (see §8.10).
+### 8.9 State of this direction
 
-Scope honestly: this runs at `PROCESS`, so it exercises the response-leak
-consequence only; file-read / code-exec consequences wait on the container (8.4).
-One class, one figure, the whole mechanism proven small.
-
-### 8.10 The indictment runs — what they actually showed
-
-A one-off validation experiment (run 2026-06-11; scaffolding not kept in the repo) ran
-89 LLM-generated worlds (Claude sonnet/haiku) across `command_injection`,
-`sql_injection`, `ssti`, `path_traversal`, guided and unguided, the final run carrying
-each generator's **own checker** (the real loop) plus a computed faithfulness control.
-
-| run | shipped | broken (self-caught) | admit-gap |
-| --- | --- | --- | --- |
-| A — guided cmdi (21) | 21 | 0 | 1 (trivial) |
-| B — unguided cmdi (20) | 6 | 14 | 0 |
-| C — 4 classes, real checkers (48) | 43 | 5 | 1 (faked engine) |
-
-The honest result is **narrower than this section first predicted, and consistent:**
-the admit-gap is **~2–4% of shipped worlds**, and did not widen with harder classes,
-bigger N, or real LLM checkers. Findings:
-
-1. The self-check is a **strong, necessary filter** — it catches the dominant failure,
-   *unsolvable* worlds (14/20 unguided cmdi never self-admit: faked tool output, the
-   stub reused, exploits that echo the literal marker).
-2. Two predicted amplifiers **didn't materialise.** Generated checkers were mostly
-   sound (`flag in response`), so broken worlds were self-rejected, not shipped; and
-   weak generation produces *more broken* worlds, not *more contaminated* ones.
-3. **The harder finding: an independent verifier is itself hard to get right.** The
-   harness mis-fired in both directions, each found only by hand-auditing real worlds —
-   false *negatives* (it took three probe iterations to stop passing `log-file-viewer`
-   trivial worlds) and false *positives* (judging faithfulness on the generator's own
-   "wrong" query flagged a real shell and real jinja2 as unfaithful; the fix is to judge
-   only on the computed control). The reliable signals are **triviality** and
-   **faked-engine**; the generator-supplied wrong-vector is not.
-
-So the defensible claim is not "self-verification fails" but: **its gross failures
-(broken worlds) are self-caught, the residual impurity is a small consistent tail
-(~2–4%) invisible to the self-check, and the genuinely hard part is building an
-independent verifier reliable enough to measure that tail.** That tail still matters —
-a `command_injection` set even 2% arbitrary-file-read biases a per-class transfer
-number — which is the independent verifier's job.
-
-### 8.9 Status of this direction
-
-| piece | state |
-| --- | --- |
-| planted-flag verifier (rung 1) | **done** — `check_success` |
-| graded reward rungs for GRPO variance | **done** — pentest subgoals; `test_trl_cyber.py` |
-| LLM behind admission (instruction, mutation enrichment) | **done** — `llm_generation.py`, strictly non-correctness-path |
-| any-hidden-leak verifier (rung 1+3 spine, 8.3) | **done** — `consequence.py`, validated on all 9 classes |
-| indictment: independent probes + run (8.8, 8.10) | **done** (one-off; scaffolding not kept) — gap ~2–4% |
-| wire the verifier into live `check_success` (runtime leak-capture) | **done** — seed → app scan → `leaked_secret_ids` → `check_success` |
-| LLM generates the *world* (emergent mode, 8.5) | **next** — not yet a gym mode |
-| report ↔ graph check (rung 2) | designed, unbuilt |
-| execution-effect consequences (rung 4) | **blocked** on container ([#252](https://github.com/vecna-labs/open-range/issues/252) / [#202](https://github.com/vecna-labs/open-range/issues/202)) |
-| novel-class discovery | far-future, human-seeded (8.7) |
+Built and validated on all 9 classes: the any-hidden-leak verifier (rungs 1+3 of the
+spine, `consequence.py`), wired into live `check_success` via runtime leak-capture; graded
+reward rungs for GRPO; the LLM kept strictly off the correctness path. Still ahead: the LLM
+generating the *world* itself (emergent mode, 8.5); report↔graph checks (rung 2, designed);
+execution-effect consequences (rung 4, blocked on the container,
+[#252](https://github.com/vecna-labs/open-range/issues/252)); novel-class discovery
+(far-future, human-seeded, 8.7).
 
 ---
 
@@ -553,12 +503,12 @@ The invariant at every stage: **procedural architects the graph** (topology, fla
 placement, the solvability skeleton — the controllable, scalable, solvable-by-
 construction part that is OpenRange's differentiator); **the LLM realizes each node**
 into a real, varied service; **admission verifies** (the consequence oracle + the
-shortcut/faithfulness probes of §8.10) that the realization is still solvable and not
+shortcut/faithfulness probes of §8.8) that the realization is still solvable and not
 *trivially* so; **the result freezes** to a content-addressed snapshot, so the study
 stays reproducible even with an LLM in the build path.
 
 Why the mix, not pure-LLM: an LLM asked for "a vulnerable world" gives *one* world,
-low controllability, and — §8.10 measured this — mostly *broken* ones. The procedural
+low controllability, and — §8.8 measured this — mostly *broken* ones. The procedural
 engine is the controllable variation source; the LLM is realism *per node, behind
 admission*. The LLM never architects correctness.
 

--- a/packs/cyber_webapp/DESIGN.md
+++ b/packs/cyber_webapp/DESIGN.md
@@ -620,3 +620,41 @@ runs real RCE (resource/privilege limits, egress, flag-out-of-image) is
 [#265](https://github.com/vecna-labs/open-range/issues/265); sandboxing the `exec`'d
 *verifier source* is the separate, host-side
 [#202](https://github.com/vecna-labs/open-range/issues/202).
+
+## 10. Networked multi-service: real network position
+
+The single-container backing (§9) runs the whole world in one container, every service
+mounted by path prefix — so "internal" services are just `/svc/<name>` paths on the same
+server and SSRF is emulated in-process. The graph already carries the topology primitives
+(`service.exposure` public/internal, `host.zone`, `network.isolation`, `connected_to`),
+but the runtime doesn't enforce them. This stage makes network position **real**, on the
+runtime-first track (#252 per-service realizer; the scale generation that feeds it is #212
+/ #235).
+
+**The shape.** A real SSRF world is: a **public** service (the agent's only entry,
+published) holds the SSRF; an **internal** service (no published port, reachable only on
+the container network) holds the flag. The flag is reachable **only** by pivoting — the
+agent exploits SSRF on the public service to make it fetch the internal service's URL,
+which returns the flag. That is genuine networked exploitation, not a path lookup.
+
+**What it takes (increments):**
+
+1. **Per-service realization.** Split the one generated app into one app per `service`
+   node — each carries only its own endpoints and only its own state (the secrets/records/
+   files of the data_stores it is `backed_by`). The flag stays in its owning internal
+   service; the public service never holds it (so it is never in the public image).
+2. **Networked runtime.** One container per service on a real docker network, each named
+   by its service so they resolve each other by name; publish only the public/entrypoint
+   service to the host; surface its `base_url`. The leak signal is **aggregated across all
+   services' request logs** — the internal service detects it leaking its own flag when it
+   serves it (it has the flag in its own guarded set; the public service does not).
+3. **Real SSRF.** The SSRF handler, in networked mode, actually `urlopen`s the target URL
+   across the network; the world is shaped so the SSRF's internal target is the internal
+   flag service. Recovering the flag requires the pivot; the internal service is not
+   directly reachable from the host.
+4. **Cross-backing parity.** The same SSRF world grades identically on `PROCESS`
+   (emulated, one app) and the networked `CONTAINER` — only fidelity changes.
+
+Later: real lateral movement / credential reuse / `metadata_credential_leak` (currently
+referenced but undefined), then enterprise scale (#212) + lazy realization (#235) on top
+of this runtime, then k8s (#189).

--- a/packs/cyber_webapp/cyber_webapp/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/__init__.py
@@ -73,10 +73,8 @@ class WebappPack(Pack):
 
 def _is_networked(graph: WorldGraph) -> bool:
     # Networked = the flag is reachable only by pivoting: an SSRF on a PUBLIC service
-    # reaches an internal service that holds the flag. Today's generator co-locates the
-    # SSRF with the flag on one internal service (so this is False — those stay one
-    # container); producing the public-SSRF -> internal-flag shape natively is the next
-    # step (DESIGN §10), at which point those worlds route here automatically.
+    # reaches an internal service that holds the flag. A vuln co-located with the flag
+    # on one service is not networked — it stays single-container.
     public_services = {
         n.id for n in graph.by_kind("service") if n.attrs.get("exposure") == "public"
     }

--- a/packs/cyber_webapp/cyber_webapp/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/__init__.py
@@ -24,6 +24,7 @@ from cyber_webapp.invariants import (
 from cyber_webapp.ontology import ONTOLOGY_ID, webapp_ontology
 from cyber_webapp.realize import (
     ContainerWebappRuntime,
+    NetworkedContainerWebappRuntime,
     WebappRuntime,
     WebappRuntimeError,
 )
@@ -58,6 +59,13 @@ class WebappPack(Pack):
         backing: Backing,
     ) -> RuntimeHandle:
         if backing is Backing.CONTAINER:
+            # A world with an SSRF needs real network position (fetch an internal
+            # service) — run it as one container per service on a network. Single-host
+            # worlds stay one container.
+            if any(
+                v.attrs.get("kind") == "ssrf" for v in graph.by_kind("vulnerability")
+            ):
+                return NetworkedContainerWebappRuntime(graph, backing)
             return ContainerWebappRuntime(graph, backing)
         return WebappRuntime(graph, backing)
 
@@ -68,6 +76,7 @@ class WebappPack(Pack):
 __all__ = [
     "ONTOLOGY_ID",
     "ContainerWebappRuntime",
+    "NetworkedContainerWebappRuntime",
     "WebappBuild",
     "WebappBuilder",
     "WebappPack",

--- a/packs/cyber_webapp/cyber_webapp/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/__init__.py
@@ -59,18 +59,36 @@ class WebappPack(Pack):
         backing: Backing,
     ) -> RuntimeHandle:
         if backing is Backing.CONTAINER:
-            # A world with an SSRF needs real network position (fetch an internal
-            # service) — run it as one container per service on a network. Single-host
-            # worlds stay one container.
-            if any(
-                v.attrs.get("kind") == "ssrf" for v in graph.by_kind("vulnerability")
-            ):
+            # A *networked* world — one whose flag is reachable only by pivoting from
+            # the public service to an internal one — runs as one container per service
+            # on a network. Single-host worlds stay one container.
+            if _is_networked(graph):
                 return NetworkedContainerWebappRuntime(graph, backing)
             return ContainerWebappRuntime(graph, backing)
         return WebappRuntime(graph, backing)
 
     def task_families(self) -> list[TaskFamily]:
         return [WebappBuild(), WebappPentest()]
+
+
+def _is_networked(graph: WorldGraph) -> bool:
+    # Networked = the flag is reachable only by pivoting: an SSRF on a PUBLIC service
+    # reaches an internal service that holds the flag. Today's generator co-locates the
+    # SSRF with the flag on one internal service (so this is False — those stay one
+    # container); producing the public-SSRF -> internal-flag shape natively is the next
+    # step (DESIGN §10), at which point those worlds route here automatically.
+    public_services = {
+        n.id for n in graph.by_kind("service") if n.attrs.get("exposure") == "public"
+    }
+    service_of_endpoint = {
+        e.dst: e.src for e in graph.edges.values() if e.kind == "exposes"
+    }
+    return any(
+        service_of_endpoint.get(edge.dst) in public_services
+        for vuln in graph.by_kind("vulnerability")
+        if vuln.attrs.get("kind") == "ssrf"
+        for edge in graph.out_edges(vuln.id, "affects")
+    )
 
 
 __all__ = [

--- a/packs/cyber_webapp/cyber_webapp/codegen/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/codegen/__init__.py
@@ -16,11 +16,15 @@ from cyber_webapp.codegen.seeding import project_seed
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 
 
-def _realize_graph(graph: WorldGraph) -> dict[str, str]:
-    # Secret must never land on disk — app.py loads seed into memory then unlinks.
-    seed = project_seed(graph)
-    handlers, routes = build_handlers_and_routes(graph)
-    discovery = build_discovery(graph)
+def _realize_graph(
+    graph: WorldGraph, only_services: frozenset[str] | None = None
+) -> dict[str, str]:
+    # ``only_services`` renders one service in isolation (its own endpoints + its own
+    # state) — the per-service app the networked CONTAINER backing runs per service.
+    # Default (None) renders the whole world into one app (PROCESS / single-container).
+    seed = project_seed(graph, only_services)
+    handlers, routes = build_handlers_and_routes(graph, only_services)
+    discovery = build_discovery(graph, only_services)
 
     template = _jinja_env().get_template("app.py.j2")
     source = template.render(

--- a/packs/cyber_webapp/cyber_webapp/codegen/discovery.py
+++ b/packs/cyber_webapp/cyber_webapp/codegen/discovery.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 from graphschema import Node, WorldGraph
 
 
-def build_discovery(graph: WorldGraph) -> dict[str, object]:
+def build_discovery(
+    graph: WorldGraph, only_services: frozenset[str] | None = None
+) -> dict[str, object]:
+    # ``only_services`` scopes the discovery doc to those services — a per-service app
+    # advertises only its own endpoints, not the rest of the (internal) estate.
     services_by_id: dict[str, Node] = {
-        n.id: n for n in graph.nodes.values() if n.kind == "service"
+        n.id: n
+        for n in graph.nodes.values()
+        if n.kind == "service" and (only_services is None or n.id in only_services)
     }
     endpoints_by_service: dict[str, list[Node]] = {sid: [] for sid in services_by_id}
     for edge in graph.edges.values():
@@ -32,9 +38,12 @@ def build_discovery(graph: WorldGraph) -> dict[str, object]:
         exposure = str(service.attrs.get("exposure", "internal"))
         paths: list[dict[str, str]] = []
         for endpoint in endpoints_by_service[service_id]:
+            # Per-service: advertise the bare path the service serves on its own
+            # container (the single app uses the /svc/<name> namespace instead).
+            url_key = "path" if only_services is not None else "public_url"
             paths.append(
                 {
-                    "url": str(endpoint.attrs["public_url"]),
+                    "url": str(endpoint.attrs[url_key]),
                     "method": str(endpoint.attrs.get("method", "GET")),
                 },
             )

--- a/packs/cyber_webapp/cyber_webapp/codegen/handlers.py
+++ b/packs/cyber_webapp/cyber_webapp/codegen/handlers.py
@@ -15,7 +15,10 @@ from cyber_webapp.vulnerabilities import render_vulnerability
 
 def build_handlers_and_routes(
     graph: WorldGraph,
+    only_services: frozenset[str] | None = None,
 ) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    # ``only_services`` restricts to one service's own endpoints — the per-service split
+    # that the networked CONTAINER backing realizes (each service is its own container).
     services_by_id: dict[str, Node] = {
         n.id: n for n in graph.nodes.values() if n.kind == "service"
     }
@@ -40,6 +43,8 @@ def build_handlers_and_routes(
     for endpoint_id, endpoint in endpoints_by_id.items():
         service_id = service_for_endpoint.get(endpoint_id)
         if service_id is None:
+            continue
+        if only_services is not None and service_id not in only_services:
             continue
         service = services_by_id[service_id]
         service_name = str(service.attrs.get("name", service_id))

--- a/packs/cyber_webapp/cyber_webapp/codegen/handlers.py
+++ b/packs/cyber_webapp/cyber_webapp/codegen/handlers.py
@@ -65,7 +65,12 @@ def build_handlers_and_routes(
         handlers.append(
             {"name": handler_name, "body": body, "docstring": docstring},
         )
-        routes.append({"path": public_url, "handler": handler_name})
+        # Single app: every service shares one server, so internal services are
+        # namespaced by ``/svc/<name>`` (public_url). Per-service: each service is its
+        # own container serving on its own port, so it routes on the bare ``path`` and a
+        # caller reaches it at ``http://<service-name><path>``.
+        route_path = path if only_services is not None else public_url
+        routes.append({"path": route_path, "handler": handler_name})
     return handlers, routes
 
 

--- a/packs/cyber_webapp/cyber_webapp/codegen/seeding.py
+++ b/packs/cyber_webapp/cyber_webapp/codegen/seeding.py
@@ -19,7 +19,9 @@ _DEFAULT_VALUE_COLUMN = "value"
 _BROKEN_AUTHZ_LEAK_FIELDS = ("value", "data", "secret", "content", "result", "flag")
 
 
-def project_seed(graph: WorldGraph) -> Mapping[str, object]:
+def project_seed(
+    graph: WorldGraph, only_services: frozenset[str] | None = None
+) -> Mapping[str, object]:
     """Project the runtime seed payload.
 
     The flag lives in exactly one place, fixed by the loot shape: a "db" loot
@@ -27,6 +29,11 @@ def project_seed(graph: WorldGraph) -> Mapping[str, object]:
     exploit); a "file" loot keeps it in the in-memory file map (read via a
     file-read exploit). It never lands on disk. Raises :class:`PackError` if
     the graph has no flag-kind secret.
+
+    ``only_services`` scopes the seed to the given services' own stores — the
+    per-service split the networked backing realizes (one container per service).
+    Each service then carries only the secrets/records/files of the data_stores it
+    is ``backed_by``, so the flag stays confined to the one service that owns it.
     """
     flag = ""
     flag_secret_id = ""
@@ -42,11 +49,21 @@ def project_seed(graph: WorldGraph) -> Mapping[str, object]:
         n.id: n for n in graph.nodes.values() if n.kind == "credential"
     }
 
+    service_of_record, service_of_secret = _service_ownership(graph)
+
+    def _owned(service_id: str | None) -> bool:
+        # Unscoped → everything; scoped → only the targeted services' own state.
+        return only_services is None or service_id in only_services
+
     for node in graph.nodes.values():
         if node.kind == "secret" and node.attrs.get("kind") == "flag":
+            if not _owned(service_of_secret.get(node.id)):
+                continue
             flag = str(node.attrs.get("value_ref", ""))
             flag_secret_id = node.id
         elif node.kind == "secret":
+            if not _owned(service_of_secret.get(node.id)):
+                continue
             secrets[str(node.attrs.get("kind", node.id))] = str(
                 node.attrs.get("value_ref", ""),
             )
@@ -62,6 +79,8 @@ def project_seed(graph: WorldGraph) -> Mapping[str, object]:
                 "password": password,
             }
         elif node.kind == "record":
+            if not _owned(service_of_record.get(node.id)):
+                continue
             fields = node.attrs.get("fields", {})
             clean = (
                 {str(k): str(v) for k, v in fields.items()}
@@ -70,12 +89,17 @@ def project_seed(graph: WorldGraph) -> Mapping[str, object]:
             )
             raw_records[node.id] = (str(node.attrs.get("key", node.id)), clean)
 
-    if not flag:
+    # Unscoped: a world must have a flag. Scoped: a service that doesn't own the
+    # flag legitimately has none — it carries only its own (decoy) state.
+    if only_services is None and not flag:
         raise PackError("graph has no flag-kind secret; codegen needs one")
 
     store_kind_of_record = _store_kind_by_record(graph)
-    flag_record_id = _record_holding(graph, flag_secret_id)
-    loot_shape = store_kind_of_record.get(flag_record_id, "kv")
+    if flag:
+        flag_record_id = _record_holding(graph, flag_secret_id)
+        loot_shape = store_kind_of_record.get(flag_record_id, "kv")
+    else:
+        loot_shape = "file"  # no flag in this slice → no flag injected into db/secrets
 
     db_records: dict[str, dict[str, str]] = {}
     files: dict[str, str] = {}
@@ -108,9 +132,36 @@ def project_seed(graph: WorldGraph) -> Mapping[str, object]:
             # The values the runtime watches for at the response boundary — every
             # HIDDEN node's value_ref, by node id. Same source the offline verifier
             # (consequence.detect_leak) reads, so live and test agree by construction.
-            "guarded": dict(guarded_values(graph)),
+            # Scoped to this slice's own secrets so the public service never holds
+            # (or watches for) the internal flag.
+            "guarded": {
+                k: v
+                for k, v in guarded_values(graph).items()
+                if _owned(service_of_secret.get(k))
+            },
         },
     )
+
+
+def _service_ownership(
+    graph: WorldGraph,
+) -> tuple[dict[str, str | None], dict[str, str | None]]:
+    # Which service owns each record / secret, via service -backed_by-> store
+    # -contains-> record -holds-> secret. Used to split the seed per service.
+    service_of_store = {
+        e.dst: e.src for e in graph.edges.values() if e.kind == "backed_by"
+    }
+    store_of_record = {
+        e.dst: e.src for e in graph.edges.values() if e.kind == "contains"
+    }
+    record_of_secret = {e.dst: e.src for e in graph.edges.values() if e.kind == "holds"}
+    service_of_record: dict[str, str | None] = {
+        rec: service_of_store.get(store) for rec, store in store_of_record.items()
+    }
+    service_of_secret: dict[str, str | None] = {
+        sec: service_of_record.get(rec) for sec, rec in record_of_secret.items()
+    }
+    return service_of_record, service_of_secret
 
 
 def _store_kind_by_record(graph: WorldGraph) -> dict[str, str]:

--- a/packs/cyber_webapp/cyber_webapp/container.py
+++ b/packs/cyber_webapp/cyber_webapp/container.py
@@ -21,6 +21,7 @@ entirely.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 
 from graphschema import WorldGraph
 
@@ -124,3 +125,40 @@ def image_files(graph: WorldGraph) -> dict[str, str]:
         APP_FILE_NAME: rendered[APP_FILE_NAME],
         SEED_FILE_NAME: rendered[SEED_FILE_NAME],
     }
+
+
+@dataclass(frozen=True)
+class ServiceImage:
+    """One service's container build context (the networked CONTAINER backing builds
+    one image per service node). ``name`` is the container/DNS name services reach each
+    other by; ``exposure`` decides whether the host publishes it (public) or it stays
+    reachable only on the container network (internal)."""
+
+    service_id: str
+    name: str
+    exposure: str
+    build_files: dict[str, str]
+
+
+def realize_services(graph: WorldGraph) -> list[ServiceImage]:
+    """Per-service build contexts: one image per service, each carrying only its own
+    endpoints + its own state (so the flag stays in the internal service that owns it
+    and never enters the public image). The networked runtime wires these on a container
+    network and publishes only the public service."""
+    dockerfile = _dockerfile(required_apt_packages(graph))
+    images: list[ServiceImage] = []
+    for service in graph.by_kind("service"):
+        rendered = _realize_graph(graph, frozenset({service.id}))
+        images.append(
+            ServiceImage(
+                service_id=service.id,
+                name=str(service.attrs.get("name", service.id)),
+                exposure=str(service.attrs.get("exposure", "internal")),
+                build_files={
+                    "Dockerfile": dockerfile,
+                    APP_FILE_NAME: rendered[APP_FILE_NAME],
+                    SEED_FILE_NAME: rendered[SEED_FILE_NAME],
+                },
+            )
+        )
+    return images

--- a/packs/cyber_webapp/cyber_webapp/families/pentest.py
+++ b/packs/cyber_webapp/cyber_webapp/families/pentest.py
@@ -75,23 +75,30 @@ class WebappPentest(TaskFamily):
         if graph.nodes.get(flag_id) is None:
             return FeasibilityVerdict(False, "goal node not in graph")
 
-        vuln_targets: set[str] = set()
-        for v in graph.by_kind("vulnerability"):
-            for a in graph.out_edges(v.id, "affects"):
-                vuln_targets.add(a.dst)
-
+        affects: dict[str, set[str]] = {
+            v.id: {a.dst for a in graph.out_edges(v.id, "affects")}
+            for v in graph.by_kind("vulnerability")
+        }
         services_exposing_ep = {e.src for e in graph.in_edges(endpoint_id, "exposes")}
+        entry_surface = {endpoint_id} | services_exposing_ep
 
-        weak_here = endpoint_id in vuln_targets or bool(
-            services_exposing_ep & vuln_targets
-        )
-        if not weak_here:
+        entry_vulns = [vid for vid, dsts in affects.items() if dsts & entry_surface]
+        if not entry_vulns:
             return FeasibilityVerdict(
                 False,
                 "no vulnerability affects the entrypoint or its service",
             )
 
-        for svc_id in services_exposing_ep:
+        # An SSRF on the public entrypoint reaches an internal service by firing the
+        # vuln it ``enables`` there (e.g. a metadata leak). Follow that pivot so the
+        # flag-bearing service the agent can only touch across the network counts as
+        # reachable — without it, a networked SSRF world reads as infeasible.
+        reachable_services = set(services_exposing_ep)
+        for vid in self._enable_closure(graph, entry_vulns):
+            for ep in affects.get(vid, ()):
+                reachable_services |= {e.src for e in graph.in_edges(ep, "exposes")}
+
+        for svc_id in reachable_services:
             for backed in graph.out_edges(svc_id, "backed_by"):
                 store_id = backed.dst
                 for contains in graph.out_edges(store_id, "contains"):
@@ -103,6 +110,24 @@ class WebappPentest(TaskFamily):
             False,
             "no service-to-flag chain (backed_by/contains/holds) found",
         )
+
+    def _enable_closure(
+        self,
+        graph: WorldGraph,
+        seed_vulns: Sequence[str],
+    ) -> set[str]:
+        seen: set[str] = set()
+        frontier = list(seed_vulns)
+        while frontier:
+            vid = frontier.pop()
+            if vid in seen:
+                continue
+            seen.add(vid)
+            for edge in graph.out_edges(vid, "enables"):
+                nxt = graph.nodes.get(edge.dst)
+                if nxt is not None and nxt.kind == "vulnerability":
+                    frontier.append(edge.dst)
+        return seen
 
     def check_success(
         self,
@@ -178,31 +203,74 @@ class WebappPentest(TaskFamily):
         graph: WorldGraph,
         flag_id: str,
     ) -> Node | None:
-        holds_in = graph.in_edges(flag_id, "holds")
-        if not holds_in:
+        flag_services = self._flag_services(graph, flag_id)
+        if not flag_services:
             return None
-        record_id = holds_in[0].src
-        contains_in = graph.in_edges(record_id, "contains")
-        if not contains_in:
-            return None
-        store_id = contains_in[0].src
 
+        # The entrypoint is the endpoint the agent attacks first. Its exploit must
+        # reach a flag-bearing service — directly (the vuln sits on that service) or
+        # by pivoting across the network through the vuln it ``enables`` there (the
+        # SSRF -> internal metadata chain). A public endpoint wins over an internal
+        # one, so a networked world starts the agent at the public pivot, not at the
+        # internal service it can only touch over the network.
         candidates: list[tuple[int, Node]] = []
-        for backed in graph.in_edges(store_id, "backed_by"):
-            svc_id = backed.src
-            svc = graph.nodes.get(svc_id)
-            if svc is None:
+        for vuln in graph.by_kind("vulnerability"):
+            if not self._vuln_reaches_services(graph, vuln.id, flag_services):
                 continue
-            for exposes in graph.out_edges(svc_id, "exposes"):
-                ep = graph.nodes.get(exposes.dst)
-                if ep is None:
-                    continue
-                priority = 0 if svc.attrs.get("exposure") == "public" else 1
-                candidates.append((priority, ep))
+            for affects in graph.out_edges(vuln.id, "affects"):
+                for ep, svc in self._affected_endpoints(graph, affects.dst):
+                    priority = 0 if svc.attrs.get("exposure") == "public" else 1
+                    candidates.append((priority, ep))
         if not candidates:
             return None
         candidates.sort(key=lambda pair: pair[0])
         return candidates[0][1]
+
+    def _flag_services(self, graph: WorldGraph, flag_id: str) -> set[str]:
+        holds_in = graph.in_edges(flag_id, "holds")
+        if not holds_in:
+            return set()
+        contains_in = graph.in_edges(holds_in[0].src, "contains")
+        if not contains_in:
+            return set()
+        store_id = contains_in[0].src
+        return {b.src for b in graph.in_edges(store_id, "backed_by")}
+
+    def _vuln_reaches_services(
+        self,
+        graph: WorldGraph,
+        vuln_id: str,
+        targets: set[str],
+    ) -> bool:
+        for vid in self._enable_closure(graph, [vuln_id]):
+            for affects in graph.out_edges(vid, "affects"):
+                for _ep, svc in self._affected_endpoints(graph, affects.dst):
+                    if svc.id in targets:
+                        return True
+        return False
+
+    def _affected_endpoints(
+        self,
+        graph: WorldGraph,
+        target_id: str,
+    ) -> list[tuple[Node, Node]]:
+        # An ``affects`` edge points at an endpoint or a whole service; normalize
+        # both to (endpoint, exposing-service) pairs.
+        target = graph.nodes.get(target_id)
+        if target is None:
+            return []
+        pairs: list[tuple[Node, Node]] = []
+        if target.kind == "endpoint":
+            for exposes in graph.in_edges(target_id, "exposes"):
+                svc = graph.nodes.get(exposes.src)
+                if svc is not None:
+                    pairs.append((target, svc))
+        elif target.kind == "service":
+            for exposes in graph.out_edges(target_id, "exposes"):
+                ep = graph.nodes.get(exposes.dst)
+                if ep is not None:
+                    pairs.append((ep, target))
+        return pairs
 
 
 _VULN_LABELS: Mapping[str, str] = {
@@ -387,13 +455,14 @@ def _exploit_hint(kind: str, params: Mapping[str, Any], loc: str) -> str:
         return f"Forge trust with the query parameter `{header}={value}`.{note}"
     if kind == "ssrf":
         host = params.get("internal_host", "169.254.169.254")
+        path = str(params.get("internal_path", "/latest/meta-data/"))
         ctx = params.get("ssrf_filter", "decimal_ip")
         allowed = str(params.get("allowed_host", "ok"))
         if ctx == "scheme_block":
-            target = f"gopher://{host}/_admin"
+            target = f"gopher://{host}{path}"
         elif ctx == "host_allowlist":
-            target = f"http://{allowed}@{host}/latest/meta-data/"
+            target = f"http://{allowed}@{host}{path}"
         else:
-            target = f"http://{params.get('internal_decimal', host)}/"
+            target = f"http://{params.get('internal_decimal', host)}{path}"
         return f"Make the server fetch the internal resource: `{param}={target}`."
     return "Exploit the vulnerability over HTTP to read the flag."

--- a/packs/cyber_webapp/cyber_webapp/realize.py
+++ b/packs/cyber_webapp/cyber_webapp/realize.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
+import tempfile
 import uuid
 from collections.abc import Mapping
 from pathlib import Path
@@ -25,7 +27,12 @@ from cyber_webapp.codegen.entrypoint import (
     REQUEST_LOG_NAME,
     RESULT_FILE_NAME,
 )
-from cyber_webapp.container import hardening_run_args, image_files
+from cyber_webapp.container import (
+    ServiceImage,
+    hardening_run_args,
+    image_files,
+    realize_services,
+)
 
 # Where the container's app writes its request log (the image CMD's --log path).
 _CONTAINER_LOG_PATH = "/app/requests.jsonl"
@@ -321,3 +328,153 @@ class ContainerWebappRuntime(WebappRuntime):
             subprocess.run(["docker", "rm", "-f", self._cname], capture_output=True)
         if self._image_built:
             subprocess.run(["docker", "rmi", "-f", self._tag], capture_output=True)
+
+
+class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
+    """The CONTAINER backing for a *networked* world: one container per service on a
+    real docker network. The public service is the foreground child (reused from
+    ContainerWebappRuntime — it gives the agent's ``base_url``); the internal services
+    run detached on the same network, reachable only by name and never published. So a
+    flag in an internal service is reachable only by pivoting from the public service
+    over the network — genuine network position, not a path lookup on one server.
+    """
+
+    def __init__(self, graph: WorldGraph, backing: Backing) -> None:
+        super().__init__(graph, backing)
+        self._services = realize_services(graph)
+        publics = [s for s in self._services if s.exposure == "public"]
+        self._public: ServiceImage = publics[0] if publics else self._services[0]
+        self._internals = [s for s in self._services if s is not self._public]
+        # The foreground child is the public service, not the whole-world image.
+        self._build_files = self._public.build_files
+        self._network = f"openrange-net-{uuid.uuid4().hex[:12]}"
+        self._network_created = False
+        self._internal_runs: list[tuple[str, str]] = []  # (container name, image tag)
+
+    def reset(self) -> None:
+        # Network + internal services first, then the public service as the child.
+        self._create_network()
+        self._start_internals()
+        super().reset()
+
+    def subprocess_command(self, env_root: Path, solver_root: Path) -> list[str]:
+        cmd = super().subprocess_command(env_root, solver_root)
+        # Put the public container on the network so it can reach the internals by name.
+        insert = cmd.index("run") + 1
+        cmd[insert:insert] = [
+            "--network",
+            self._network,
+            "--network-alias",
+            self._public.name,
+        ]
+        return cmd
+
+    def _create_network(self) -> None:
+        if self._network_created:
+            return
+        subprocess.run(
+            ["docker", "network", "create", self._network],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        self._network_created = True
+
+    def _start_internals(self) -> None:
+        if self._internal_runs:
+            return
+        for service in self._internals:
+            tag = f"openrange-cyber-{service.name}-{uuid.uuid4().hex[:8]}"
+            cname = f"{self._network}-{service.name}"
+            self._build_service_image(tag, service.build_files)
+            subprocess.run(
+                [
+                    "docker",
+                    "run",
+                    "-d",
+                    "--name",
+                    cname,
+                    "--network",
+                    self._network,
+                    "--network-alias",
+                    service.name,
+                    *hardening_run_args(),
+                    tag,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            self._internal_runs.append((cname, tag))
+            self._wait_ready_in_container(cname)
+
+    @staticmethod
+    def _build_service_image(tag: str, build_files: dict[str, str]) -> None:
+        context = Path(tempfile.mkdtemp(prefix="openrange-svc-"))
+        try:
+            for name, content in build_files.items():
+                (context / name).write_text(content, encoding="utf-8")
+            subprocess.run(
+                ["docker", "build", "-q", "-t", tag, str(context)],
+                check=True,
+                capture_output=True,
+                timeout=600,
+            )
+        finally:
+            shutil.rmtree(context, ignore_errors=True)
+
+    @staticmethod
+    def _wait_ready_in_container(cname: str) -> None:
+        # The internal service publishes no port, so probe it from inside the container
+        # (the docker-exec latency itself paces the retries).
+        probe = (
+            "import urllib.request as u; u.urlopen('http://localhost:8000/', timeout=2)"
+        )
+        for _ in range(40):
+            done = subprocess.run(
+                ["docker", "exec", cname, "python", "-c", probe],
+                capture_output=True,
+                timeout=10,
+                check=False,
+            )
+            if done.returncode == 0:
+                return
+        raise WebappRuntimeError(f"internal service {cname} did not become ready")
+
+    def _read_log_bytes(self) -> bytes | None:
+        # Aggregate the public child's log with every internal service's log, so the
+        # verdict sees a leak wherever it happened (the internal service detects it
+        # serving its own flag). collect() reads this fully; poll_events is disabled —
+        # one offset can't track concatenated, independently-growing logs.
+        chunks: list[bytes] = []
+        public = super()._read_log_bytes()
+        if public:
+            chunks.append(public)
+        for cname, _tag in self._internal_runs:
+            done = subprocess.run(
+                ["docker", "exec", cname, "cat", _CONTAINER_LOG_PATH],
+                capture_output=True,
+                timeout=10,
+                check=False,
+            )
+            if done.returncode == 0 and done.stdout:
+                chunks.append(done.stdout)
+        if chunks:
+            return b"".join(chunks)
+        return b"" if self._cname is not None else None
+
+    def poll_events(self) -> tuple[Mapping[str, Any], ...]:
+        return ()  # verdict comes from collect()'s full aggregated read, not offsets
+
+    def stop(self) -> None:
+        super().stop()  # tears down the public child + its image
+        for cname, tag in self._internal_runs:
+            subprocess.run(["docker", "rm", "-f", cname], capture_output=True)
+            subprocess.run(["docker", "rmi", "-f", tag], capture_output=True)
+        self._internal_runs.clear()
+        if self._network_created:
+            subprocess.run(
+                ["docker", "network", "rm", self._network], capture_output=True
+            )
+            self._network_created = False

--- a/packs/cyber_webapp/cyber_webapp/realize.py
+++ b/packs/cyber_webapp/cyber_webapp/realize.py
@@ -359,13 +359,17 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
 
     def subprocess_command(self, env_root: Path, solver_root: Path) -> list[str]:
         cmd = super().subprocess_command(env_root, solver_root)
-        # Put the public container on the network so it can reach the internals by name.
+        # Put the public container on the network so it can reach the internals by name,
+        # and switch its SSRF handler to a real cross-network fetch (the public service
+        # holds no flag — the secret can only come from the internal host).
         insert = cmd.index("run") + 1
         cmd[insert:insert] = [
             "--network",
             self._network,
             "--network-alias",
             self._public.name,
+            "-e",
+            "OPENRANGE_NETWORKED=1",
         ]
         return cmd
 

--- a/packs/cyber_webapp/cyber_webapp/realize.py
+++ b/packs/cyber_webapp/cyber_webapp/realize.py
@@ -370,7 +370,7 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
         return cmd
 
     def _create_network(self) -> None:
-        if self._network_created:
+        if self._network_created:  # pragma: no cover - idempotent across resets
             return
         subprocess.run(
             ["docker", "network", "create", self._network],
@@ -381,7 +381,7 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
         self._network_created = True
 
     def _start_internals(self) -> None:
-        if self._internal_runs:
+        if self._internal_runs:  # pragma: no cover - idempotent across resets
             return
         for service in self._internals:
             tag = f"openrange-cyber-{service.name}-{uuid.uuid4().hex[:8]}"
@@ -440,7 +440,9 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
             )
             if done.returncode == 0:
                 return
-        raise WebappRuntimeError(f"internal service {cname} did not become ready")
+        raise WebappRuntimeError(  # pragma: no cover - an internal that never starts
+            f"internal service {cname} did not become ready"
+        )
 
     def _read_log_bytes(self) -> bytes | None:
         # Aggregate the public child's log with every internal service's log, so the
@@ -462,7 +464,9 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
                 chunks.append(done.stdout)
         if chunks:
             return b"".join(chunks)
-        return b"" if self._cname is not None else None
+        # In practice every internal service has at least its readiness-probe request
+        # logged, so this empty fallback is only the pre-reset / no-container state.
+        return b"" if self._cname is not None else None  # pragma: no cover
 
     def poll_events(self) -> tuple[Mapping[str, Any], ...]:
         return ()  # verdict comes from collect()'s full aggregated read, not offsets

--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -629,7 +629,13 @@ def _sample_vulnerabilities(
     # ``oracle_service_id``, so the flag is reachable by construction. The
     # rest are decoys drawn from the weighted pool.
     count = _sample_int(rng, prior, "vuln_count")
-    pool = _weighted_pool(prior, "vuln_kinds")
+    # Internal-only kinds (a metadata leak that serves the flag on a plain GET) are
+    # never placed by general sampling — on a reachable endpoint they leak the flag
+    # with no exploit. They enter a world only via ``_networkize_ssrf``, on an
+    # unreachable internal endpoint that an SSRF must pivot to.
+    pool = [
+        k for k in _weighted_pool(prior, "vuln_kinds") if k not in _INTERNAL_ONLY_KINDS
+    ]
     if not pool:
         return
 

--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -214,6 +214,11 @@ _COMMAND_INJECTION_PARAMS: tuple[str, ...] = (
     "ip",
     "domain",
 )
+# Classes never placed by general sampling: a metadata_credential_leak on a reachable
+# endpoint would hand over the flag with no exploit. It goes only inside the networked
+# SSRF chain, on an INTERNAL service the agent can reach only by pivoting.
+_INTERNAL_ONLY_KINDS: frozenset[str] = frozenset({"metadata_credential_leak"})
+
 _COMMAND_INJECTION_BASE: tuple[str, ...] = (
     "ping",
     "nslookup",
@@ -730,7 +735,9 @@ def _forced_oracle(
     fallback = [
         k
         for k, v in VULN_CATALOG.items()
-        if v.shape in oracle_shapes and "endpoint" in v.target_kinds
+        if v.shape in oracle_shapes
+        and "endpoint" in v.target_kinds
+        and k not in _INTERNAL_ONLY_KINDS
     ]
     preferred = [k for k in pool if k in fallback]
     for source in (preferred, fallback):

--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -947,15 +947,11 @@ def _flag_service_id(graph: WorldGraph) -> str | None:
 
 
 def _networkize_ssrf(graph: WorldGraph) -> None:
-    """Turn an SSRF world into a real networked chain: move the SSRF onto the public web
-    service and pivot it to an internal metadata endpoint that serves the flag.
-
-    Today's sampler co-locates the SSRF with the flag on one internal service. This
-    makes the flag reachable only by pivoting across the network (SSRF on the public
-    service -> an internal ``metadata_credential_leak``), so the world is networked by
-    construction. It stays solvable in-process for the PROCESS backing (the SSRF still
-    reads the shared flag); the CONTAINER backing makes the pivot a real fetch.
-    """
+    # The sampler co-locates the SSRF with the flag on one internal service.
+    # Re-home it onto the public service and add an internal metadata endpoint
+    # that serves the flag, so the flag is reachable only by pivoting across the
+    # network. It stays solvable in-process for PROCESS (the SSRF reads the shared
+    # flag); CONTAINER makes the pivot a real fetch.
     ssrf = next(
         (n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"),
         None,

--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -507,6 +507,7 @@ def sample_graph(
         oracle_service_id=deepest_service_id,
         oracle_shapes=_ORACLE_SHAPES_FOR_LOOT[loot_shape],
     )
+    _networkize_ssrf(graph)
 
     return graph
 
@@ -904,6 +905,120 @@ def default_vuln_params(
             "cred_format": rng.choice(["pair", "combined", "basic"]),
         }
     return {}
+
+
+# The internal metadata path the SSRF pivots to (a cloud-metadata-style endpoint). Not
+# "/", which the runtime's readiness probe hits — that path must never serve the flag.
+_METADATA_PATH = "/latest/meta-data/credential"
+
+
+def _flag_service_id(graph: WorldGraph) -> str | None:
+    flag = next(
+        (n for n in graph.by_kind("secret") if n.attrs.get("kind") == "flag"), None
+    )
+    if flag is None:
+        return None
+    record = next(
+        (e.src for e in graph.edges.values() if e.kind == "holds" and e.dst == flag.id),
+        None,
+    )
+    store = next(
+        (
+            e.src
+            for e in graph.edges.values()
+            if e.kind == "contains" and e.dst == record
+        ),
+        None,
+    )
+    return next(
+        (
+            e.src
+            for e in graph.edges.values()
+            if e.kind == "backed_by" and e.dst == store
+        ),
+        None,
+    )
+
+
+def _networkize_ssrf(graph: WorldGraph) -> None:
+    """Turn an SSRF world into a real networked chain: move the SSRF onto the public web
+    service and pivot it to an internal metadata endpoint that serves the flag.
+
+    Today's sampler co-locates the SSRF with the flag on one internal service. This
+    makes the flag reachable only by pivoting across the network (SSRF on the public
+    service -> an internal ``metadata_credential_leak``), so the world is networked by
+    construction. It stays solvable in-process for the PROCESS backing (the SSRF still
+    reads the shared flag); the CONTAINER backing makes the pivot a real fetch.
+    """
+    ssrf = next(
+        (n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"),
+        None,
+    )
+    if ssrf is None:
+        return
+    public = next(
+        (n for n in graph.by_kind("service") if n.attrs.get("exposure") == "public"),
+        None,
+    )
+    flag_service_id = _flag_service_id(graph)
+    if public is None or flag_service_id is None or flag_service_id == public.id:
+        return  # single-service / flag-on-public: nothing to pivot to
+    public_ep = next((e.dst for e in graph.out_edges(public.id, "exposes")), None)
+    if public_ep is None:
+        return
+    flag_service = graph.nodes[flag_service_id]
+    flag_name = str(flag_service.attrs.get("name", flag_service_id))
+
+    # Re-home the SSRF onto the public endpoint, aimed at the internal service by name.
+    for edge in graph.edges.values():
+        if edge.kind == "affects" and edge.src == ssrf.id:
+            edge.dst = public_ep
+            edge.attrs = {
+                "injection_site": str(
+                    graph.nodes[public_ep].attrs.get("path", "service")
+                )
+            }
+            break
+    params = dict(ssrf.attrs.get("params", {}))
+    params["internal_host"] = flag_name
+    params["internal_path"] = _METADATA_PATH
+    params["internal_decimal"] = ""  # the target is a hostname, not an IP
+    if params.get("ssrf_filter") == "decimal_ip":
+        params["ssrf_filter"] = "host_allowlist"
+    ssrf.attrs["params"] = params
+
+    # The internal half: a metadata endpoint on the flag service that serves the flag,
+    # plus the vuln that makes the flag reachable by construction (oracle_path_exists).
+    meta_ep_id = f"ep_{flag_name}_metadata"
+    graph.add_node(
+        Node(
+            id=meta_ep_id,
+            kind="endpoint",
+            attrs={
+                "path": _METADATA_PATH,
+                "public_url": _public_url(flag_service.attrs, _METADATA_PATH),
+                "method": "GET",
+                "auth_required": False,
+                "behavior_ref": "metadata.default",
+            },
+        )
+    )
+    _add_edge(graph, "exposes", flag_service_id, meta_ep_id)
+    meta_vuln_id = "vuln_metadata_credential_leak_0"
+    graph.add_node(
+        Node(
+            id=meta_vuln_id,
+            kind="vulnerability",
+            attrs={
+                "kind": "metadata_credential_leak",
+                "family": "code_web",
+                "params": {},
+            },
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    _add_edge(graph, "affects", meta_vuln_id, meta_ep_id)
+    _add_edge(graph, "enables", ssrf.id, meta_vuln_id)
 
 
 def _add_edge(

--- a/packs/cyber_webapp/cyber_webapp/vulnerabilities/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/vulnerabilities/__init__.py
@@ -227,6 +227,21 @@ WEAK_CREDENTIALS = Vulnerability(
 )
 
 
+METADATA_CREDENTIAL_LEAK = Vulnerability(
+    id="metadata_credential_leak",
+    family="code_web",
+    description=(
+        "An unauthenticated internal endpoint (cloud-metadata / admin style) returns a "
+        "secret on a plain GET. Not reachable from outside; it is the resource an SSRF "
+        "on a public service pivots to — the internal half of the networked SSRF chain."
+    ),
+    target_kinds=frozenset({"endpoint"}),
+    template="metadata_credential_leak.py.j2",
+    shape="response_leak",
+    attrs_schema={},
+)
+
+
 CATALOG: Mapping[str, Vulnerability] = {
     SQL_INJECTION.id: SQL_INJECTION,
     SSRF.id: SSRF,
@@ -237,6 +252,7 @@ CATALOG: Mapping[str, Vulnerability] = {
     SSTI.id: SSTI,
     IDOR.id: IDOR,
     WEAK_CREDENTIALS.id: WEAK_CREDENTIALS,
+    METADATA_CREDENTIAL_LEAK.id: METADATA_CREDENTIAL_LEAK,
 }
 
 
@@ -310,6 +326,7 @@ __all__ = [
     "CATALOG",
     "COMMAND_INJECTION",
     "IDOR",
+    "METADATA_CREDENTIAL_LEAK",
     "PATH_TRAVERSAL",
     "SQL_INJECTION",
     "SSRF",

--- a/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/metadata_credential_leak.py.j2
+++ b/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/metadata_credential_leak.py.j2
@@ -1,0 +1,16 @@
+"""Internal metadata / admin endpoint — returns the secret on a plain GET.
+
+Models a cloud-metadata service or an unauthenticated internal admin endpoint: it
+trusts that only internal callers can reach it, so it hands the secret to anyone who
+asks. It is never exposed to the agent directly; it is the resource a public-service
+SSRF pivots to (the internal half of the networked SSRF chain).
+"""
+
+import json
+
+
+def handle(query, state):
+    del query
+    secret = state.get("secrets", {}).get("flag", "")
+    body = json.dumps({"credential": secret}).encode()
+    return 200, {"Content-Type": "application/json"}, body

--- a/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/ssrf.py.j2
+++ b/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/ssrf.py.j2
@@ -2,12 +2,14 @@
 target, and an internal resource that the filter is meant to protect leaks the
 secret when the supplied URL reaches it.
 
-The fetch is kept in-process so it is deterministic: instead of opening a socket
-to the supplied host, the handler recognizes when the URL resolves to the
-designated INTERNAL host and returns ``state["secrets"]["flag"]`` — modeling an
-SSRF that reaches an internal metadata/admin endpoint exposing the secret.
+Once the supplied URL resolves to the designated INTERNAL host, how the secret is
+reached depends on the backing. Under CONTAINER the internal service is a real,
+separate host on the network, so the handler fetches its metadata endpoint for
+real (``OPENRANGE_NETWORKED``). Under PROCESS the whole world shares one process,
+so it reads ``state["secrets"]["flag"]`` in place — same verdict, no socket.
 """
 import json
+import os
 from urllib.parse import urlparse
 
 
@@ -18,6 +20,7 @@ def handle(query, state):
         return 400, {}, b"missing url"
 
     internal_host = {{ (internal_host | default("169.254.169.254")) | tojson }}
+    internal_path = {{ (internal_path | default("/latest/meta-data/")) | tojson }}
     allowed_host = {{ (allowed_host | default("allowed.example.com")) | tojson }}
     # The three filters are DISJOINT: each admits exactly ONE evasion and
     # actively rejects the other two, while all three still reach the SAME
@@ -95,6 +98,18 @@ def handle(query, state):
         reached = bool(internal_decimal) and host == internal_decimal
 
     if reached:
+        if os.environ.get("OPENRANGE_NETWORKED"):
+            # Real network position: the public service holds no flag, so the secret
+            # can only come across the wire from the internal metadata host.
+            import urllib.request
+
+            url = "http://" + internal_host + ":8000" + internal_path
+            try:
+                with urllib.request.urlopen(url, timeout=5) as resp:
+                    fetched = resp.read()
+            except Exception as exc:  # the internal host was unreachable
+                return 502, {}, ("ssrf fetch failed: " + str(exc)).encode()
+            return 200, {"Content-Type": "application/json"}, fetched
         secret = state.get("secrets", {}).get("flag", "")
         body = json.dumps({"data": secret}).encode()
         return 200, {"Content-Type": "application/json"}, body

--- a/tests/test_cyber_codegen.py
+++ b/tests/test_cyber_codegen.py
@@ -43,6 +43,27 @@ def _sample_graph(seed: int = 0) -> WorldGraph:
     return build_result.graph
 
 
+def _multi_service_graph() -> WorldGraph:
+    for seed in range(8):
+        graph = _sample_graph(seed)
+        if sum(1 for n in graph.nodes.values() if n.kind == "service") >= 2:
+            return graph
+    raise AssertionError("no multi-service world found in seeds 0-7")
+
+
+def test_build_handlers_filters_to_one_service() -> None:
+    # The per-service split: building for one service sees only its own endpoints.
+    from cyber_webapp.codegen.handlers import build_handlers_and_routes
+
+    graph = _multi_service_graph()
+    services = [n.id for n in graph.nodes.values() if n.kind == "service"]
+    all_handlers, _ = build_handlers_and_routes(graph)
+    one_handlers, _ = build_handlers_and_routes(graph, frozenset({services[0]}))
+    name = str(graph.nodes[services[0]].attrs.get("name", services[0]))
+    assert 0 < len(one_handlers) < len(all_handlers)
+    assert all(h["name"].startswith(f"handle__{name}__") for h in one_handlers)
+
+
 def test_realize_graph_emits_app_and_seed_files() -> None:
     """The codegen returns a plain mapping containing both required files."""
     files = _realize_graph(_sample_graph())

--- a/tests/test_cyber_codegen.py
+++ b/tests/test_cyber_codegen.py
@@ -64,6 +64,27 @@ def test_build_handlers_filters_to_one_service() -> None:
     assert all(h["name"].startswith(f"handle__{name}__") for h in one_handlers)
 
 
+def test_per_service_seed_confines_the_flag() -> None:
+    # The per-service split keeps the flag in exactly the service that owns it, so the
+    # public service never holds (or even watches for) the internal flag.
+    from cyber_webapp.codegen.seeding import project_seed
+
+    graph = _multi_service_graph()
+    flag = next(
+        str(n.attrs["value_ref"])
+        for n in graph.nodes.values()
+        if n.kind == "secret" and n.attrs.get("kind") == "flag"
+    )
+    services = [n.id for n in graph.nodes.values() if n.kind == "service"]
+    owners = [
+        sid
+        for sid in services
+        if flag in json.dumps(dict(project_seed(graph, frozenset({sid}))), default=str)
+    ]
+    assert len(owners) == 1  # the flag lives in exactly one service
+    assert flag in json.dumps(dict(project_seed(graph)), default=str)  # unscoped has it
+
+
 def test_realize_graph_emits_app_and_seed_files() -> None:
     """The codegen returns a plain mapping containing both required files."""
     files = _realize_graph(_sample_graph())

--- a/tests/test_cyber_networked.py
+++ b/tests/test_cyber_networked.py
@@ -4,10 +4,18 @@ the runtime that runs one container per service on a real network with real SSRF
 from __future__ import annotations
 
 import ast
+import shutil
+import subprocess
+import urllib.request
 
-from cyber_webapp import WebappPack
+import pytest
+from cyber_webapp import (
+    ContainerWebappRuntime,
+    NetworkedContainerWebappRuntime,
+    WebappPack,
+)
 from cyber_webapp.container import realize_services
-from openrange_pack_sdk import Snapshot
+from openrange_pack_sdk import Backing, Snapshot
 
 from openrange.core.admit import admit
 
@@ -48,3 +56,67 @@ def test_realize_services_splits_per_service_and_confines_the_flag() -> None:
     # Per-service apps route on bare paths (their own container/port), not the
     # single-app `/svc/<name>` namespace.
     assert "/svc/" not in internal.build_files["app.py"]
+
+
+def test_ssrf_world_routes_to_networked_backing() -> None:
+    # The CONTAINER backing runs an SSRF world networked (per-service); a non-SSRF
+    # multi-service world stays a single container.
+    ssrf = WebappPack().realize(_admit_ssrf().graph, Backing.CONTAINER)
+    assert isinstance(ssrf, NetworkedContainerWebappRuntime)
+    cmdi = admit(
+        WebappPack(),
+        manifest={
+            "pack": {"id": "webapp"},
+            "runtime": {"tick": {"mode": "off"}},
+            "npc": [],
+            "seed": 7,
+            "loot_shapes": {"file": 1, "db": 0},
+            "vuln_kinds": {"command_injection": 1},
+        },
+        max_repairs=3,
+    )
+    assert isinstance(cmdi, Snapshot)
+    single = WebappPack().realize(cmdi.graph, Backing.CONTAINER)
+    assert isinstance(single, ContainerWebappRuntime)
+    assert not isinstance(single, NetworkedContainerWebappRuntime)
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        probe = subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=10, check=False
+        )
+    except Exception:  # noqa: BLE001 - any failure means "no"
+        return False
+    return probe.returncode == 0
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
+def test_networked_runtime_isolates_internal_services() -> None:
+    # The public service is reachable from the host; an internal service is reachable
+    # only from inside the network, by name — real network position.
+    runtime = WebappPack().realize(_admit_ssrf().graph, Backing.CONTAINER)
+    assert isinstance(runtime, NetworkedContainerWebappRuntime)
+    try:
+        runtime.reset()
+        base_url = str(runtime.surface()["base_url"])
+        with urllib.request.urlopen(base_url + "/", timeout=10) as resp:
+            assert resp.status == 200  # public service reachable from the host
+
+        internal_name = runtime._internals[0].name
+        probe = (
+            "import urllib.request as u; "
+            f"print(u.urlopen('http://{internal_name}:8000/', timeout=3).status)"
+        )
+        out = subprocess.run(
+            ["docker", "exec", str(runtime._cname), "python", "-c", probe],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        # The public container reaches the internal service by name over the network.
+        assert out.returncode == 0 and "200" in out.stdout, out.stderr
+    finally:
+        runtime.stop()

--- a/tests/test_cyber_networked.py
+++ b/tests/test_cyber_networked.py
@@ -58,12 +58,18 @@ def test_realize_services_splits_per_service_and_confines_the_flag() -> None:
     assert "/svc/" not in internal.build_files["app.py"]
 
 
-def test_ssrf_world_routes_to_networked_backing() -> None:
-    # The CONTAINER backing runs an SSRF world networked (per-service); a non-SSRF
-    # multi-service world stays a single container.
-    ssrf = WebappPack().realize(_admit_ssrf().graph, Backing.CONTAINER)
-    assert isinstance(ssrf, NetworkedContainerWebappRuntime)
-    cmdi = admit(
+def test_todays_worlds_stay_single_container() -> None:
+    # No regression: today's generator co-locates the SSRF with the flag on one internal
+    # service, so a world isn't yet "networked-shaped" (SSRF on a public service) — it
+    # stays one container. Native networked-shape generation is the follow-up.
+    for snap in (_admit_ssrf(), _admit_cmdi()):
+        runtime = WebappPack().realize(snap.graph, Backing.CONTAINER)
+        assert isinstance(runtime, ContainerWebappRuntime)
+        assert not isinstance(runtime, NetworkedContainerWebappRuntime)
+
+
+def _admit_cmdi() -> Snapshot:
+    snap = admit(
         WebappPack(),
         manifest={
             "pack": {"id": "webapp"},
@@ -75,10 +81,8 @@ def test_ssrf_world_routes_to_networked_backing() -> None:
         },
         max_repairs=3,
     )
-    assert isinstance(cmdi, Snapshot)
-    single = WebappPack().realize(cmdi.graph, Backing.CONTAINER)
-    assert isinstance(single, ContainerWebappRuntime)
-    assert not isinstance(single, NetworkedContainerWebappRuntime)
+    assert isinstance(snap, Snapshot), snap
+    return snap
 
 
 def _docker_available() -> bool:
@@ -96,9 +100,9 @@ def _docker_available() -> bool:
 @pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
 def test_networked_runtime_isolates_internal_services() -> None:
     # The public service is reachable from the host; an internal service is reachable
-    # only from inside the network, by name — real network position.
-    runtime = WebappPack().realize(_admit_ssrf().graph, Backing.CONTAINER)
-    assert isinstance(runtime, NetworkedContainerWebappRuntime)
+    # only from inside the network, by name — real network position. (Constructed
+    # directly: today's worlds don't yet auto-route here, see the routing test above.)
+    runtime = NetworkedContainerWebappRuntime(_admit_ssrf().graph, Backing.CONTAINER)
     try:
         runtime.reset()
         base_url = str(runtime.surface()["base_url"])

--- a/tests/test_cyber_networked.py
+++ b/tests/test_cyber_networked.py
@@ -58,34 +58,33 @@ def test_realize_services_splits_per_service_and_confines_the_flag() -> None:
     assert "/svc/" not in internal.build_files["app.py"]
 
 
-def test_todays_worlds_stay_single_container() -> None:
-    # No regression: today's generator co-locates the SSRF with the flag on one internal
-    # service, so a world isn't yet "networked-shaped" (SSRF on a public service) — it
-    # stays one container. Native networked-shape generation is the follow-up.
-    for snap in (_admit_ssrf(), _admit_cmdi()):
-        runtime = WebappPack().realize(snap.graph, Backing.CONTAINER)
-        assert isinstance(runtime, ContainerWebappRuntime)
-        assert not isinstance(runtime, NetworkedContainerWebappRuntime)
-
-
-def test_networked_shaped_world_routes_to_networked_backing() -> None:
-    # When a world IS networked-shaped (an SSRF reaches a public service's endpoint),
-    # the CONTAINER backing routes it to the networked runtime.
-    from graphschema import Edge
-
+def test_ssrf_world_is_networked_by_construction() -> None:
+    # Generation re-homes the SSRF onto a PUBLIC service's endpoint — the pivot the
+    # agent attacks — so it reaches the flag only across the network. That public-facing
+    # shape is exactly what routes the world to the networked backing.
     graph = _admit_ssrf().graph
-    public = next(
-        n for n in graph.by_kind("service") if n.attrs.get("exposure") == "public"
-    )
-    public_ep = next(e.dst for e in graph.out_edges(public.id, "exposes"))
     ssrf = next(
         n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
     )
-    graph.add_edge(
-        Edge(id="affects_ssrf_public", kind="affects", src=ssrf.id, dst=public_ep)
-    )
+    affected = {e.dst for e in graph.out_edges(ssrf.id, "affects")}
+    public_eps = {
+        e.dst
+        for svc in graph.by_kind("service")
+        if svc.attrs.get("exposure") == "public"
+        for e in graph.out_edges(svc.id, "exposes")
+    }
+    assert affected & public_eps  # the SSRF sits on a public endpoint
+
     runtime = WebappPack().realize(graph, Backing.CONTAINER)
     assert isinstance(runtime, NetworkedContainerWebappRuntime)
+
+
+def test_non_networked_world_stays_single_container() -> None:
+    # A world whose vuln sits directly on the flag's own service (no public-service
+    # pivot) isn't networked-shaped, so the CONTAINER backing runs it as one container.
+    runtime = WebappPack().realize(_admit_cmdi().graph, Backing.CONTAINER)
+    assert isinstance(runtime, ContainerWebappRuntime)
+    assert not isinstance(runtime, NetworkedContainerWebappRuntime)
 
 
 def _admit_cmdi() -> Snapshot:
@@ -121,7 +120,8 @@ def _docker_available() -> bool:
 def test_networked_runtime_isolates_internal_services() -> None:
     # The public service is reachable from the host; an internal service is reachable
     # only from inside the network, by name — real network position. (Constructed
-    # directly: today's worlds don't yet auto-route here, see the routing test above.)
+    # directly to isolate the runtime; an SSRF world also auto-routes here — see the
+    # routing test above.)
     runtime = NetworkedContainerWebappRuntime(_admit_ssrf().graph, Backing.CONTAINER)
     try:
         runtime.reset()

--- a/tests/test_cyber_networked.py
+++ b/tests/test_cyber_networked.py
@@ -65,9 +65,6 @@ def test_realize_services_splits_per_service_and_confines_the_flag() -> None:
 
 
 def test_ssrf_world_is_networked_by_construction() -> None:
-    # Generation re-homes the SSRF onto a PUBLIC service's endpoint — the pivot the
-    # agent attacks — so it reaches the flag only across the network. That public-facing
-    # shape is exactly what routes the world to the networked backing.
     graph = _admit_ssrf().graph
     ssrf = next(
         n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
@@ -86,8 +83,6 @@ def test_ssrf_world_is_networked_by_construction() -> None:
 
 
 def test_non_networked_world_stays_single_container() -> None:
-    # A world whose vuln sits directly on the flag's own service (no public-service
-    # pivot) isn't networked-shaped, so the CONTAINER backing runs it as one container.
     runtime = WebappPack().realize(_admit_cmdi().graph, Backing.CONTAINER)
     assert isinstance(runtime, ContainerWebappRuntime)
     assert not isinstance(runtime, NetworkedContainerWebappRuntime)
@@ -186,11 +181,9 @@ def test_networked_runtime_isolates_internal_services() -> None:
             text=True,
             timeout=20,
         )
-        # The public container reaches the internal service by name over the network.
         assert out.returncode == 0 and "200" in out.stdout, out.stderr
 
-        # collect() aggregates every service's request log; a benign request leaks
-        # nothing (the public service never holds the flag).
+        # A benign request leaks nothing — the public service never holds the flag.
         final = runtime.collect()
         assert final["leaked_secret_ids"] == []
         assert "/" in final["requests_made"]
@@ -200,9 +193,8 @@ def test_networked_runtime_isolates_internal_services() -> None:
 
 @pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
 def test_networked_ssrf_recovers_the_flag_across_containers() -> None:
-    # The whole point: the flag lives in an internal container the host can't address.
-    # The agent recovers it ONLY by making the public service's SSRF fetch the internal
-    # metadata host over the docker network — a real cross-container exploit.
+    # The flag lives in an internal container the host can't address; only the SSRF
+    # pivot across the docker network reaches it.
     snap = _admit_ssrf()
     graph = snap.graph
     flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
@@ -218,21 +210,17 @@ def test_networked_ssrf_recovers_the_flag_across_containers() -> None:
         runtime.reset()
         base_url = str(runtime.surface()["base_url"])
 
-        # The internal metadata path is NOT reachable on the public service directly —
-        # the flag can only come through the pivot, not a path lookup on one host.
+        # The internal path isn't reachable on the public service directly, and a fetch
+        # that doesn't resolve to the internal host leaks nothing — only the pivot does.
         _, direct_body = _get(base_url, internal_path, {})
         assert flag not in direct_body
-
-        # A benign fetch that doesn't resolve to the internal host leaks nothing.
         _, benign_body = _get(base_url, path, {param: "gopher://example.com/"})
         assert flag not in benign_body
 
-        # The real exploit: the SSRF pivots to the internal host and returns its secret.
         status, body = _get(base_url, path, {param: payload})
         assert status == 200, body
         assert flag in body  # recovered across the container boundary
 
-        # The verdict sees the leak in the aggregated logs.
         final = runtime.collect()
         assert "secret_flag" in final["leaked_secret_ids"]
     finally:
@@ -241,16 +229,15 @@ def test_networked_ssrf_recovers_the_flag_across_containers() -> None:
 
 @pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
 def test_ssrf_parity_across_backings(tmp_path: Path) -> None:
-    # The same SSRF world is solvable on both backings — PROCESS reads the shared
-    # secret in place, CONTAINER fetches it for real across the network. Same exploit,
-    # same flag: the sim-to-real gap is the runtime, not the task.
+    # Same exploit, same flag on both backings: PROCESS reads the shared secret in
+    # place, CONTAINER fetches it across the network — only the runtime differs.
     snap = _admit_ssrf()
     graph = snap.graph
     flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
     path, param, payload = _ssrf_exploit(graph)
     query = {param: payload}
 
-    # PROCESS, through the real episode harness.
+    # PROCESS, through the episode harness.
     pentest = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
     svc = EpisodeService(WebappPack(), tmp_path)
     try:
@@ -261,7 +248,7 @@ def test_ssrf_parity_across_backings(tmp_path: Path) -> None:
         svc.close()
     assert flag in process_body
 
-    # CONTAINER, through the networked runtime (a real cross-container fetch).
+    # CONTAINER, through the networked runtime.
     runtime = WebappPack().realize(graph, Backing.CONTAINER)
     try:
         runtime.reset()
@@ -274,10 +261,8 @@ def test_ssrf_parity_across_backings(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
 def test_networked_ssrf_grades_through_the_container_harness(tmp_path: Path) -> None:
-    # The full grade path the trainer / run_episode use: start the episode on the
-    # CONTAINER backing, recover the flag across the network, submit it, and let the
-    # pack's check_success grade it. Proves the networked world is a gradable episode
-    # end to end — not just an HTTP body that happens to carry the flag.
+    # Grade through the full harness path the trainer / run_episode use — not just an
+    # HTTP body that happens to carry the flag.
     snap = _admit_ssrf()
     graph = snap.graph
     flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
@@ -290,7 +275,7 @@ def test_networked_ssrf_grades_through_the_container_harness(tmp_path: Path) -> 
         base = str(svc.surface(handle)["base_url"])
         _, body = _get(base, path, {param: payload})
         assert flag in body  # recovered across the container boundary
-        # Submit the recovered flag the way the harness grades it.
+        # The harness grades the submitted flag from result.json.
         (Path(svc.solver_root(handle)) / "result.json").write_text(
             json.dumps({"flag": flag})
         )

--- a/tests/test_cyber_networked.py
+++ b/tests/test_cyber_networked.py
@@ -111,8 +111,8 @@ def _admit_cmdi() -> Snapshot:
 
 
 def _ssrf_exploit(graph: WorldGraph) -> tuple[str, str, str]:
-    """The (public path, query param, payload URL) that pivots the SSRF to the
-    internal metadata host — built from the sampled filter, as an agent would."""
+    # Build the (public path, query param, payload URL) the way an agent would — from
+    # the sampled filter — so the same payload drives every backing.
     ssrf = next(
         n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
     )

--- a/tests/test_cyber_networked.py
+++ b/tests/test_cyber_networked.py
@@ -1,0 +1,50 @@
+"""The networked multi-service backing: per-service realization, then (docker-gated)
+the runtime that runs one container per service on a real network with real SSRF."""
+
+from __future__ import annotations
+
+import ast
+
+from cyber_webapp import WebappPack
+from cyber_webapp.container import realize_services
+from openrange_pack_sdk import Snapshot
+
+from openrange.core.admit import admit
+
+_SSRF_MANIFEST = {
+    "pack": {"id": "webapp"},
+    "runtime": {"tick": {"mode": "off"}},
+    "npc": [],
+    "seed": 3,
+    "vuln_kinds": {"ssrf": 1},
+}
+
+
+def _admit_ssrf() -> Snapshot:
+    snap = admit(WebappPack(), manifest=_SSRF_MANIFEST, max_repairs=3)
+    assert isinstance(snap, Snapshot), snap
+    return snap
+
+
+def test_realize_services_splits_per_service_and_confines_the_flag() -> None:
+    snap = _admit_ssrf()
+    graph = snap.graph
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    images = realize_services(graph)
+
+    assert len(images) == sum(1 for _ in graph.by_kind("service"))
+    assert len(images) >= 2  # a networked world has multiple services
+    owners = []
+    for image in images:
+        assert set(image.build_files) == {"Dockerfile", "app.py", "seed.json"}
+        ast.parse(image.build_files["app.py"])  # each per-service app is valid Python
+        if flag in image.build_files["seed.json"]:
+            owners.append(image.name)
+    assert len(owners) == 1  # the flag lives in exactly one service's image
+
+    public = next(im for im in images if im.exposure == "public")
+    internal = next(im for im in images if im.exposure == "internal")
+    assert flag not in public.build_files["seed.json"]  # never in the public image
+    # Per-service apps route on bare paths (their own container/port), not the
+    # single-app `/svc/<name>` namespace.
+    assert "/svc/" not in internal.build_files["app.py"]

--- a/tests/test_cyber_networked.py
+++ b/tests/test_cyber_networked.py
@@ -68,6 +68,26 @@ def test_todays_worlds_stay_single_container() -> None:
         assert not isinstance(runtime, NetworkedContainerWebappRuntime)
 
 
+def test_networked_shaped_world_routes_to_networked_backing() -> None:
+    # When a world IS networked-shaped (an SSRF reaches a public service's endpoint),
+    # the CONTAINER backing routes it to the networked runtime.
+    from graphschema import Edge
+
+    graph = _admit_ssrf().graph
+    public = next(
+        n for n in graph.by_kind("service") if n.attrs.get("exposure") == "public"
+    )
+    public_ep = next(e.dst for e in graph.out_edges(public.id, "exposes"))
+    ssrf = next(
+        n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
+    )
+    graph.add_edge(
+        Edge(id="affects_ssrf_public", kind="affects", src=ssrf.id, dst=public_ep)
+    )
+    runtime = WebappPack().realize(graph, Backing.CONTAINER)
+    assert isinstance(runtime, NetworkedContainerWebappRuntime)
+
+
 def _admit_cmdi() -> Snapshot:
     snap = admit(
         WebappPack(),
@@ -105,6 +125,7 @@ def test_networked_runtime_isolates_internal_services() -> None:
     runtime = NetworkedContainerWebappRuntime(_admit_ssrf().graph, Backing.CONTAINER)
     try:
         runtime.reset()
+        assert runtime.poll_events() == ()  # networked verdict comes from collect()
         base_url = str(runtime.surface()["base_url"])
         with urllib.request.urlopen(base_url + "/", timeout=10) as resp:
             assert resp.status == 200  # public service reachable from the host
@@ -122,5 +143,11 @@ def test_networked_runtime_isolates_internal_services() -> None:
         )
         # The public container reaches the internal service by name over the network.
         assert out.returncode == 0 and "200" in out.stdout, out.stderr
+
+        # collect() aggregates every service's request log; a benign request leaks
+        # nothing (the public service never holds the flag).
+        final = runtime.collect()
+        assert final["leaked_secret_ids"] == []
+        assert "/" in final["requests_made"]
     finally:
         runtime.stop()

--- a/tests/test_cyber_networked.py
+++ b/tests/test_cyber_networked.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 import ast
 import shutil
 import subprocess
+import urllib.error
+import urllib.parse
 import urllib.request
+from pathlib import Path
 
 import pytest
 from cyber_webapp import (
@@ -15,9 +18,11 @@ from cyber_webapp import (
     WebappPack,
 )
 from cyber_webapp.container import realize_services
+from graphschema import WorldGraph
 from openrange_pack_sdk import Backing, Snapshot
 
 from openrange.core.admit import admit
+from openrange.core.episode import EpisodeService
 
 _SSRF_MANIFEST = {
     "pack": {"id": "webapp"},
@@ -104,6 +109,45 @@ def _admit_cmdi() -> Snapshot:
     return snap
 
 
+def _ssrf_exploit(graph: WorldGraph) -> tuple[str, str, str]:
+    """The (public path, query param, payload URL) that pivots the SSRF to the
+    internal metadata host — built from the sampled filter, as an agent would."""
+    ssrf = next(
+        n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
+    )
+    params = dict(ssrf.attrs.get("params", {}))
+    affected = {e.dst for e in graph.out_edges(ssrf.id, "affects")}
+    public_eps = {
+        e.dst
+        for svc in graph.by_kind("service")
+        if svc.attrs.get("exposure") == "public"
+        for e in graph.out_edges(svc.id, "exposes")
+    }
+    ep_id = next(iter(affected & public_eps))
+    path = str(graph.nodes[ep_id].attrs.get("path", "/"))
+    param = str(params["target_param"])
+    host = str(params["internal_host"])
+    internal_path = str(params["internal_path"])
+    ssrf_filter = params.get("ssrf_filter")
+    if ssrf_filter == "scheme_block":
+        payload = f"gopher://{host}{internal_path}"
+    elif ssrf_filter == "host_allowlist":
+        allowed = str(params.get("allowed_host", "ok"))
+        payload = f"http://{allowed}@{host}{internal_path}"
+    else:  # pragma: no cover - generation only emits the two service-name filters
+        raise AssertionError(f"unexpected networked ssrf_filter: {ssrf_filter!r}")
+    return path, param, payload
+
+
+def _get(base_url: str, path: str, query: dict[str, str]) -> tuple[int, str]:
+    url = f"{base_url}{path}?{urllib.parse.urlencode(query)}"
+    try:
+        with urllib.request.urlopen(url, timeout=15) as resp:
+            return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode()
+
+
 def _docker_available() -> bool:
     if shutil.which("docker") is None:
         return False
@@ -151,3 +195,77 @@ def test_networked_runtime_isolates_internal_services() -> None:
         assert "/" in final["requests_made"]
     finally:
         runtime.stop()
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
+def test_networked_ssrf_recovers_the_flag_across_containers() -> None:
+    # The whole point: the flag lives in an internal container the host can't address.
+    # The agent recovers it ONLY by making the public service's SSRF fetch the internal
+    # metadata host over the docker network — a real cross-container exploit.
+    snap = _admit_ssrf()
+    graph = snap.graph
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    ssrf = next(
+        n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
+    )
+    internal_path = str(ssrf.attrs["params"]["internal_path"])
+    path, param, payload = _ssrf_exploit(graph)
+
+    runtime = WebappPack().realize(graph, Backing.CONTAINER)
+    assert isinstance(runtime, NetworkedContainerWebappRuntime)
+    try:
+        runtime.reset()
+        base_url = str(runtime.surface()["base_url"])
+
+        # The internal metadata path is NOT reachable on the public service directly —
+        # the flag can only come through the pivot, not a path lookup on one host.
+        _, direct_body = _get(base_url, internal_path, {})
+        assert flag not in direct_body
+
+        # A benign fetch that doesn't resolve to the internal host leaks nothing.
+        _, benign_body = _get(base_url, path, {param: "gopher://example.com/"})
+        assert flag not in benign_body
+
+        # The real exploit: the SSRF pivots to the internal host and returns its secret.
+        status, body = _get(base_url, path, {param: payload})
+        assert status == 200, body
+        assert flag in body  # recovered across the container boundary
+
+        # The verdict sees the leak in the aggregated logs.
+        final = runtime.collect()
+        assert "secret_flag" in final["leaked_secret_ids"]
+    finally:
+        runtime.stop()
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
+def test_ssrf_parity_across_backings(tmp_path: Path) -> None:
+    # The same SSRF world is solvable on both backings — PROCESS reads the shared
+    # secret in place, CONTAINER fetches it for real across the network. Same exploit,
+    # same flag: the sim-to-real gap is the runtime, not the task.
+    snap = _admit_ssrf()
+    graph = snap.graph
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    path, param, payload = _ssrf_exploit(graph)
+    query = {param: payload}
+
+    # PROCESS, through the real episode harness.
+    pentest = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+    svc = EpisodeService(WebappPack(), tmp_path)
+    try:
+        handle = svc.start_episode(snap, pentest.id)
+        base = str(svc.surface(handle)["base_url"])
+        _, process_body = _get(base, path, query)
+    finally:
+        svc.close()
+    assert flag in process_body
+
+    # CONTAINER, through the networked runtime (a real cross-container fetch).
+    runtime = WebappPack().realize(graph, Backing.CONTAINER)
+    try:
+        runtime.reset()
+        base = str(runtime.surface()["base_url"])
+        _, container_body = _get(base, path, query)
+    finally:
+        runtime.stop()
+    assert flag in container_body

--- a/tests/test_cyber_networked.py
+++ b/tests/test_cyber_networked.py
@@ -4,6 +4,7 @@ the runtime that runs one container per service on a real network with real SSRF
 from __future__ import annotations
 
 import ast
+import json
 import shutil
 import subprocess
 import urllib.error
@@ -269,3 +270,33 @@ def test_ssrf_parity_across_backings(tmp_path: Path) -> None:
     finally:
         runtime.stop()
     assert flag in container_body
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
+def test_networked_ssrf_grades_through_the_container_harness(tmp_path: Path) -> None:
+    # The full grade path the trainer / run_episode use: start the episode on the
+    # CONTAINER backing, recover the flag across the network, submit it, and let the
+    # pack's check_success grade it. Proves the networked world is a gradable episode
+    # end to end — not just an HTTP body that happens to carry the flag.
+    snap = _admit_ssrf()
+    graph = snap.graph
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    path, param, payload = _ssrf_exploit(graph)
+    pentest = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+
+    svc = EpisodeService(WebappPack(), tmp_path, backing=Backing.CONTAINER)
+    try:
+        handle = svc.start_episode(snap, pentest.id)
+        base = str(svc.surface(handle)["base_url"])
+        _, body = _get(base, path, {param: payload})
+        assert flag in body  # recovered across the container boundary
+        # Submit the recovered flag the way the harness grades it.
+        (Path(svc.solver_root(handle)) / "result.json").write_text(
+            json.dumps({"flag": flag})
+        )
+        report = svc.stop_episode(handle)
+    finally:
+        svc.close()
+    assert report.passed
+    assert report.episode_result.success
+    assert report.episode_result.subgoals["matched_flag"]

--- a/tests/test_cyber_networkize.py
+++ b/tests/test_cyber_networkize.py
@@ -129,7 +129,6 @@ def test_networkize_builds_the_pivot_half() -> None:
     params = g.nodes["ssrf"].attrs["params"]
     assert params["internal_host"] == "db"
     assert params["internal_path"] == "/latest/meta-data/credential"
-    # The metadata vuln is enabled by the SSRF and affects the new internal endpoint.
     enables = [(e.src, e.dst) for e in g.edges.values() if e.kind == "enables"]
     assert ("ssrf", "vuln_metadata_credential_leak_0") in enables
 
@@ -160,7 +159,6 @@ def test_networkize_switches_decimal_ip_filter_to_host_allowlist() -> None:
 
     ssrf = g.nodes["ssrf"]
     assert ssrf.attrs["params"]["ssrf_filter"] == "host_allowlist"
-    # The SSRF is re-homed onto the public endpoint.
     affected = [
         e.dst for e in g.edges.values() if e.kind == "affects" and e.src == "ssrf"
     ]

--- a/tests/test_cyber_networkize.py
+++ b/tests/test_cyber_networkize.py
@@ -8,6 +8,7 @@ pivot to make, and is a no-op otherwise.
 
 from __future__ import annotations
 
+from cyber_webapp import WebappPack
 from cyber_webapp.sampling import _flag_service_id, _networkize_ssrf
 from graphschema import Edge, Node, Visibility, WorldGraph
 
@@ -45,6 +46,30 @@ def _flag_on(g: WorldGraph, service_id: str) -> None:
 
 def test_flag_service_id_none_without_flag() -> None:
     assert _flag_service_id(_graph()) is None
+
+
+def test_metadata_kind_is_filtered_from_general_sampling() -> None:
+    # Requested as a decoy, the internal-only metadata leak is dropped from the pool:
+    # on a reachable endpoint it would hand over the flag with no exploit. In a non-SSRF
+    # world (no networkize) that means zero metadata vulns, despite the request.
+    graph = (
+        WebappPack()
+        .make_builder(None)
+        .build(
+            {
+                "seed": 1,
+                "vuln_kinds": {"sql_injection": 3, "metadata_credential_leak": 3},
+                "vuln_count": 4,
+            }
+        )
+        .graph
+    )
+    metas = [
+        v
+        for v in graph.by_kind("vulnerability")
+        if v.attrs["kind"] == "metadata_credential_leak"
+    ]
+    assert metas == []
 
 
 def test_networkize_noop_without_public_service() -> None:

--- a/tests/test_cyber_networkize.py
+++ b/tests/test_cyber_networkize.py
@@ -1,0 +1,142 @@
+"""The ``_networkize_ssrf`` sampler transform.
+
+It turns an SSRF world into a real networked chain — the SSRF on a public service
+pivots to an internal ``metadata_credential_leak`` that serves the flag. These
+drive the guard branches: it only rewires when there's an actual public-service
+pivot to make, and is a no-op otherwise.
+"""
+
+from __future__ import annotations
+
+from cyber_webapp.sampling import _flag_service_id, _networkize_ssrf
+from graphschema import Edge, Node, Visibility, WorldGraph
+
+
+def _graph() -> WorldGraph:
+    return WorldGraph(ontology="cyber.webapp@v2")
+
+
+def _ssrf(g: WorldGraph) -> None:
+    g.add_node(
+        Node(
+            id="ssrf",
+            kind="vulnerability",
+            attrs={"kind": "ssrf", "params": {}},
+            visibility=Visibility.HIDDEN,
+        )
+    )
+
+
+def _flag_on(g: WorldGraph, service_id: str) -> None:
+    g.add_node(Node(id="store", kind="data_store"))
+    g.add_node(Node(id="record", kind="record"))
+    g.add_node(
+        Node(
+            id="secret_flag",
+            kind="secret",
+            attrs={"kind": "flag"},
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    g.add_edge(Edge(id="b", kind="backed_by", src=service_id, dst="store"))
+    g.add_edge(Edge(id="c", kind="contains", src="store", dst="record"))
+    g.add_edge(Edge(id="h", kind="holds", src="record", dst="secret_flag"))
+
+
+def test_flag_service_id_none_without_flag() -> None:
+    assert _flag_service_id(_graph()) is None
+
+
+def test_networkize_noop_without_public_service() -> None:
+    g = _graph()
+    g.add_node(Node(id="svc", kind="service", attrs={"exposure": "internal"}))
+    _ssrf(g)
+    _flag_on(g, "svc")
+    before = set(g.nodes)
+    _networkize_ssrf(g)
+    assert set(g.nodes) == before  # no metadata endpoint/vuln added
+
+
+def test_networkize_noop_when_flag_lives_on_the_public_service() -> None:
+    g = _graph()
+    g.add_node(Node(id="svc", kind="service", attrs={"exposure": "public"}))
+    g.add_node(Node(id="ep", kind="endpoint", attrs={"path": "/"}))
+    g.add_edge(Edge(id="x", kind="exposes", src="svc", dst="ep"))
+    _ssrf(g)
+    g.add_edge(Edge(id="a", kind="affects", src="ssrf", dst="ep"))
+    _flag_on(g, "svc")  # the flag's own service IS the public one — nothing to pivot to
+    before = set(g.nodes)
+    _networkize_ssrf(g)
+    assert set(g.nodes) == before
+
+
+def test_networkize_noop_when_public_has_no_endpoint() -> None:
+    g = _graph()
+    g.add_node(
+        Node(id="pub", kind="service", attrs={"exposure": "public"})
+    )  # no exposes
+    g.add_node(Node(id="int", kind="service", attrs={"exposure": "internal"}))
+    _ssrf(g)
+    _flag_on(g, "int")
+    before = set(g.nodes)
+    _networkize_ssrf(g)
+    assert set(g.nodes) == before
+
+
+def test_networkize_builds_the_pivot_half() -> None:
+    g = _graph()
+    g.add_node(
+        Node(id="pub", kind="service", attrs={"exposure": "public", "name": "web"})
+    )
+    g.add_node(Node(id="pub_ep", kind="endpoint", attrs={"path": "/search"}))
+    g.add_edge(Edge(id="e", kind="exposes", src="pub", dst="pub_ep"))
+    _ssrf(g)
+    # No affects edge from the SSRF yet: the re-home loop finds nothing to move, but
+    # the internal pivot half is still added.
+    g.add_node(
+        Node(id="int", kind="service", attrs={"exposure": "internal", "name": "db"})
+    )
+    _flag_on(g, "int")
+    _networkize_ssrf(g)
+
+    assert "ep_db_metadata" in g.nodes
+    assert "vuln_metadata_credential_leak_0" in g.nodes
+    params = g.nodes["ssrf"].attrs["params"]
+    assert params["internal_host"] == "db"
+    assert params["internal_path"] == "/latest/meta-data/credential"
+    # The metadata vuln is enabled by the SSRF and affects the new internal endpoint.
+    enables = [(e.src, e.dst) for e in g.edges.values() if e.kind == "enables"]
+    assert ("ssrf", "vuln_metadata_credential_leak_0") in enables
+
+
+def test_networkize_switches_decimal_ip_filter_to_host_allowlist() -> None:
+    # A service-name target has no decimal-IP form, so the decimal_ip evasion can't
+    # apply; generation swaps it for the http allowlist trick that does.
+    g = _graph()
+    g.add_node(
+        Node(id="pub", kind="service", attrs={"exposure": "public", "name": "web"})
+    )
+    g.add_node(Node(id="pub_ep", kind="endpoint", attrs={"path": "/search"}))
+    g.add_edge(Edge(id="e", kind="exposes", src="pub", dst="pub_ep"))
+    g.add_node(
+        Node(
+            id="ssrf",
+            kind="vulnerability",
+            attrs={"kind": "ssrf", "params": {"ssrf_filter": "decimal_ip"}},
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    g.add_edge(Edge(id="a", kind="affects", src="ssrf", dst="pub_ep"))
+    g.add_node(
+        Node(id="int", kind="service", attrs={"exposure": "internal", "name": "db"})
+    )
+    _flag_on(g, "int")
+    _networkize_ssrf(g)
+
+    ssrf = g.nodes["ssrf"]
+    assert ssrf.attrs["params"]["ssrf_filter"] == "host_allowlist"
+    # The SSRF is re-homed onto the public endpoint.
+    affected = [
+        e.dst for e in g.edges.values() if e.kind == "affects" and e.src == "ssrf"
+    ]
+    assert affected == ["pub_ep"]

--- a/tests/test_cyber_pentest_feasibility.py
+++ b/tests/test_cyber_pentest_feasibility.py
@@ -141,9 +141,8 @@ def _networked_graph() -> WorldGraph:
 
 def test_feasibility_ssrf_pivot_reaches_internal_flag() -> None:
     g = _networked_graph()
-    # The flag is reachable only by pivoting from the public entrypoint.
     assert FAM.check_feasibility(g, _task("pub_ep", "secret_flag")).feasible
-    # ...and the public pivot wins entrypoint selection over the internal endpoint.
+    # The public pivot wins entrypoint selection over the internal endpoint.
     entry = FAM._find_public_entrypoint_for(g, "secret_flag")
     assert entry is not None and entry.id == "pub_ep"
 
@@ -195,23 +194,20 @@ def test_entrypoint_none_when_no_vuln_reaches_flag() -> None:
 
 def test_affected_endpoints_normalizes_targets_and_skips_dangling() -> None:
     g = _graph()
-    # Missing target -> no pairs.
     assert FAM._affected_endpoints(g, "ghost") == []
 
-    # Endpoint target -> (endpoint, exposing service).
+    # An endpoint target and its own service target both normalize to the same pair.
     g.add_node(Node(id="svc", kind="service", attrs={"exposure": "public"}))
     g.add_node(Node(id="ep", kind="endpoint"))
     g.add_edge(Edge(id="x", kind="exposes", src="svc", dst="ep"))
     assert [(e.id, s.id) for e, s in FAM._affected_endpoints(g, "ep")] == [
         ("ep", "svc")
     ]
-
-    # Service target -> each exposed endpoint.
     assert [(e.id, s.id) for e, s in FAM._affected_endpoints(g, "svc")] == [
         ("ep", "svc")
     ]
 
-    # A node that is neither endpoint nor service -> no pairs.
+    # A node that is neither endpoint nor service yields nothing.
     g.add_node(_hidden("v", "vulnerability", kind="ssrf"))
     assert FAM._affected_endpoints(g, "v") == []
 

--- a/tests/test_cyber_pentest_feasibility.py
+++ b/tests/test_cyber_pentest_feasibility.py
@@ -1,0 +1,224 @@
+"""Feasibility and entrypoint selection for the pentest family.
+
+The interesting case is the networked SSRF chain: the agent's entrypoint is a
+PUBLIC endpoint, but the flag lives on an INTERNAL service it can only touch by
+making the SSRF pivot to the vuln it ``enables`` there. These tests drive that
+pivot, plus the guard branches, on small hand-built graphs.
+"""
+
+from __future__ import annotations
+
+from cyber_webapp.families.pentest import WebappPentest
+from graphschema import Edge, Node, Visibility, WorldGraph
+from openrange_pack_sdk import TaskSpec
+
+FAM = WebappPentest()
+
+
+def _graph() -> WorldGraph:
+    return WorldGraph(ontology="cyber.webapp@v2")
+
+
+def _task(entrypoints: object, goal_nodes: object) -> TaskSpec:
+    return FAM.make_task(
+        instruction="x",
+        entrypoints=entrypoints,  # type: ignore[arg-type]
+        goal_nodes=goal_nodes,  # type: ignore[arg-type]
+    )
+
+
+def _hidden(node_id: str, node_kind: str, **attrs: object) -> Node:
+    return Node(
+        id=node_id,
+        kind=node_kind,
+        attrs=dict(attrs),
+        visibility=Visibility.HIDDEN,
+    )
+
+
+def _flag_chain(g: WorldGraph, service_id: str, suffix: str = "") -> None:
+    """Wire service -backed_by-> store -contains-> record -holds-> flag."""
+    g.add_node(Node(id=f"store{suffix}", kind="data_store"))
+    g.add_node(Node(id=f"record{suffix}", kind="record"))
+    g.add_node(_hidden("secret_flag", "secret", kind="flag"))
+    g.add_edge(
+        Edge(id=f"b{suffix}", kind="backed_by", src=service_id, dst=f"store{suffix}")
+    )
+    g.add_edge(
+        Edge(
+            id=f"c{suffix}",
+            kind="contains",
+            src=f"store{suffix}",
+            dst=f"record{suffix}",
+        )
+    )
+    g.add_edge(
+        Edge(id=f"h{suffix}", kind="holds", src=f"record{suffix}", dst="secret_flag")
+    )
+
+
+def test_feasibility_missing_entrypoint_or_goal() -> None:
+    verdict = FAM.check_feasibility(_graph(), _task((), ()))
+    assert not verdict.feasible
+    assert "missing" in verdict.reason
+
+
+def test_feasibility_entrypoint_not_in_graph() -> None:
+    g = _graph()
+    g.add_node(_hidden("secret_flag", "secret", kind="flag"))
+    verdict = FAM.check_feasibility(g, _task("ghost_ep", "secret_flag"))
+    assert not verdict.feasible
+    assert "entrypoint" in verdict.reason
+
+
+def test_feasibility_goal_not_in_graph() -> None:
+    g = _graph()
+    g.add_node(Node(id="ep", kind="endpoint"))
+    verdict = FAM.check_feasibility(g, _task("ep", "ghost_flag"))
+    assert not verdict.feasible
+    assert "goal" in verdict.reason
+
+
+def test_feasibility_no_vuln_on_entrypoint() -> None:
+    g = _graph()
+    g.add_node(Node(id="ep", kind="endpoint"))
+    g.add_node(_hidden("secret_flag", "secret", kind="flag"))
+    verdict = FAM.check_feasibility(g, _task("ep", "secret_flag"))
+    assert not verdict.feasible
+    assert "no vulnerability affects" in verdict.reason
+
+
+def test_feasibility_vuln_but_flag_unreachable() -> None:
+    # The entrypoint is vulnerable and its service has a full backing chain, but
+    # that chain holds a different secret — so no path reaches the flag.
+    g = _graph()
+    g.add_node(Node(id="svc", kind="service", attrs={"exposure": "public"}))
+    g.add_node(Node(id="ep", kind="endpoint"))
+    g.add_edge(Edge(id="x", kind="exposes", src="svc", dst="ep"))
+    g.add_node(_hidden("vuln", "vulnerability", kind="sql_injection"))
+    g.add_edge(Edge(id="a", kind="affects", src="vuln", dst="ep"))
+    g.add_node(Node(id="store", kind="data_store"))
+    g.add_node(Node(id="record", kind="record"))
+    g.add_node(Node(id="other", kind="secret", attrs={"kind": "api_key"}))
+    g.add_edge(Edge(id="b", kind="backed_by", src="svc", dst="store"))
+    g.add_edge(Edge(id="c", kind="contains", src="store", dst="record"))
+    g.add_edge(Edge(id="h", kind="holds", src="record", dst="other"))
+    g.add_node(_hidden("secret_flag", "secret", kind="flag"))
+    verdict = FAM.check_feasibility(g, _task("ep", "secret_flag"))
+    assert not verdict.feasible
+    assert "no service-to-flag chain" in verdict.reason
+
+
+def test_feasibility_direct_chain() -> None:
+    g = _graph()
+    g.add_node(Node(id="svc", kind="service", attrs={"exposure": "internal"}))
+    g.add_node(Node(id="ep", kind="endpoint"))
+    g.add_edge(Edge(id="x", kind="exposes", src="svc", dst="ep"))
+    g.add_node(_hidden("vuln", "vulnerability", kind="sql_injection"))
+    g.add_edge(Edge(id="a", kind="affects", src="vuln", dst="ep"))
+    _flag_chain(g, "svc")
+    assert FAM.check_feasibility(g, _task("ep", "secret_flag")).feasible
+
+
+def _networked_graph() -> WorldGraph:
+    g = _graph()
+    # Public web service with an SSRF.
+    g.add_node(Node(id="pub_svc", kind="service", attrs={"exposure": "public"}))
+    g.add_node(Node(id="pub_ep", kind="endpoint"))
+    g.add_edge(Edge(id="e1", kind="exposes", src="pub_svc", dst="pub_ep"))
+    g.add_node(_hidden("ssrf", "vulnerability", kind="ssrf"))
+    g.add_edge(Edge(id="a1", kind="affects", src="ssrf", dst="pub_ep"))
+    # Internal service whose metadata endpoint serves the flag.
+    g.add_node(Node(id="int_svc", kind="service", attrs={"exposure": "internal"}))
+    g.add_node(Node(id="meta_ep", kind="endpoint"))
+    g.add_edge(Edge(id="e2", kind="exposes", src="int_svc", dst="meta_ep"))
+    g.add_node(_hidden("meta", "vulnerability", kind="metadata_credential_leak"))
+    g.add_edge(Edge(id="a2", kind="affects", src="meta", dst="meta_ep"))
+    g.add_edge(Edge(id="en", kind="enables", src="ssrf", dst="meta"))
+    _flag_chain(g, "int_svc")
+    return g
+
+
+def test_feasibility_ssrf_pivot_reaches_internal_flag() -> None:
+    g = _networked_graph()
+    # The flag is reachable only by pivoting from the public entrypoint.
+    assert FAM.check_feasibility(g, _task("pub_ep", "secret_flag")).feasible
+    # ...and the public pivot wins entrypoint selection over the internal endpoint.
+    entry = FAM._find_public_entrypoint_for(g, "secret_flag")
+    assert entry is not None and entry.id == "pub_ep"
+
+
+def test_enable_closure_dedups_and_skips_non_vuln_targets() -> None:
+    # A diamond (v1, v2 both enable v3) forces v3 onto the frontier twice, exercising
+    # the dedup. v3 then ``enables`` a non-vuln node and a missing node — both skipped.
+    g = _graph()
+    g.add_node(Node(id="ep", kind="endpoint"))
+    g.add_node(Node(id="svc", kind="service", attrs={"exposure": "public"}))
+    g.add_edge(Edge(id="x", kind="exposes", src="svc", dst="ep"))
+    for vid in ("v1", "v2"):
+        g.add_node(_hidden(vid, "vulnerability", kind="ssrf"))
+        g.add_edge(Edge(id=f"a_{vid}", kind="affects", src=vid, dst="ep"))
+        g.add_edge(Edge(id=f"en_{vid}", kind="enables", src=vid, dst="v3"))
+    g.add_node(_hidden("v3", "vulnerability", kind="metadata_credential_leak"))
+    g.add_edge(Edge(id="bad_ep", kind="enables", src="v3", dst="ep"))  # not a vuln
+    g.add_edge(Edge(id="bad_ghost", kind="enables", src="v3", dst="ghost"))  # missing
+    assert FAM._enable_closure(g, ["v1", "v2"]) == {"v1", "v2", "v3"}
+
+
+def test_entrypoint_none_when_flag_not_held() -> None:
+    g = _graph()
+    g.add_node(_hidden("secret_flag", "secret", kind="flag"))
+    assert FAM._find_public_entrypoint_for(g, "secret_flag") is None
+
+
+def test_entrypoint_none_when_record_not_contained() -> None:
+    g = _graph()
+    g.add_node(_hidden("secret_flag", "secret", kind="flag"))
+    g.add_node(Node(id="record", kind="record"))
+    g.add_edge(Edge(id="h", kind="holds", src="record", dst="secret_flag"))
+    assert FAM._find_public_entrypoint_for(g, "secret_flag") is None
+
+
+def test_entrypoint_none_when_no_vuln_reaches_flag() -> None:
+    g = _graph()
+    g.add_node(Node(id="svc_a", kind="service", attrs={"exposure": "internal"}))
+    _flag_chain(g, "svc_a")
+    assert FAM._flag_services(g, "secret_flag") == {"svc_a"}
+    # A vuln on an unrelated service never reaches the flag's service.
+    g.add_node(Node(id="svc_b", kind="service", attrs={"exposure": "public"}))
+    g.add_node(Node(id="ep_b", kind="endpoint"))
+    g.add_edge(Edge(id="e", kind="exposes", src="svc_b", dst="ep_b"))
+    g.add_node(_hidden("vuln", "vulnerability", kind="ssrf"))
+    g.add_edge(Edge(id="a", kind="affects", src="vuln", dst="ep_b"))
+    assert FAM._find_public_entrypoint_for(g, "secret_flag") is None
+
+
+def test_affected_endpoints_normalizes_targets_and_skips_dangling() -> None:
+    g = _graph()
+    # Missing target -> no pairs.
+    assert FAM._affected_endpoints(g, "ghost") == []
+
+    # Endpoint target -> (endpoint, exposing service).
+    g.add_node(Node(id="svc", kind="service", attrs={"exposure": "public"}))
+    g.add_node(Node(id="ep", kind="endpoint"))
+    g.add_edge(Edge(id="x", kind="exposes", src="svc", dst="ep"))
+    assert [(e.id, s.id) for e, s in FAM._affected_endpoints(g, "ep")] == [
+        ("ep", "svc")
+    ]
+
+    # Service target -> each exposed endpoint.
+    assert [(e.id, s.id) for e, s in FAM._affected_endpoints(g, "svc")] == [
+        ("ep", "svc")
+    ]
+
+    # A node that is neither endpoint nor service -> no pairs.
+    g.add_node(_hidden("v", "vulnerability", kind="ssrf"))
+    assert FAM._affected_endpoints(g, "v") == []
+
+    # Dangling exposes edges (missing service / missing endpoint) are skipped.
+    g.add_node(Node(id="ep2", kind="endpoint"))
+    g.add_edge(Edge(id="d1", kind="exposes", src="ghost_svc", dst="ep2"))
+    assert FAM._affected_endpoints(g, "ep2") == []
+    g.add_node(Node(id="svc2", kind="service", attrs={"exposure": "public"}))
+    g.add_edge(Edge(id="d2", kind="exposes", src="svc2", dst="ghost_ep"))
+    assert FAM._affected_endpoints(g, "svc2") == []

--- a/tests/test_cyber_pentest_feasibility.py
+++ b/tests/test_cyber_pentest_feasibility.py
@@ -37,7 +37,7 @@ def _hidden(node_id: str, node_kind: str, **attrs: object) -> Node:
 
 
 def _flag_chain(g: WorldGraph, service_id: str, suffix: str = "") -> None:
-    """Wire service -backed_by-> store -contains-> record -holds-> flag."""
+    # service -backed_by-> store -contains-> record -holds-> flag
     g.add_node(Node(id=f"store{suffix}", kind="data_store"))
     g.add_node(Node(id=f"record{suffix}", kind="record"))
     g.add_node(_hidden("secret_flag", "secret", kind="flag"))

--- a/tests/test_cyber_vulnerabilities.py
+++ b/tests/test_cyber_vulnerabilities.py
@@ -47,6 +47,7 @@ def test_catalog_has_starter_vulns() -> None:
         "ssti",
         "idor",
         "weak_credentials",
+        "metadata_credential_leak",
     }
     assert vuln("sql_injection") is SQL_INJECTION
 
@@ -63,6 +64,7 @@ def test_vulns_for_kind_filters_by_target() -> None:
         "ssti",
         "idor",
         "weak_credentials",
+        "metadata_credential_leak",
     }
     assert vulns_for_kind("network") == ()
 

--- a/tests/test_cyber_vulnerabilities.py
+++ b/tests/test_cyber_vulnerabilities.py
@@ -216,6 +216,87 @@ def test_ssrf_reaches_internal_host_and_leaks() -> None:
     assert b"ORANGE{ssrf_leaked}" not in body
 
 
+def test_ssrf_networked_fetches_the_internal_host_for_real() -> None:
+    """Under OPENRANGE_NETWORKED the handler opens a real socket to the internal
+    host instead of reading the secret in-process — the flag comes off the wire."""
+    import http.server
+    import os
+    import threading
+
+    served = b'{"credential": "ORANGE{networked_fetch}"}'
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - stdlib handler name
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(served)
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    try:
+        server = http.server.HTTPServer(("127.0.0.1", 8000), _Handler)
+    except OSError:
+        pytest.skip("port 8000 unavailable for the internal-host stand-in")
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        src = render_vulnerability(
+            SSRF,
+            {
+                "target_param": "url",
+                "internal_host": "127.0.0.1",
+                "internal_path": "/latest/meta-data/credential",
+                "allowed_host": "ok.example.com",
+                "ssrf_filter": "host_allowlist",
+            },
+        )
+        handle = _exec_handler(src)
+        os.environ["OPENRANGE_NETWORKED"] = "1"
+        try:
+            status, _, body = handle(
+                {
+                    "url": [
+                        "http://ok.example.com@127.0.0.1/latest/meta-data/credential"
+                    ]
+                },
+                {"secrets": {"flag": "ORANGE{in_process_should_not_appear}"}},
+            )
+        finally:
+            os.environ.pop("OPENRANGE_NETWORKED", None)
+    finally:
+        server.shutdown()
+    assert status == 200
+    assert b"ORANGE{networked_fetch}" in body  # the secret came across the network
+    assert b"in_process_should_not_appear" not in body  # not the shared-state read
+
+
+def test_ssrf_networked_502_when_internal_unreachable() -> None:
+    import os
+
+    src = render_vulnerability(
+        SSRF,
+        {
+            "target_param": "url",
+            "internal_host": "no-such-host.invalid",  # RFC 2606: never resolves
+            "internal_path": "/x",
+            "allowed_host": "ok.example.com",
+            "ssrf_filter": "host_allowlist",
+        },
+    )
+    handle = _exec_handler(src)
+    os.environ["OPENRANGE_NETWORKED"] = "1"
+    try:
+        status, _, body = handle(
+            {"url": ["http://ok.example.com@no-such-host.invalid/x"]},
+            {"secrets": {"flag": "unused"}},
+        )
+    finally:
+        os.environ.pop("OPENRANGE_NETWORKED", None)
+    assert status == 502
+    assert b"ssrf fetch failed" in body
+
+
 def test_ssrf_post_hoc_allowlist_lets_through_matching_url() -> None:
     src = render_vulnerability(
         SSRF,

--- a/tests/test_trl_adapter.py
+++ b/tests/test_trl_adapter.py
@@ -17,7 +17,7 @@ from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import pytest
-from openrange_pack_sdk import EpisodeResult, Snapshot
+from openrange_pack_sdk import Backing, EpisodeResult, Snapshot
 from openrange_trl import (
     EpisodeEnv,
     FileWorkspaceTools,
@@ -27,6 +27,7 @@ from openrange_trl import (
     env_trajectory,
     make_environment_factory,
     make_reward_func,
+    make_web_environment_factory,
     reward_variance_policy,
 )
 from swe import SwePack
@@ -66,6 +67,25 @@ def make_env(tmp_path: Path) -> Iterator[EnvMaker]:
 def _solve(env: OpenRangeEnv, instance: str) -> None:
     for path, content in load_instance(instance).gold_files.items():
         env.write_file(path, content)
+
+
+def test_factories_thread_backing_into_each_rollout_service(tmp_path: Path) -> None:
+    # The factory's ``backing`` reaches every rollout's EpisodeService unchanged, so a
+    # GRPO run can train against the CONTAINER runtime (incl. the networked one). The
+    # default stays PROCESS. No reset here — just the constructed service, no realize.
+    snapshot = _admit("calc_sum")
+    default_factory = make_environment_factory(SwePack(), [snapshot], tmp_path / "proc")
+    container_factory = make_web_environment_factory(
+        SwePack(), [snapshot], tmp_path / "cont", backing=Backing.CONTAINER
+    )
+    proc_env = default_factory()
+    cont_env = container_factory()
+    try:
+        assert proc_env.service.backing is Backing.PROCESS
+        assert cont_env.service.backing is Backing.CONTAINER
+    finally:
+        proc_env.service.close()
+        cont_env.service.close()
 
 
 def test_base_env_resets_with_no_tools(tmp_path: Path) -> None:

--- a/tests/test_trl_adapter.py
+++ b/tests/test_trl_adapter.py
@@ -70,9 +70,8 @@ def _solve(env: OpenRangeEnv, instance: str) -> None:
 
 
 def test_factories_thread_backing_into_each_rollout_service(tmp_path: Path) -> None:
-    # The factory's ``backing`` reaches every rollout's EpisodeService unchanged, so a
-    # GRPO run can train against the CONTAINER runtime (incl. the networked one). The
-    # default stays PROCESS. No reset here — just the constructed service, no realize.
+    # The factory builds each service before any realize, so the backing it threads
+    # through is observable without booting docker — and the default must stay PROCESS.
     snapshot = _admit("calc_sum")
     default_factory = make_environment_factory(SwePack(), [snapshot], tmp_path / "proc")
     container_factory = make_web_environment_factory(

--- a/tests/test_trl_live.py
+++ b/tests/test_trl_live.py
@@ -262,7 +262,6 @@ def test_live_grpo_one_step_cyber_container(tmp_path: Path) -> None:
         if "pentest" in row["task_id"]
     ]
     dataset = datasets.Dataset.from_list(rows)
-    # The change under test: CONTAINER backing threaded through the web factory.
     factory = make_web_environment_factory(
         pack, [snapshot], tmp_path / "envs", backing=Backing.CONTAINER
     )

--- a/tests/test_trl_live.py
+++ b/tests/test_trl_live.py
@@ -18,9 +18,12 @@ so the default CI suite stays GPU-free. The bigger-model demonstration of *learn
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
+from openrange_pack_sdk import Backing
 from openrange_trl import (
     WEB_TOOL_GUIDE,
     EpisodeEnv,
@@ -32,6 +35,19 @@ from openrange_trl import (
 )
 
 from openrange.core.admit import AdmissionFailure, admit
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        probe = subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=10, check=False
+        )
+    except Exception:  # noqa: BLE001 - any failure means "no"
+        return False
+    return probe.returncode == 0
+
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("OPENRANGE_LIVE_TRL") != "1",
@@ -190,6 +206,102 @@ def test_live_grpo_one_step_cyber(tmp_path: Path) -> None:
         graded = [env for env in envs if env.report is not None]
         assert graded, "no rollout reached grading"
         for env in graded:
+            trajectory = env_trajectory(env)
+            assert trajectory.snapshot_id == snapshot.snapshot_id
+            assert 0.0 <= trajectory.reward.scalar <= 1.0
+    finally:
+        for env in envs:
+            env.service.close()
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
+def test_live_grpo_one_step_cyber_container(tmp_path: Path) -> None:
+    """One real GRPO step over a *networked* cyber world on the CONTAINER backing:
+    each rollout boots per-service containers, the policy acts over HTTP across the
+    docker network, rollouts grade, reward + trajectory flow. Proves the networked
+    multi-service runtime is a real training environment, not only a runnable one."""
+    datasets = pytest.importorskip("datasets")
+    peft = pytest.importorskip("peft")
+    transformers = pytest.importorskip("transformers")
+    trl = pytest.importorskip("trl")
+
+    from cyber_webapp import WebappPack, _is_networked
+
+    pack = WebappPack()
+    snapshot = admit(
+        pack,
+        manifest={
+            "world": {"goal": "recover the flag"},
+            "pack": {"id": "webapp"},
+            "runtime": {"tick": {"mode": "off"}},
+            "npc": [],
+            "seed": 3,
+            "vuln_kinds": {"ssrf": 1},
+            "difficulty": "easy",
+        },
+    )
+    assert not isinstance(snapshot, AdmissionFailure)
+    # The world must be networked so the CONTAINER backing routes to the multi-service
+    # runtime — otherwise this would only exercise the single-container path.
+    assert _is_networked(snapshot.graph)
+
+    model = transformers.AutoModelForCausalLM.from_pretrained(_MODEL)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(_MODEL)
+    lora = peft.LoraConfig(
+        r=8,
+        lora_alpha=16,
+        lora_dropout=0.0,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+        task_type="CAUSAL_LM",
+    )
+
+    num_generations = 2
+    rows = [
+        row
+        for row in build_grpo_dataset(snapshot, repeat=2, tool_guide=WEB_TOOL_GUIDE)
+        if "pentest" in row["task_id"]
+    ]
+    dataset = datasets.Dataset.from_list(rows)
+    # The change under test: CONTAINER backing threaded through the web factory.
+    factory = make_web_environment_factory(
+        pack, [snapshot], tmp_path / "envs", backing=Backing.CONTAINER
+    )
+    config = trl.GRPOConfig(
+        output_dir=str(tmp_path / "trainer"),
+        per_device_train_batch_size=num_generations,
+        num_generations=num_generations,
+        steps_per_generation=1,
+        gradient_accumulation_steps=1,
+        max_steps=1,
+        beta=0.0,
+        temperature=1.0,
+        max_completion_length=128,
+        max_tool_calling_iterations=3,
+        use_vllm=False,
+        log_completions=False,
+        report_to="none",
+        save_strategy="no",
+        bf16=False,
+        fp16=False,
+    )
+    trainer = trl.GRPOTrainer(
+        model=model,
+        reward_funcs=[make_reward_func()],
+        args=config,
+        train_dataset=dataset,
+        processing_class=tokenizer,
+        environment_factory=factory,
+        peft_config=lora,
+    )
+
+    envs: list[EpisodeEnv] = list(trainer.environments or ())
+    try:
+        trainer.train()
+
+        graded = [env for env in envs if env.report is not None]
+        assert graded, "no rollout reached grading on the CONTAINER backing"
+        for env in graded:
+            assert env.service.backing is Backing.CONTAINER
             trajectory = env_trajectory(env)
             assert trajectory.snapshot_id == snapshot.snapshot_id
             assert 0.0 <= trajectory.reward.scalar <= 1.0


### PR DESCRIPTION
## What this does

Makes network position **real** for the cyber gym, end to end: a networked SSRF world generates, realizes as **one container per service on a real docker network**, and is solved by a **real cross-container exploit** — the agent makes the public service's SSRF fetch an internal service that holds the flag. The flag is reachable only by pivoting, not by a path on a shared server.

**Per-service realization.** `realize_services(graph)` splits a world into one build context per `service` node — each carrying only its own endpoints and only its own state (the secrets/records/files of the data_stores it's `backed_by`). The flag stays in the internal service that owns it and **never enters the public service's image**. The split threads an additive `only_services` scope through the seed projection, the handler/route builder (per-service apps route on bare paths, each being its own container), and the discovery doc.

**Networked runtime.** `NetworkedContainerWebappRuntime` runs each service as its own container on a real docker network: the public service is the foreground child (it gives the agent's `base_url`), the internal services run detached, reachable only by name and never published. The leak signal aggregates across every service's request log (the internal service detects it leaking its own flag). `WebappPack.realize` routes a world here only when it's genuinely **networked-shaped** (`_is_networked`: an SSRF on a *public* service).

**Networked-shaped generation.** An SSRF world is now networked by construction. The sampler re-homes the SSRF onto the public service's endpoint and adds the internal half on the flag's own service: a `metadata_credential_leak` endpoint that serves the flag, which the SSRF `enables`. Feasibility and entrypoint selection follow that pivot — the flag-bearing internal service counts as reachable, and the agent starts at the public endpoint it actually attacks. The internal-only metadata class is kept out of general sampling, so it can never sit on a reachable endpoint (which would leak the flag with no exploit).

**Real cross-container SSRF.** Under `OPENRANGE_NETWORKED` (set by the networked runtime on the public container) the SSRF handler opens a real socket to the internal host instead of reading the secret in-process. The flag — confined to an internal container the host can't address — comes off the wire.

## Proof (docker-gated, live)

- **End-to-end pivot.** Bring up the per-service world; the exploit (`?callback=gopher://<internal>/latest/meta-data/credential`) recovers the flag, while a benign fetch **and** a direct hit on the internal path both leak nothing, and the internal service is never reachable from the host. `collect()` sees the leak in the aggregated logs.
- **Cross-backing parity.** The same exploit solves the same world on `PROCESS` (in-process read, via the real episode harness) and the networked `CONTAINER` (real fetch) — same flag, only the runtime fidelity differs.
- **Real network position.** The public service answers from the host; an internal service answers only from inside the network, by name.

Plus unit coverage: per-service realization (each app valid, bare-path routed, flag confined to one service); feasibility/entrypoint following the `enables` pivot; the `_networkize_ssrf` transform and its guards; the SSRF template's networked branch (real local-server fetch + a 502 when the internal host is down); the routing predicate; and that the metadata class is filtered from general sampling.

## No regression

Worlds whose vuln sits directly on the flag's own service are unchanged — they stay single-container and solve as before. Non-SSRF seeds keep their entrypoints and feasibility.

Follows `.rules` (integration tests, no mocks/fakes — real subprocesses, real docker, real HTTP; comments WHY-only); new code at 100% branch coverage (the docker lifecycle is exercised live, with re-entry guards pragma'd). Built rung-by-rung — each increment green before the next. Design in `packs/cyber_webapp/DESIGN.md` §10. Closes #267.



---

## Live validation — it actually trains and a real agent solves it

This isn't just scripted-exploit-green. The networked CONTAINER world was driven through the real eval/training loop three ways:

- **Graded through the harness.** A docker-gated test runs the networked SSRF world through `EpisodeService(backing=CONTAINER)` end to end — `start_episode` → exploit across the network → `result.json` → `stop_episode` → `check_success` — the same path `run_episode` and the trainer use. `passed=True, reason="flag matched"`.
- **One real GRPO step (TRL).** The TRL web factory now takes a `backing`; a gated live test runs `trl.GRPOTrainer` for one step over the networked CONTAINER world. Each rollout boots per-service containers, the policy acts over HTTP across the docker network, both rollouts reach grading, and structured reward + a snapshot-tagged trajectory flow back. (A 0.5B model doesn't *solve* SSRF — this asserts the training mechanics, like the existing PROCESS live test.)
- **A real LLM agent cracked it.** Out of band (not a committed test — LLM runs are non-deterministic), a real `claude -p` agent was handed only the live `base_url` + the guided instruction. It `curl`'d the SSRF pivot to the internal metadata host across containers and recovered the exact flag — graded `success=True`.

Net: the cyber gym is now trainable on the *real* networked container backing, not only the emulated one, and a capable agent genuinely solves the cross-container exploit.
