### PR TITLE
Cyber: LLM realizes vuln handlers for any class, gated by the reference solver (#260)

### DIFF
--- a/examples/cyber_realize.py
+++ b/examples/cyber_realize.py
@@ -1,117 +1,83 @@
-"""Close the LLM-realization loop with a real LLM (the codex harness).
+"""Close the LLM-realization loop with a real LLM (DESIGN.md §9, #260).
 
-The LLM writes a command-injection handler; we inject it into a procedurally-built
-world and run it through the dynamic admission gate (cyber_webapp.realize_admit): the
-exploit must leak the flag, a benign request must not. Accepted handlers are the LLM's
-own varied-but-valid implementations; trivial or broken ones are rejected.
+For each realizable class, the LLM writes the vuln handler; we inject it into a
+procedurally-built world and run it through the dynamic admission gate (realize_admit +
+reference_solver): the intended exploit must leak the flag, a benign request must not.
+Accepted handlers are the LLM's own varied-but-valid implementations; trivial or broken
+ones are rejected.
 
 Run::
 
-    uv run python -m examples.cyber_realize --rounds 5
+    uv run python -m examples.cyber_realize --rounds 3            # all classes
+    uv run python -m examples.cyber_realize --kind sql_injection  # just one
 """
 
 from __future__ import annotations
 
 import argparse
 import tempfile
+import urllib.error
 import urllib.request
 from pathlib import Path
 
 from cyber_webapp import WebappPack
-from cyber_webapp.realize_admit import (
-    AdmissionVerdict,
-    classify_admission,
-    cmdi_exploit_and_benign,
+from cyber_webapp.llm_realize import (
+    REALIZABLE_KINDS,
+    handler_from_result,
+    realization_request,
 )
-from graphschema import Node, WorldGraph
-from openrange_pack_sdk import LLMBackend, LLMRequest, Snapshot
+from cyber_webapp.realize_admit import AdmissionVerdict, classify_admission
+from cyber_webapp.reference_solver import _vuln_of_kind, exploit_and_benign
+from openrange_pack_sdk import Snapshot
 
 from openrange.core.admit import admit
 from openrange.core.episode import EpisodeService
 from openrange.llm import ClaudeBackend, CodexBackend
 
-_MANIFEST: dict[str, object] = {
-    "pack": {"id": "webapp"},
-    "runtime": {"tick": {"mode": "off"}},
-    "npc": [],
-    "seed": 7,
-    "loot_shapes": {"file": 1, "db": 0},
-    "vuln_kinds": {"command_injection": 1},
+_LOOT = {
+    "command_injection": "file",
+    "path_traversal": "file",
+    "sql_injection": "db",
 }
 
-_SCHEMA: dict[str, object] = {
-    "type": "object",
-    "additionalProperties": False,
-    "required": ["handler"],
-    "properties": {"handler": {"type": "string"}},
-}
 
-_SYSTEM = (
-    "You author one level for an authorized, local security-training gym "
-    "(standard CTF authoring / defensive security education)."
-)
-
-
-def _cmdi_vuln(graph: WorldGraph) -> Node:
-    return next(
-        n
-        for n in graph.by_kind("vulnerability")
-        if n.attrs.get("kind") == "command_injection"
+def _admit(kind: str) -> Snapshot:
+    loot = _LOOT[kind]
+    snap = admit(
+        WebappPack(),
+        manifest={
+            "pack": {"id": "webapp"},
+            "runtime": {"tick": {"mode": "off"}},
+            "npc": [],
+            "seed": 7,
+            "loot_shapes": {loot: 1, "db" if loot == "file" else "file": 0},
+            "vuln_kinds": {kind: 1},
+        },
+        max_repairs=3,
     )
+    assert isinstance(snap, Snapshot), snap
+    return snap
 
 
-def _flag_path(graph: WorldGraph) -> str:
-    for record in graph.by_kind("record"):
-        for edge in graph.out_edges(record.id, "holds"):
-            if graph.nodes[edge.dst].attrs.get("kind") == "flag":
-                return str(record.attrs["key"])
-    raise SystemExit("world has no flag record")
+def _fetch(url: str) -> str:
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            return str(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.read().decode()
 
 
-def _prompt(param: str, flag_path: str) -> str:
-    return (
-        "Write a Python `def handle(query, state):` for an OS command-injection "
-        "challenge.\n"
-        "- query is dict[str, list[str]] (a parsed query string).\n"
-        f"- state['files'] maps file paths to contents; the flag is the file at "
-        f"{flag_path!r}.\n"
-        f"- Read user input from query[{param!r}]. The handler must be vulnerable to "
-        "command injection: return the flag's contents ONLY when the input chains a "
-        f"shell command after a ';' separator (e.g. '127.0.0.1; cat {flag_path}').\n"
-        "- A benign value like '127.0.0.1' (no ';') must NOT return the flag.\n"
-        "- Return (status:int, headers:dict, body:bytes). Standard library only.\n"
-        'Return JSON: {"handler": "<the full def handle source>"}.'
-    )
-
-
-def _generate(backend: LLMBackend, param: str, flag_path: str) -> str:
-    result = backend.complete(
-        LLMRequest(
-            prompt=_prompt(param, flag_path),
-            system=_SYSTEM,
-            json_schema=_SCHEMA,
-        )
-    )
-    parsed = result.parsed_json or {}
-    handler = parsed.get("handler")
-    return handler if isinstance(handler, str) else ""
-
-
-def _gate(snap: Snapshot, handler: str, tmp_path: Path) -> AdmissionVerdict:
+def _gate(snap: Snapshot, kind: str, handler: str, workdir: Path) -> AdmissionVerdict:
     graph = snap.graph
-    _cmdi_vuln(graph).attrs["realized_handler"] = handler
-    exploit_path, benign_path = cmdi_exploit_and_benign(graph)
-    service = EpisodeService(WebappPack(), tmp_path)
+    _vuln_of_kind(graph, kind).attrs["realized_handler"] = handler
+    exploit_path, benign_path = exploit_and_benign(graph, kind)
+    service = EpisodeService(WebappPack(), workdir)
     try:
         task = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
         handle = service.start_episode(snap, task.id)
         base = str(service.surface(handle)["base_url"])
-        exploit_body = (
-            urllib.request.urlopen(base + exploit_path, timeout=10).read().decode()
-        )
-        benign_body = (
-            urllib.request.urlopen(base + benign_path, timeout=10).read().decode()
-        )
+        exploit_body = _fetch(base + exploit_path)
+        benign_body = _fetch(base + benign_path)
     finally:
         service.close()
     return classify_admission(graph, exploit_body, benign_body)
@@ -119,44 +85,42 @@ def _gate(snap: Snapshot, handler: str, tmp_path: Path) -> AdmissionVerdict:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--rounds", type=int, default=3)
     parser.add_argument("--backend", choices=("claude", "codex"), default="claude")
+    parser.add_argument("--kind", choices=REALIZABLE_KINDS, default=None)
     args = parser.parse_args(argv)
 
     backend = ClaudeBackend() if args.backend == "claude" else CodexBackend()
     backend.preflight()
-    snap = admit(WebappPack(), manifest=_MANIFEST, max_repairs=3)
-    assert isinstance(snap, Snapshot), snap
-    vuln = _cmdi_vuln(snap.graph)
-    params = vuln.attrs["params"]
-    assert isinstance(params, dict)
-    params["inj_context"] = "separator"  # pin the exploit shape the gate will use
-    param = str(params["target_param"])
-    flag_path = _flag_path(snap.graph)
+    kinds = [args.kind] if args.kind else list(REALIZABLE_KINDS)
 
-    accepted: list[str] = []
+    total = 0
     with tempfile.TemporaryDirectory() as tmp:
-        for index in range(args.rounds):
-            handler = _generate(backend, param, flag_path)
-            if not handler.strip():
-                print(f"round {index}: REFUSED/empty — no handler returned")
-                continue
-            try:
-                verdict = _gate(snap, handler, Path(tmp) / f"r{index}")
-            except Exception as exc:  # noqa: BLE001
-                print(f"round {index}: REJECT — handler crashed the world: {exc}")
-                continue
+        for kind in kinds:
+            snap = _admit(kind)
+            request = realization_request(snap.graph, kind)
+            accepted: list[str] = []
+            for index in range(args.rounds):
+                handler = handler_from_result(backend.complete(request).parsed_json)
+                if not handler.strip():
+                    print(f"{kind} r{index}: REFUSED/empty")
+                    continue
+                try:
+                    verdict = _gate(snap, kind, handler, Path(tmp) / f"{kind}{index}")
+                except Exception as exc:  # noqa: BLE001
+                    print(f"{kind} r{index}: REJECT — handler crashed: {exc}")
+                    continue
+                tag = "ACCEPT" if verdict.accepted else "REJECT"
+                print(f"{kind} r{index}: {tag} — {verdict.reason}")
+                if verdict.accepted:
+                    accepted.append(handler)
             print(
-                f"round {index}: {'ACCEPT' if verdict.accepted else 'REJECT'} "
-                f"— {verdict.reason}"
+                f"  {kind}: {len(accepted)}/{args.rounds} accepted, "
+                f"{len(set(accepted))} distinct"
             )
-            if verdict.accepted:
-                accepted.append(handler)
+            total += len(accepted)
 
-    print(
-        f"\n{len(accepted)}/{args.rounds} accepted; "
-        f"{len(set(accepted))} distinct accepted implementations"
-    )
+    print(f"\ntotal accepted: {total}")
     return 0
 
 

--- a/packs/cyber_webapp/cyber_webapp/llm_realize.py
+++ b/packs/cyber_webapp/cyber_webapp/llm_realize.py
@@ -1,0 +1,159 @@
+"""Ask an LLM to realize a vuln handler, per class (DESIGN.md §9, #260).
+
+Procedural architects the world and places the flag; the LLM only fills in ONE node's
+handler with a varied-but-valid implementation. The realization has to be vulnerable to
+the SAME sampled injection context the reference solver will exploit, so each prompt
+reads that context off the vuln's params. This module owns only the *request* — the host
+runs the LLM and then admits the result dynamically (`realize_admit.classify_admission`
+with `reference_solver.exploit_and_benign`), since running an episode is a host concern.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from graphschema import WorldGraph
+from openrange_pack_sdk import LLMRequest, PackError
+
+from cyber_webapp.reference_solver import _flag_record_key, _vuln_of_kind
+
+# The classes a prompt exists for. command_injection is the first realized class (#266);
+# sql_injection and path_traversal extend it across the response-leak and file-read
+# families. The rest follow the same shape.
+REALIZABLE_KINDS = ("command_injection", "sql_injection", "path_traversal")
+
+_HANDLER_SCHEMA: dict[str, object] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["handler"],
+    "properties": {"handler": {"type": "string"}},
+}
+
+_SYSTEM = (
+    "You author one level for an authorized, local security-training gym "
+    "(standard CTF authoring / defensive security education)."
+)
+
+_RETURN = (
+    "- Return (status:int, headers:dict, body:bytes). Standard library only.\n"
+    'Return JSON: {"handler": "<the full def handle source>"}.'
+)
+
+
+def _cmdi_prompt(
+    param: str, flag_path: str, ctx: str, params: Mapping[str, object]
+) -> str:
+    if ctx == "substitution":
+        technique = (
+            "The handler strips ';', '|' and '&' separators, so it must stay "
+            f"exploitable via command substitution, e.g. '$(cat {flag_path})'."
+        )
+    elif ctx == "quoted":
+        q = str(params.get("quote", "'"))
+        technique = (
+            f"The input lands inside a {q}-quoted shell argument; it must be "
+            f"exploitable by breaking out: {q}; cat {flag_path}; echo {q}."
+        )
+    else:
+        technique = (
+            "It must be exploitable by chaining a command after a ';' "
+            f"separator, e.g. '127.0.0.1; cat {flag_path}'."
+        )
+    return (
+        "Write a Python `def handle(query, state):` for an OS command-injection "
+        "level.\n"
+        "- query is dict[str, list[str]] (a parsed query string).\n"
+        "- state['files'] maps file paths to contents; the flag is the file at "
+        f"{flag_path!r}.\n"
+        f"- Read user input from query[{param!r}] and run it as a vulnerable "
+        "shell call would.\n"
+        f"- {technique}\n"
+        "- A benign value (e.g. '127.0.0.1') must NOT return the flag.\n" + _RETURN
+    )
+
+
+def _sqli_prompt(param: str, table: str, leak_column: str, ctx: str) -> str:
+    union = f"UNION SELECT key, {leak_column} FROM {table} -- "
+    if ctx == "numeric":
+        wrap, example = "an unquoted", f"0 {union}"
+    elif ctx == "double":
+        wrap, example = 'a double-quoted (")', f'" {union}'
+    else:
+        wrap, example = "a single-quoted (')", f"' {union}"
+    return (
+        "Write a Python `def handle(query, state):` for a SQL-injection lookup "
+        "level.\n"
+        "- query is dict[str, list[str]].\n"
+        "- state['db'] is a sqlite3 connection whose rows read as dicts; "
+        "state['schema']['key_column'] is the key column.\n"
+        f"- The records table is {table!r} with the key column and a "
+        f"{leak_column!r} column; the flag is the value in that column for one row.\n"
+        f"- Concatenate query[{param!r}] into the WHERE clause with NO "
+        f"parameterization, in {wrap} string context, so a UNION payload "
+        f"surfaces every row, e.g. {example}\n"
+        "- A benign id must return only its own (non-flag) row.\n" + _RETURN
+    )
+
+
+def _path_prompt(param: str, flag_path: str, base_dir: str, ctx: str) -> str:
+    if ctx == "relative":
+        technique = (
+            "Re-anchor an absolute path under base_dir, but let a relative '../' "
+            f"chain climb out, so enough '../' segments reach {flag_path!r}."
+        )
+    elif ctx == "dotdot_filter":
+        technique = (
+            "Strip '../' exactly once (so '....//' collapses back to '../' and "
+            "survives) and re-anchor absolute paths; only the '....//' form escapes."
+        )
+    else:
+        technique = (
+            "Strip relative '../' chains but honor an absolute path "
+            f"(posixpath.join drops the base), so an absolute {flag_path!r} leaks."
+        )
+    return (
+        "Write a Python `def handle(query, state):` for a path-traversal "
+        "file-serving level.\n"
+        "- query is dict[str, list[str]].\n"
+        "- state['files'] maps absolute file paths to contents; the flag is at "
+        f"{flag_path!r}.\n"
+        f"- Join query[{param!r}] onto base_dir {base_dir!r} without proper "
+        "confinement.\n"
+        f"- {technique}\n"
+        "- A benign filename must NOT return the flag.\n" + _RETURN
+    )
+
+
+def realization_request(graph: WorldGraph, kind: str) -> LLMRequest:
+    """The LLM request to realize `kind`'s handler, tailored to its sampled context.
+
+    Raises if `kind` has no prompt yet (see `REALIZABLE_KINDS`). The host runs this
+    against an `LLMBackend` and passes the returned handler through the admission gate.
+    """
+    vuln = _vuln_of_kind(graph, kind)
+    params = vuln.attrs["params"]
+    if not isinstance(params, Mapping):
+        raise PackError(f"{kind} vuln has no params mapping")
+    param = str(params["target_param"])
+    if kind == "command_injection":
+        ctx = str(params.get("inj_context", "separator"))
+        prompt = _cmdi_prompt(param, _flag_record_key(graph), ctx, params)
+    elif kind == "sql_injection":
+        ctx = str(params.get("context", "single"))
+        prompt = _sqli_prompt(
+            param, str(params["table"]), str(params["leak_column"]), ctx
+        )
+    elif kind == "path_traversal":
+        ctx = str(params.get("confinement", "absolute_only"))
+        prompt = _path_prompt(
+            param, _flag_record_key(graph), str(params["base_dir"]), ctx
+        )
+    else:
+        raise PackError(f"no LLM realization prompt for kind {kind!r}")
+    return LLMRequest(prompt=prompt, system=_SYSTEM, json_schema=_HANDLER_SCHEMA)
+
+
+def handler_from_result(parsed_json: Mapping[str, object] | None) -> str:
+    """The handler source out of an LLM result's parsed JSON, or '' if absent."""
+    handler = (parsed_json or {}).get("handler")
+    return handler if isinstance(handler, str) else ""

--- a/tests/test_cyber_llm_realize.py
+++ b/tests/test_cyber_llm_realize.py
@@ -1,0 +1,204 @@
+"""LLM handler realization across classes (DESIGN.md §9, #260).
+
+Two halves, both free of a live LLM: the per-class realization *request* is a pure
+function of the world (tested directly), and the dynamic admission gate is exercised by
+injecting hand-written handlers — a faithful one is admitted, a trivial one rejected —
+proving the gate generalizes past command-injection to the response-leak and file-read
+families via the reference solver.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+from cyber_webapp import WebappPack
+from cyber_webapp.llm_realize import (
+    handler_from_result,
+    realization_request,
+)
+from cyber_webapp.ontology import ONTOLOGY_ID
+from cyber_webapp.realize_admit import AdmissionVerdict, classify_admission
+from cyber_webapp.reference_solver import _vuln_of_kind, exploit_and_benign
+from graphschema import Node, WorldGraph
+from openrange_pack_sdk import PackError, Snapshot
+
+from openrange.core.admit import admit
+from openrange.core.episode import EpisodeService
+
+
+def _admit(loot: str, kind: str, **pin: object) -> Snapshot:
+    snap = admit(
+        WebappPack(),
+        manifest={
+            "pack": {"id": "webapp"},
+            "runtime": {"tick": {"mode": "off"}},
+            "npc": [],
+            "seed": 7,
+            "loot_shapes": {loot: 1, "db" if loot == "file" else "file": 0},
+            "vuln_kinds": {kind: 1},
+        },
+        max_repairs=3,
+    )
+    assert isinstance(snap, Snapshot), snap
+    if pin:
+        params = _vuln_of_kind(snap.graph, kind).attrs["params"]
+        assert isinstance(params, dict)
+        params.update(pin)  # pin the context so the exploit + handler agree
+    return snap
+
+
+def _fetch(url: str) -> str:
+    try:
+        with urllib.request.urlopen(url, timeout=15) as resp:
+            return str(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.read().decode()
+
+
+def _gate(snap: Snapshot, kind: str, handler: str, workdir: Path) -> AdmissionVerdict:
+    graph = snap.graph
+    _vuln_of_kind(graph, kind).attrs["realized_handler"] = handler
+    exploit_path, benign_path = exploit_and_benign(graph, kind)
+    svc = EpisodeService(WebappPack(), workdir)
+    try:
+        task = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+        handle = svc.start_episode(snap, task.id)
+        base = str(svc.surface(handle)["base_url"])
+        exploit_body, benign_body = (
+            _fetch(base + exploit_path),
+            _fetch(base + benign_path),
+        )
+    finally:
+        svc.close()
+    return classify_admission(graph, exploit_body, benign_body)
+
+
+def _faithful_sqli(graph: WorldGraph) -> str:
+    p = _vuln_of_kind(graph, "sql_injection").attrs["params"]
+    param, table, leak = str(p["target_param"]), str(p["table"]), str(p["leak_column"])
+    return "\n".join(
+        [
+            "def handle(query, state):",
+            "    import json",
+            f"    val = (query.get({param!r}, ['']) or [''])[0]",
+            "    kc = state['schema']['key_column']",
+            f'    sql = "SELECT " + kc + ", {leak} FROM {table} WHERE " + kc'
+            ' + " = \'" + val + "\'"',
+            "    try:",
+            "        rows = [dict(r) for r in state['db'].execute(sql).fetchall()]",
+            "    except Exception as e:",
+            "        return 500, {}, json.dumps({'error': str(e)}).encode()",
+            "    return 200, {}, json.dumps({'rows': rows}).encode()",
+        ]
+    )
+
+
+def _trivial_sqli(graph: WorldGraph) -> str:
+    p = _vuln_of_kind(graph, "sql_injection").attrs["params"]
+    table, leak = str(p["table"]), str(p["leak_column"])
+    return "\n".join(
+        [
+            "def handle(query, state):",
+            "    import json",
+            f"    rows = [dict(r) for r in"
+            f" state['db'].execute('SELECT key, {leak} FROM {table}').fetchall()]",
+            "    return 200, {}, json.dumps({'rows': rows}).encode()",
+        ]
+    )
+
+
+def _faithful_path(graph: WorldGraph) -> str:
+    p = _vuln_of_kind(graph, "path_traversal").attrs["params"]
+    param, base = str(p["target_param"]), str(p["base_dir"])
+    return "\n".join(
+        [
+            "def handle(query, state):",
+            "    import posixpath",
+            f"    req = (query.get({param!r}, ['']) or [''])[0]",
+            "    while '../' in req:",
+            "        req = req.replace('../', '')",
+            f"    resolved = posixpath.normpath(posixpath.join({base!r}, req))",
+            "    files = state.get('files', {})",
+            "    if resolved in files:",
+            "        return 200, {}, str(files[resolved]).encode()",
+            "    return 404, {}, b'nope'",
+        ]
+    )
+
+
+_CONTEXTS = [
+    ("command_injection", "file", "inj_context", "separator"),
+    ("command_injection", "file", "inj_context", "substitution"),
+    ("command_injection", "file", "inj_context", "quoted"),
+    ("sql_injection", "db", "context", "single"),
+    ("sql_injection", "db", "context", "numeric"),
+    ("sql_injection", "db", "context", "double"),
+    ("path_traversal", "file", "confinement", "absolute_only"),
+    ("path_traversal", "file", "confinement", "relative"),
+    ("path_traversal", "file", "confinement", "dotdot_filter"),
+]
+
+
+@pytest.mark.parametrize(("kind", "loot", "key", "ctx"), _CONTEXTS)
+def test_realization_request_per_context(
+    kind: str, loot: str, key: str, ctx: str
+) -> None:
+    # Every class × sampled-context pair yields a handler-authoring prompt that names
+    # the flag, so the realized handler matches the exploit the solver will run.
+    req = realization_request(_admit(loot, kind, **{key: ctx}).graph, kind)
+    assert "def handle" in req.prompt
+    assert "flag" in req.prompt.lower()
+    assert req.json_schema is not None
+
+
+def test_realization_request_sqli_names_its_table() -> None:
+    graph = _admit("db", "sql_injection").graph
+    table = str(_vuln_of_kind(graph, "sql_injection").attrs["params"]["table"])
+    assert table in realization_request(graph, "sql_injection").prompt
+
+
+def test_realization_request_rejects_unrealized_kind() -> None:
+    # ssti has a vuln in the graph but no realization prompt yet.
+    with pytest.raises(PackError):
+        realization_request(_admit("file", "ssti").graph, "ssti")
+
+
+def test_realization_request_rejects_non_mapping_params() -> None:
+    graph = WorldGraph(ontology=ONTOLOGY_ID)
+    graph.add_node(
+        Node(
+            id="v",
+            kind="vulnerability",
+            attrs={"kind": "command_injection", "params": "not-a-map"},
+        )
+    )
+    with pytest.raises(PackError):
+        realization_request(graph, "command_injection")
+
+
+def test_handler_from_result() -> None:
+    assert handler_from_result({"handler": "def handle(): ..."}) == "def handle(): ..."
+    assert handler_from_result({}) == ""
+    assert handler_from_result(None) == ""
+    assert handler_from_result({"handler": 123}) == ""
+
+
+def test_gate_admits_a_realized_sqli_handler(tmp_path: Path) -> None:
+    snap = _admit("db", "sql_injection", context="single")
+    accepted = _gate(snap, "sql_injection", _faithful_sqli(snap.graph), tmp_path / "ok")
+    assert accepted.accepted, accepted.reason
+    rejected = _gate(
+        snap, "sql_injection", _trivial_sqli(snap.graph), tmp_path / "triv"
+    )
+    assert not rejected.accepted and rejected.trivial  # benign also leaks
+
+
+def test_gate_admits_a_realized_path_handler(tmp_path: Path) -> None:
+    snap = _admit("file", "path_traversal", confinement="absolute_only")
+    accepted = _gate(
+        snap, "path_traversal", _faithful_path(snap.graph), tmp_path / "ok"
+    )
+    assert accepted.accepted, accepted.reason


### PR DESCRIPTION
## What

Generalizes the LLM-realization gate (DESIGN.md §9, [#260](https://github.com/vecna-labs/open-range/issues/260)) from **command-injection only** to **any vuln class**: the LLM writes a vuln handler, and it's admitted only if the real per-class exploit fires and a benign request doesn't.

The dynamic admission gate already existed but could only check command-injection ([`cmdi_exploit_and_benign`](packs/cyber_webapp/cyber_webapp/realize_admit.py)). Now that the reference solver (`exploit_and_benign(graph, kind)`, merged in #270) covers every shape, the gate works for all of them — this is the realization *primitive* §9 says everything else (real containers, whole networked services [#212], k8s [#189]) builds on.

## How

- **`cyber_webapp/llm_realize.py`** (new): `realization_request(graph, kind)` builds a per-class, **context-aware** handler-authoring prompt. It reads the *sampled injection context* off the vuln's params (e.g. single- vs double-quote SQLi, `absolute_only` vs `relative` traversal) so the LLM's handler is vulnerable to the exact payload the solver will run. Covers `command_injection`, `sql_injection`, `path_traversal` — one per exploit family (code-exec, response-leak, file-read); the rest follow the same shape.
- The pack only builds the *request* and parses the result; the host runs the LLM and the episode (admission is a host concern, per the §8.6 boundary — packs don't import `openrange`).
- **`examples/cyber_realize.py`**: generalized from cmdi-only to any realizable class — `realize → inject → exploit_and_benign → classify_admission`.

The invariant holds at every stage: **procedural architects the world and places the flag; the LLM realizes only one node's handler; admission verifies; freeze.** The LLM never owns correctness.

## Tests (no live LLM, no test doubles)

- the realization request across **all 9 class×context branches** (real worlds, pinned context);
- the gate **admits a hand-written faithful handler and rejects a trivial one** for sqli + path, over **real episodes** (the gate generalization, proven without needing a live LLM);
- defensive: unrealized-kind and non-mapping-params raises.
- `llm_realize` at **100% branch coverage**; mypy + ruff clean.

## Not in this PR

- The remaining 6 classes' prompts (same pattern).
- A live-LLM end-to-end run (the example drives it; needs a backend).
- Whole-service realization (#212) — this is the per-node primitive it builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
