### PR TITLE
feat(trl): bring-your-own tools for the training adapter + brief the agent on the target

### DIFF
--- a/examples/_briefing.py
+++ b/examples/_briefing.py
@@ -1,16 +1,9 @@
 """Render the world's interface contract into an agent prompt.
 
-OpenRange exposes a world through its pack-defined ``surface`` (an HTTP
-``base_url``, a file ``solver_root``, an MCP endpoint, ...) plus the ``task``.
-A harness owns the agent loop, so it must tell its agent *which* interface this
-world presents and *where* — otherwise an agent handed only the instruction
-(which names a path like ``GET /svc/orders-db/backup``, not the dynamic
-host:port) can't reach the target.
-
-``agent_briefing`` is that glue: the task instruction plus a one-line statement
-of the live interface, adapted to whatever the world declares. It reads the
-surface with ``.get`` (not the raising ``EpisodeContext`` accessors) so the same
-helper works for an HTTP world, a file world, or both.
+A harness owns the agent loop, so it must tell its agent which interface the
+world presents and where — an agent handed only the instruction (a path, not the
+dynamic host:port) can't reach the target. ``agent_briefing`` adds that: the task
+plus a one-line statement of the live ``surface`` (HTTP ``base_url`` / file root).
 """
 
 from __future__ import annotations

--- a/examples/_briefing.py
+++ b/examples/_briefing.py
@@ -1,0 +1,33 @@
+"""Render the world's interface contract into an agent prompt.
+
+OpenRange exposes a world through its pack-defined ``surface`` (an HTTP
+``base_url``, a file ``solver_root``, an MCP endpoint, ...) plus the ``task``.
+A harness owns the agent loop, so it must tell its agent *which* interface this
+world presents and *where* — otherwise an agent handed only the instruction
+(which names a path like ``GET /svc/orders-db/backup``, not the dynamic
+host:port) can't reach the target.
+
+``agent_briefing`` is that glue: the task instruction plus a one-line statement
+of the live interface, adapted to whatever the world declares. It reads the
+surface with ``.get`` (not the raising ``EpisodeContext`` accessors) so the same
+helper works for an HTTP world, a file world, or both.
+"""
+
+from __future__ import annotations
+
+from openrange.runtime import EpisodeContext
+
+
+def agent_briefing(ctx: EpisodeContext) -> str:
+    """The task plus the live interface contract, for any harness's agent."""
+    parts = [ctx.task.instruction]
+    base_url = ctx.surface.get("base_url")
+    solver_root = ctx.surface.get("solver_root")
+    if isinstance(base_url, str):
+        parts.append(
+            f"The target web service is running at {base_url} — "
+            "interact with it over HTTP."
+        )
+    elif solver_root is not None:
+        parts.append(f"You are working in the directory {solver_root}.")
+    return "\n\n".join(parts)

--- a/examples/codex_eval.py
+++ b/examples/codex_eval.py
@@ -24,6 +24,7 @@ from openrange_pack_sdk import (
     TaskSpec,
 )
 
+from examples._briefing import agent_briefing
 from openrange.agent_backend import CodexAgentBackend
 from openrange.core import PACKS, auto_evolve
 from openrange.core.episode import AgentTurn, EpisodeReport
@@ -183,7 +184,7 @@ def _codex_solver(harness: CodexHarness) -> Solver:
 
     def solve(ctx: EpisodeContext) -> AgentTurn:
         try:
-            result = harness.run(ctx.task.instruction, ctx.root)
+            result = harness.run(agent_briefing(ctx), ctx.root)
             return AgentTurn(message=result.text)
         except LLMBackendError as exc:
             print(f"agent backend failed on {ctx.task.id}: {exc}", flush=True)

--- a/examples/strands_eval.py
+++ b/examples/strands_eval.py
@@ -14,6 +14,7 @@ from typing import Protocol, cast
 
 from openrange_pack_sdk import LLMResult, OpenRangeError, Snapshot, TaskSpec
 
+from examples._briefing import agent_briefing
 from openrange.core.episode import AgentTurn
 from openrange.runtime import EpisodeContext, OpenRangeRun, RunConfig
 
@@ -72,7 +73,7 @@ def run_task(
     run: OpenRangeRun,
 ) -> dict[str, object]:
     def solve(ctx: EpisodeContext) -> AgentTurn:
-        result = harness.run(ctx.task.instruction, ctx.root)
+        result = harness.run(agent_briefing(ctx), ctx.root)
         return AgentTurn(message=result.text)
 
     ep = run.run_episode(snapshot, solve, task_id=task.id)

--- a/examples/trl_grpo_cyber.ipynb
+++ b/examples/trl_grpo_cyber.ipynb
@@ -4,25 +4,7 @@
    "cell_type": "markdown",
    "id": "80d85d85",
    "metadata": {},
-   "source": [
-    "# Train a model to exploit a live web service with TRL GRPO + LoRA\n",
-    "\n",
-    "OpenRange admits **content-addressed** agent-training worlds. This notebook trains\n",
-    "a small model on the *cyber* pack: every rollout boots a **real HTTP server** with\n",
-    "a planted vulnerability, and the policy must **exploit it over the wire** and\n",
-    "exfiltrate a hidden flag — graded by the world itself, no static dataset of\n",
-    "\"correct\" attacks.\n",
-    "\n",
-    "It is the same torch-free TRL seam that also trains file-editing agents, with a cyber **action surface**:\n",
-    "instead of file tools, the policy gets `http_get` and `submit`. The trainer adapter\n",
-    "is unchanged — `WebTargetEnv` just exposes different tools on the same lifecycle.\n",
-    "\n",
-    "Runs on a laptop (MPS or CUDA). The point is the **mechanics and a reward you can\n",
-    "see is real** — §3 maps the whole reward surface *before* any GPU work.\n",
-    "\n",
-    "For the simplest file-editing surface (a one-line bug fix), see\n",
-    "`trl_grpo_lora.ipynb`."
-   ]
+   "source": "# Train a model to exploit a live web service with TRL GRPO + LoRA\n\nOpenRange admits **content-addressed** agent-training worlds. This notebook trains\na small model on the *cyber* pack: every rollout boots a **real HTTP server** with\na planted vulnerability, and the policy must **exploit it over the wire** and\nexfiltrate a hidden flag — graded by the world itself, no static dataset of\n\"correct\" attacks.\n\nIt is the same torch-free TRL seam that also trains file-editing agents, with a cyber **action surface**:\nthe policy gets the `http_get` and `submit` tools you pass in. The adapter is\nunchanged — the generic `EpisodeEnv` reflects whatever tools you bring (these are\nOpenRange's reference `WEB_TOOLS`; bring your own to change the surface).\n\nRuns on a laptop (MPS or CUDA). The point is the **mechanics and a reward you can\nsee is real** — §3 maps the whole reward surface *before* any GPU work.\n\nFor the simplest file-editing surface (a one-line bug fix), see\n`trl_grpo_lora.ipynb`."
   },
   {
    "cell_type": "markdown",
@@ -99,22 +81,11 @@
    "cell_type": "markdown",
    "id": "452b67a0",
    "metadata": {},
-   "source": [
-    "## 3. See the reward before you train\n",
-    "\n",
-    "The reward is the world's held-out verdict over the **HTTP path**. The pentest\n",
-    "family scores three subgoals — reach the endpoint, extract *something*, submit the\n",
-    "*right* flag — so `episode_reward` yields a four-rung surface. Driving\n",
-    "`WebTargetEnv`'s own tools by hand maps it: no model, no GPU, one fresh booted\n",
-    "server per call.\n",
-    "\n",
-    "We read the exploit's coordinates (endpoint, injection param, the ground-truth\n",
-    "flag) from the world graph, then run a **real SQL injection** for the top rung."
-   ]
+   "source": "## 3. See the reward before you train\n\nThe reward is the world's held-out verdict over the **HTTP path**. The pentest\nfamily scores three subgoals — reach the endpoint, extract *something*, submit the\n*right* flag — so `episode_reward` yields a four-rung surface. Driving the env's\ntools by hand maps it: no model, no GPU, one fresh booted server per call.\n\nWe read the exploit's coordinates (endpoint, injection param, the ground-truth\nflag) from the world graph, then run a **real SQL injection** for the top rung."
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "a812c6ef",
    "metadata": {
     "execution": {
@@ -124,30 +95,14 @@
      "shell.execute_reply": "2026-06-09T13:23:02.566576Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "no-op (no request)     reward=0.000  resolved=False\n",
-      "reach endpoint         reward=0.333  resolved=False\n",
-      "reach + wrong flag     reward=0.667  resolved=False\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "exploit + submit       reward=1.000  resolved=True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "import re\n",
     "from urllib.parse import urlencode\n",
     "\n",
-    "from openrange_trl import WebTargetEnv\n",
+    "from openrange_trl import EpisodeEnv\n",
+    "from openrange_trl.tools import WEB_TOOLS  # the reference http_get + submit tools\n",
     "\n",
     "from openrange.core.episode import EpisodeService\n",
     "\n",
@@ -177,7 +132,11 @@
     "\n",
     "def grade(name, actions):\n",
     "    svc = EpisodeService(pack, f\"or-runs/cyber/{name}\")\n",
-    "    env = WebTargetEnv(service=svc, snapshots={snapshot.snapshot_id: snapshot})\n",
+    "    # The policy's tools are the caller's — here the reference WEB_TOOLS; the env\n",
+    "    # reflects them as http_get / submit and binds them to the live target.\n",
+    "    env = EpisodeEnv(\n",
+    "        service=svc, snapshots={snapshot.snapshot_id: snapshot}, tools=WEB_TOOLS\n",
+    "    )\n",
     "    env.reset(snapshot_id=snapshot.snapshot_id, task_id=task.id)\n",
     "    actions(env)\n",
     "    env._finalize()\n",
@@ -228,22 +187,11 @@
    "cell_type": "markdown",
    "id": "7ee84019",
    "metadata": {},
-   "source": [
-    "## 4. Wrap the world as a TRL environment\n",
-    "\n",
-    "The torch-free adapter exposes the three seams TRL needs, with the web\n",
-    "action surface:\n",
-    "\n",
-    "- **`build_grpo_dataset`** — the prompt rows (we keep the pentest task), tagged\n",
-    "  with `snapshot_id`. `WEB_TOOL_GUIDE` tells the policy how to use the HTTP tools.\n",
-    "- **`make_web_environment_factory`** — one `WebTargetEnv` per rollout: a fresh\n",
-    "  booted server exposing two **tools**, `http_get` and `submit`.\n",
-    "- **`make_reward_func`** — grades the final interaction with the held-out verdict."
-   ]
+   "source": "## 4. Wrap the world as a TRL environment\n\nThe torch-free adapter exposes the three seams TRL needs, with the web action\nsurface — the tools you bring (here OpenRange's reference `WEB_TOOLS`):\n\n- **`build_grpo_dataset`** — the prompt rows (we keep the pentest task), tagged\n  with `snapshot_id`. The policy sees the tools via TRL's tool schemas, so a row\n  is just the task instruction.\n- **`make_environment_factory(..., tools=WEB_TOOLS)`** — one `EpisodeEnv` per\n  rollout: a fresh booted server, with the tools you pass (`http_get`, `submit`)\n  bound to it.\n- **`make_reward_func`** — grades the final interaction with the held-out verdict."
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "5f042eb0",
    "metadata": {
     "execution": {
@@ -257,20 +205,17 @@
    "source": [
     "from datasets import Dataset\n",
     "from openrange_trl import (\n",
-    "    WEB_TOOL_GUIDE,\n",
     "    build_grpo_dataset,\n",
+    "    make_environment_factory,\n",
     "    make_reward_func,\n",
-    "    make_web_environment_factory,\n",
     ")\n",
     "\n",
     "rows = [\n",
-    "    row\n",
-    "    for row in build_grpo_dataset(snapshot, repeat=4, tool_guide=WEB_TOOL_GUIDE)\n",
-    "    if \"pentest\" in row[\"task_id\"]\n",
+    "    row for row in build_grpo_dataset(snapshot, repeat=4) if \"pentest\" in row[\"task_id\"]\n",
     "]\n",
     "dataset = Dataset.from_list(rows)\n",
-    "environment_factory = make_web_environment_factory(\n",
-    "    pack, [snapshot], \"or-runs/cyber/envs\"\n",
+    "environment_factory = make_environment_factory(\n",
+    "    pack, [snapshot], \"or-runs/cyber/envs\", tools=WEB_TOOLS\n",
     ")\n",
     "reward_func = make_reward_func()"
    ]
@@ -398,19 +343,7 @@
    "cell_type": "markdown",
    "id": "d78733aa",
    "metadata": {},
-   "source": [
-    "## 7. Train\n",
-    "\n",
-    "`GRPOTrainer` discovers `WebTargetEnv`'s tool methods by reflection, runs the\n",
-    "multi-turn rollouts (each against its own booted server), reads `reward_func`, and\n",
-    "steps the LoRA adapters.\n",
-    "\n",
-    "A 0.5B policy will usually **floor low** here — popping a SQL injection is much\n",
-    "harder than a one-line fix, so most rollouts only `reach` the endpoint (0.333). That\n",
-    "is the honest starting point, not a failure: §3 proved 1.0 is reachable, and the\n",
-    "gradient appears once a rollout diverges (a stronger model, higher temperature, more\n",
-    "samples)."
-   ]
+   "source": "## 7. Train\n\n`GRPOTrainer` discovers the env's tool methods by reflection, runs the multi-turn\nrollouts (each against its own booted server), reads `reward_func`, and steps the\nLoRA adapters.\n\nA 0.5B policy will usually **floor low** here — popping a SQL injection is much\nharder than a one-line fix, so most rollouts only `reach` the endpoint (0.333). That\nis the honest starting point, not a failure: §3 proved 1.0 is reachable, and the\ngradient appears once a rollout diverges (a stronger model, higher temperature, more\nsamples)."
   },
   {
    "cell_type": "code",

--- a/examples/trl_grpo_cyber.ipynb
+++ b/examples/trl_grpo_cyber.ipynb
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "a812c6ef",
    "metadata": {
     "execution": {
@@ -95,7 +95,24 @@
      "shell.execute_reply": "2026-06-09T13:23:02.566576Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "no-op (no request)     reward=0.000  resolved=False\n",
+      "reach endpoint         reward=0.333  resolved=False\n",
+      "reach + wrong flag     reward=0.667  resolved=False\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "exploit + submit       reward=1.000  resolved=True\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "import re\n",

--- a/examples/trl_grpo_lora.ipynb
+++ b/examples/trl_grpo_lora.ipynb
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "ddc8f214",
    "metadata": {
     "execution": {
@@ -113,7 +113,36 @@
      "shell.execute_reply": "2026-06-09T13:20:53.793170Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "no-op (read only)          reward=0.5  resolved=False\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "naive replace-all          reward=0.5  resolved=False\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "targeted fix (add only)    reward=1.0  resolved=True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "break subtract             reward=0.0  resolved=False\n"
+     ]
+    }
+   ],
    "source": "from openrange_trl import env_trajectory, make_environment_factory\nfrom openrange_trl.tools import FILE_TOOLS  # reference read/write/list/patch/run_tests\n\nprobe_factory = make_environment_factory(\n    pack, [snapshot], \"or-runs/notebook/probe\", tools=FILE_TOOLS\n)\n\n\ndef grade(label, edit):\n    env = probe_factory()\n    env.reset()\n    edit(env)\n    traj = env_trajectory(env)\n    env.service.close()\n    print(f\"{label:<26} reward={traj.reward.scalar:.1f}  resolved={traj.success}\")\n\n\ngrade(\"no-op (read only)\", lambda e: e.read_file(\"calc/core.py\"))\ngrade(\n    \"naive replace-all\",\n    lambda e: e.apply_patch(\"calc/core.py\", \"return a - b\", \"return a + b\"),\n)\ngrade(\n    \"targeted fix (add only)\",\n    lambda e: e.apply_patch(\n        \"calc/core.py\",\n        \"def add(a, b):\\n    return a - b\",\n        \"def add(a, b):\\n    return a + b\",\n    ),\n)\ngrade(\n    \"break subtract\",\n    lambda e: e.apply_patch(\n        \"calc/core.py\",\n        \"def subtract(a, b):\\n    return a - b\",\n        \"def subtract(a, b):\\n    return a * b\",\n    ),\n)"
   },
   {

--- a/examples/trl_grpo_lora.ipynb
+++ b/examples/trl_grpo_lora.ipynb
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "ddc8f214",
    "metadata": {
     "execution": {
@@ -113,73 +113,8 @@
      "shell.execute_reply": "2026-06-09T13:20:53.793170Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "no-op (read only)          reward=0.5  resolved=False\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "naive replace-all          reward=0.5  resolved=False\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "targeted fix (add only)    reward=1.0  resolved=True\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "break subtract             reward=0.0  resolved=False\n"
-     ]
-    }
-   ],
-   "source": [
-    "from openrange_trl import env_trajectory, make_environment_factory\n",
-    "\n",
-    "probe_factory = make_environment_factory(pack, [snapshot], \"or-runs/notebook/probe\")\n",
-    "\n",
-    "\n",
-    "def grade(label, edit):\n",
-    "    env = probe_factory()\n",
-    "    env.reset()\n",
-    "    edit(env)\n",
-    "    traj = env_trajectory(env)\n",
-    "    env.service.close()\n",
-    "    print(f\"{label:<26} reward={traj.reward.scalar:.1f}  resolved={traj.success}\")\n",
-    "\n",
-    "\n",
-    "grade(\"no-op (read only)\", lambda e: e.read_file(\"calc/core.py\"))\n",
-    "grade(\n",
-    "    \"naive replace-all\",\n",
-    "    lambda e: e.apply_patch(\"calc/core.py\", \"return a - b\", \"return a + b\"),\n",
-    ")\n",
-    "grade(\n",
-    "    \"targeted fix (add only)\",\n",
-    "    lambda e: e.apply_patch(\n",
-    "        \"calc/core.py\",\n",
-    "        \"def add(a, b):\\n    return a - b\",\n",
-    "        \"def add(a, b):\\n    return a + b\",\n",
-    "    ),\n",
-    ")\n",
-    "grade(\n",
-    "    \"break subtract\",\n",
-    "    lambda e: e.apply_patch(\n",
-    "        \"calc/core.py\",\n",
-    "        \"def subtract(a, b):\\n    return a - b\",\n",
-    "        \"def subtract(a, b):\\n    return a * b\",\n",
-    "    ),\n",
-    ")"
-   ]
+   "outputs": [],
+   "source": "from openrange_trl import env_trajectory, make_environment_factory\nfrom openrange_trl.tools import FILE_TOOLS  # reference read/write/list/patch/run_tests\n\nprobe_factory = make_environment_factory(\n    pack, [snapshot], \"or-runs/notebook/probe\", tools=FILE_TOOLS\n)\n\n\ndef grade(label, edit):\n    env = probe_factory()\n    env.reset()\n    edit(env)\n    traj = env_trajectory(env)\n    env.service.close()\n    print(f\"{label:<26} reward={traj.reward.scalar:.1f}  resolved={traj.success}\")\n\n\ngrade(\"no-op (read only)\", lambda e: e.read_file(\"calc/core.py\"))\ngrade(\n    \"naive replace-all\",\n    lambda e: e.apply_patch(\"calc/core.py\", \"return a - b\", \"return a + b\"),\n)\ngrade(\n    \"targeted fix (add only)\",\n    lambda e: e.apply_patch(\n        \"calc/core.py\",\n        \"def add(a, b):\\n    return a - b\",\n        \"def add(a, b):\\n    return a + b\",\n    ),\n)\ngrade(\n    \"break subtract\",\n    lambda e: e.apply_patch(\n        \"calc/core.py\",\n        \"def subtract(a, b):\\n    return a - b\",\n        \"def subtract(a, b):\\n    return a * b\",\n    ),\n)"
   },
   {
    "cell_type": "markdown",
@@ -206,24 +141,11 @@
    "cell_type": "markdown",
    "id": "00f3630d",
    "metadata": {},
-   "source": [
-    "## 4. Wrap the world as a TRL environment\n",
-    "\n",
-    "The torch-free adapter `openrange_trl` exposes the three seams TRL needs:\n",
-    "\n",
-    "- **`build_grpo_dataset`** — the prompt rows (problem statement, `snapshot_id`-tagged).\n",
-    "- **`make_environment_factory`** — builds one `OpenRangeEnv` per rollout (used above\n",
-    "  for the probe). Each env resets a fresh workspace and exposes five **tools**:\n",
-    "  `read_file`, `write_file`, `list_dir`, `apply_patch`, `run_tests`.\n",
-    "- **`make_reward_func`** — grades the final workspace with the held-out suite and\n",
-    "  shapes it into the scalar you just saw.\n",
-    "\n",
-    "GRPO never sees the grader; it only reads the reward the world returns."
-   ]
+   "source": "## 4. Wrap the world as a TRL environment\n\nThe torch-free adapter `openrange_trl` exposes the three seams TRL needs:\n\n- **`build_grpo_dataset`** — the prompt rows (problem statement, `snapshot_id`-tagged).\n- **`make_environment_factory(..., tools=FILE_TOOLS)`** — builds one `EpisodeEnv`\n  per rollout (used above for the probe). Each env resets a fresh workspace and\n  exposes the tools you pass — here the five reference file tools `read_file`,\n  `write_file`, `list_dir`, `apply_patch`, `run_tests`.\n- **`make_reward_func`** — grades the final workspace with the held-out suite and\n  shapes it into the scalar you just saw.\n\nGRPO never sees the grader; it only reads the reward the world returns."
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "305dba40",
    "metadata": {
     "execution": {
@@ -234,16 +156,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "from datasets import Dataset\n",
-    "from openrange_trl import build_grpo_dataset, make_reward_func\n",
-    "\n",
-    "dataset = Dataset.from_list(build_grpo_dataset(snapshot, repeat=4))\n",
-    "environment_factory = make_environment_factory(\n",
-    "    pack, [snapshot], \"or-runs/notebook/envs\"\n",
-    ")\n",
-    "reward_func = make_reward_func()"
-   ]
+   "source": "from datasets import Dataset\nfrom openrange_trl import build_grpo_dataset, make_reward_func\n\ndataset = Dataset.from_list(build_grpo_dataset(snapshot, repeat=4))\nenvironment_factory = make_environment_factory(\n    pack, [snapshot], \"or-runs/notebook/envs\", tools=FILE_TOOLS\n)\nreward_func = make_reward_func()"
   },
   {
    "cell_type": "markdown",

--- a/packages/openrange-trl/README.md
+++ b/packages/openrange-trl/README.md
@@ -22,12 +22,16 @@ constructing a real `GRPOTrainer` needs the `train` extra. End-to-end tutorials:
 
 ## Surface
 
-- `OpenRangeEnv` / `WebTargetEnv` — one rollout's env over an `EpisodeService`
-  episode (file tools / HTTP tools); `EpisodeEnv` is the shared base.
-- `build_grpo_dataset`, `make_reward_func`, `make_environment_factory`,
-  `make_web_environment_factory`, `env_trajectory` — the TRL-shaped dataset,
-  reward bridge, per-rollout factory, and trajectory export.
+- `EpisodeEnv` — one rollout's env over an `EpisodeService` episode. The policy's
+  tools are **brought by the caller** (the user's harness), bound to the live world
+  surface, and reflected to TRL as the action surface — OpenRange owns the bridge,
+  not the tools. `openrange_trl.tools` ships a reference set (`WEB_TOOLS`,
+  `FILE_TOOLS`) you can use, extend, or replace.
+- `build_grpo_dataset`, `make_reward_func`, `make_environment_factory(..., tools=)`,
+  `env_trajectory` — the TRL-shaped dataset, reward bridge, per-rollout factory (you
+  pass the `tools` the policy gets), and trajectory export.
 - `reward_variance_policy` — a curriculum policy keyed on the reward spread GRPO consumes.
 
-All reward/trajectory logic defers to OpenRange's pack-agnostic `episode_reward` /
-`episode_trajectory`; none is reinvented here.
+A tool is a plain callable taking the live `surface` first, then the model's kwargs
+(see `openrange_trl/tools.py`). All reward/trajectory logic defers to OpenRange's
+pack-agnostic `episode_reward` / `episode_trajectory`; none is reinvented here.

--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -144,8 +144,6 @@ class EpisodeEnv:
         # (missing names still raise ``AttributeError``).
         def __getattr__(self, name: str) -> Callable[..., str]: ...
 
-    # -- lifecycle -----------------------------------------------------------
-
     def reset(
         self,
         *,
@@ -171,7 +169,6 @@ class EpisodeEnv:
         return self._initial_observation()
 
     def _initial_observation(self) -> str:
-        """The reset text appended to the prompt: the live interface contract."""
         surface = self._surface or {}
         base_url = surface.get("base_url")
         if isinstance(base_url, str):
@@ -181,16 +178,11 @@ class EpisodeEnv:
             )
         solver_root = surface.get("solver_root")
         if solver_root is not None:
-            from openrange_trl.tools import FileWorkspaceTools
-
-            listing = FileWorkspaceTools(str(solver_root)).list_dir(".")
-            return f"Workspace ready at {solver_root}. Files:\n{listing}"
+            names = sorted(p.name for p in Path(str(solver_root)).iterdir())
+            return f"Workspace ready at {solver_root}. Files:\n" + "\n".join(names)
         return "Environment ready. Use the available tools."
 
-    # -- tool dispatch -------------------------------------------------------
-
     def _invoke(self, fn: Tool, **kwargs: Any) -> str:
-        """Run a tool against the live surface, fail-soft + recorded + tailed."""
         out = self._safe(lambda: fn(self._require_surface(), **kwargs))
         self._record(fn.__name__, kwargs, out)
         return out[-_OUTPUT_TAIL:]
@@ -200,14 +192,9 @@ class EpisodeEnv:
             raise RuntimeError("tool called before reset()")
         return self._surface
 
-    # -- grading / lifecycle internals (underscore → TRL skips these) --------
-
     def _finalize(self) -> None:
-        """Stop + grade the episode, caching the report and scalar reward.
-
-        Idempotent: the reward func may read ``env.reward`` more than once, and
-        ``stop_episode`` itself caches, so a double read is safe.
-        """
+        # Idempotent: the reward func may read env.reward more than once, and
+        # stop_episode caches, so a double read is safe.
         if self._finalized or self._handle is None:
             self._finalized = True
             return

--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -56,26 +56,20 @@ from openrange.training import (
     episode_trajectory,
 )
 
-# A tool: takes the live episode ``surface`` first, then the model-supplied kwargs,
-# and returns an observation string. See ``openrange_trl.tools`` for examples.
 Tool = Callable[..., str]
 
-# Tail tool output so a chatty surface can't flood a tiny model's context window.
+# Tail tool output so a chatty surface can't flood the context window.
 _OUTPUT_TAIL = 2000
 
 
 def _tool_method(env: EpisodeEnv, fn: Tool) -> Any:
-    """Synthesize a TRL-introspectable bound method from a user tool fn.
+    """Build a TRL-introspectable bound method from a user tool fn.
 
-    TRL's agentic GRPO discovers tools by reflecting an env's public methods and
-    derives each schema from the method signature + Google docstring
-    (``transformers.utils.get_json_schema``). A tool fn takes the live ``surface``
-    as its first parameter; we present TRL a method with that parameter dropped
-    (the model never supplies it) and inject ``env._surface`` at call time. Real
-    annotation objects (not stringified) ride through so generics like
-    ``list[str]`` survive.
+    TRL reflects an env's public methods into tools (schema from the signature +
+    docstring). The tool takes the live ``surface`` first; we hand TRL the same
+    method with that parameter dropped and inject ``self._surface`` at call time.
     """
-    params = list(inspect.signature(fn).parameters.values())[1:]  # drop ``surface``
+    params = list(inspect.signature(fn).parameters.values())[1:]
     ns: dict[str, Any] = {"_fn": fn}
     decl, forward = "", ""
     for p in params:
@@ -96,21 +90,12 @@ def _tool_method(env: EpisodeEnv, fn: Tool) -> Any:
 
 
 class EpisodeEnv:
-    """One GRPO rollout's environment over a single ``EpisodeService`` episode.
+    """One GRPO rollout over a single ``EpisodeService`` episode.
 
-    The pack-agnostic lifecycle (``reset`` → act → lazy grade) plus the caller's
-    tools. Each supplied tool becomes a public method TRL reflects as a tool;
-    everything else is underscore-prefixed (TRL skips it) or a plain data
-    attribute (``reward`` / ``turns`` / ``report``). Tool calls are **fail-soft**
-    (``_invoke`` wraps the body in ``_safe``) — a weak model's bad call costs
-    reward, not the run.
-
-    Lifecycle (mirrors TRL's agentic loop): ``reset(**row)`` starts a fresh
-    episode (each ``start_episode`` realizes its own ``solver_root`` / target, so
-    a group of N concurrent envs never collides), caches the live ``surface`` the
-    tools bind against, and returns ``_initial_observation`` (appended to the
-    prompt). The first ``_finalize`` (via the reward func) stops + grades the
-    *final* state into ``self.reward``.
+    Each caller-supplied tool becomes a public method TRL reflects as a tool,
+    bound to the live ``surface`` at ``reset``; tool calls are fail-soft (a bad
+    call costs reward, not the run). The first read of ``env.reward`` (via the
+    reward func) lazily stops + grades the episode.
     """
 
     def __init__(
@@ -138,10 +123,8 @@ class EpisodeEnv:
             setattr(self, fn.__name__, _tool_method(self, fn))
 
     if TYPE_CHECKING:
-        # Tool methods are attached dynamically from the caller's list, so the
-        # type checker can't see them; declare that any such access is a
-        # string-returning tool call. Runtime keeps normal attribute lookup
-        # (missing names still raise ``AttributeError``).
+        # Tools are attached dynamically, so the type checker can't see them;
+        # declare any such access as a string-returning tool call.
         def __getattr__(self, name: str) -> Callable[..., str]: ...
 
     def reset(
@@ -151,12 +134,9 @@ class EpisodeEnv:
         task_id: str | None = None,
         **_: object,
     ) -> str:
-        """Start a fresh episode and return the initial observation.
-
-        ``snapshot_id`` / ``task_id`` come straight from the dataset row (extra
-        columns absorbed by ``**_``). The returned text is appended to the prompt
-        by TRL — it carries the *live* interface (a target URL, a workspace
-        listing) the dataset can't know, since the world is realized only here.
+        """Start a fresh episode; the returned observation (the live target URL or
+        workspace listing the dataset can't know) is appended to the prompt.
+        ``snapshot_id`` / ``task_id`` come from the dataset row.
         """
         snapshot = self._resolve_snapshot(snapshot_id)
         handle = self.service.start_episode(snapshot, task_id)

--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -1,30 +1,29 @@
 """TRL GRPO adapter — torch-free.
 
 The whole adapter lives here and imports only ``openrange`` + stdlib, so
-``import openrange_trl`` works with no ``torch`` installed and every
-piece below is deterministically unit-testable without a model. Only the gated
+``import openrange_trl`` works with no ``torch`` installed and every piece below
+is deterministically unit-testable without a model. Only the gated
 ``tests/test_trl_live.py`` and the example notebooks (``examples/trl_grpo_*``)
 import ``trl`` / ``torch`` and build a real ``GRPOTrainer``.
 
-The core public pieces map onto TRL's agentic GRPO (the ``environment_factory``
-path, ``transformers>=5.2``):
+OpenRange owns the world + the grade; it owns nothing of the agent runtime. So
+the policy's **tools are brought by the caller** (the user's harness), not
+hard-coded here. A tool is a plain callable taking the live episode ``surface``
+first, then the model's kwargs (see ``openrange_trl.tools`` for a reusable,
+replaceable reference set). The core public pieces map onto TRL's agentic GRPO
+(the ``environment_factory`` path, ``transformers>=5.2``):
 
-- ``OpenRangeEnv`` — one rollout's environment. ``reset(**row)`` starts a fresh
-  ``EpisodeService`` episode and returns the live workspace listing (appended to
-  the prompt); its public tool methods (``read_file`` / ``write_file`` /
-  ``list_dir`` / ``apply_patch`` / ``run_tests``) are what TRL exposes to the
-  policy as tools; the first read of ``env.reward`` (via the reward func) lazily
-  stops + grades the episode through ``episode_reward``.
-- ``WebTargetEnv`` — the sibling env for tasks against a *live web target*: same
-  lifecycle, different action surface (``http_get`` to probe the running service,
-  ``submit`` to write the answer the pack grades). The cyber webapp pack trains
-  through this one; pair it with ``make_web_environment_factory``.
-- ``FileWorkspaceTools`` — the sandboxed, path-traversal-guarded file IO the SWE
-  *surface* never exposed (gap C): a tool-calling policy can now *change* the
-  graded state, not just observe it. Harness-neutral, no TRL import.
+- ``EpisodeEnv`` — one rollout's environment over an ``EpisodeService`` episode.
+  Constructed with the caller's ``tools``; it synthesizes one TRL-introspectable
+  method per tool (so the trainer reflects them as the policy's tool surface) and
+  binds each to the live ``surface`` at ``reset``. The first read of
+  ``env.reward`` (via the reward func) lazily stops + grades the episode.
 - ``build_grpo_dataset`` — a snapshot's tasks → GRPO prompt rows, each tagged
   with ``snapshot_id`` / ``task_id`` so trajectories stay attributable across an
-  ``auto_evolve`` curriculum.
+  ``auto_evolve`` curriculum. The model sees the tools via TRL's tool schemas, so
+  a row carries just the task instruction.
+- ``make_environment_factory`` — the per-rollout factory TRL calls; the caller
+  passes the ``tools`` the policy gets.
 - ``make_reward_func`` — the TRL-shaped reward bridge; defers entirely to the
   pack's structured grade via ``episode_reward`` (no reward logic reinvented).
 - ``reward_variance_policy`` — a ``CurriculumPolicy`` keyed on the signal GRPO
@@ -34,14 +33,14 @@ path, ``transformers>=5.2``):
 
 from __future__ import annotations
 
+import inspect
+import types
 import uuid
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-from typing import Any
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
+from typing import TYPE_CHECKING, Any
 
-from openrange_pack_sdk import Backing, EpisodeReportLike, Pack, Snapshot, TaskSpec
+from openrange_pack_sdk import Backing, EpisodeReportLike, Pack, Snapshot
 
 from openrange.core.curriculum import Direction
 from openrange.core.episode import (
@@ -57,115 +56,61 @@ from openrange.training import (
     episode_trajectory,
 )
 
-# Tail tool output so a chatty suite can't flood a tiny model's context window.
+# A tool: takes the live episode ``surface`` first, then the model-supplied kwargs,
+# and returns an observation string. See ``openrange_trl.tools`` for examples.
+Tool = Callable[..., str]
+
+# Tail tool output so a chatty surface can't flood a tiny model's context window.
 _OUTPUT_TAIL = 2000
 
-_TOOL_GUIDE = (
-    "You are solving a coding task in a sandboxed workspace. Use these tools:\n"
-    "- list_dir(path): list a directory (default '.')\n"
-    "- read_file(path): read a UTF-8 text file\n"
-    "- write_file(path, content): create or overwrite a file\n"
-    "- apply_patch(path, find, replace): replace exact text in a file\n"
-    "- run_tests(node_ids): run pytest; node_ids is space-separated targets, "
-    "empty runs all\n"
-    "Edit files until the task is solved, then stop. A held-out test suite "
-    "grades your final workspace."
-)
 
-_HTTP_TIMEOUT = 5
+def _tool_method(env: EpisodeEnv, fn: Tool) -> Any:
+    """Synthesize a TRL-introspectable bound method from a user tool fn.
 
-WEB_TOOL_GUIDE = (
-    "You are probing a live web service. Use these tools:\n"
-    "- http_get(path): send an HTTP GET (include any query string) and read the "
-    "response status + body\n"
-    "- submit(content): submit your final answer as a JSON object, e.g. "
-    '{"flag": "<the value you recovered>"}\n'
-    "Investigate the service, then submit. A held-out grader checks your answer."
-)
-
-
-class WorkspaceError(Exception):
-    """A file actuator call that can't be honored — most importantly a path that
-    escapes the workspace root, but also a missing file or a not-yet-reset env.
-
-    Raised by ``FileWorkspaceTools`` and caught at the ``OpenRangeEnv`` tool
-    boundary, which turns it into an error string (fail-soft): a malformed call
-    from a weak model costs reward, never the run.
+    TRL's agentic GRPO discovers tools by reflecting an env's public methods and
+    derives each schema from the method signature + Google docstring
+    (``transformers.utils.get_json_schema``). A tool fn takes the live ``surface``
+    as its first parameter; we present TRL a method with that parameter dropped
+    (the model never supplies it) and inject ``env._surface`` at call time. Real
+    annotation objects (not stringified) ride through so generics like
+    ``list[str]`` survive.
     """
-
-
-class FileWorkspaceTools:
-    """Sandboxed file IO rooted at one episode's ``solver_root``.
-
-    Every path is resolved and asserted to stay under ``root`` — a
-    ``write_file("../../etc/passwd")`` raises ``WorkspaceError``. Writing
-    *inside* a throwaway temp ``solver_root`` is safe (grading already runs
-    untrusted code sandboxed); escaping it is not. Harness-neutral: no TRL
-    import, so a second trainer adapter can share it unchanged.
-    """
-
-    def __init__(self, root: str | Path) -> None:
-        self.root = Path(root).resolve()
-
-    def _resolve(self, path: str) -> Path:
-        candidate = (self.root / path).resolve()
-        if candidate != self.root and self.root not in candidate.parents:
-            raise WorkspaceError(f"path {path!r} escapes the workspace root")
-        return candidate
-
-    def read_file(self, path: str) -> str:
-        target = self._resolve(path)
-        if not target.is_file():
-            raise WorkspaceError(f"no such file: {path!r}")
-        return target.read_text(encoding="utf-8")
-
-    def write_file(self, path: str, content: str) -> str:
-        target = self._resolve(path)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(content, encoding="utf-8")
-        return f"wrote {len(content)} byte(s) to {path}"
-
-    def list_dir(self, path: str = ".") -> str:
-        target = self._resolve(path)
-        if not target.exists():
-            raise WorkspaceError(f"no such directory: {path!r}")
-        if target.is_file():
-            return path
-        names = sorted(p.name + ("/" if p.is_dir() else "") for p in target.iterdir())
-        return "\n".join(names) if names else "(empty)"
-
-    def apply_patch(self, path: str, find: str, replace: str) -> str:
-        target = self._resolve(path)
-        if not target.is_file():
-            raise WorkspaceError(f"no such file: {path!r}")
-        original = target.read_text(encoding="utf-8")
-        if find not in original:
-            raise WorkspaceError(f"patch text not found in {path!r}")
-        occurrences = original.count(find)
-        target.write_text(original.replace(find, replace), encoding="utf-8")
-        return f"patched {path} ({occurrences} occurrence(s))"
+    params = list(inspect.signature(fn).parameters.values())[1:]  # drop ``surface``
+    ns: dict[str, Any] = {"_fn": fn}
+    decl, forward = "", ""
+    for p in params:
+        ns[f"_ann_{p.name}"] = p.annotation if p.annotation is not p.empty else str
+        decl += f", {p.name}: _ann_{p.name}"
+        if p.default is not p.empty:
+            ns[f"_def_{p.name}"] = p.default
+            decl += f" = _def_{p.name}"
+        forward += f", {p.name}={p.name}"
+    exec(  # noqa: S102 - source is built from the tool's own signature, not input
+        f"def {fn.__name__}(self{decl}):\n    return self._invoke(_fn{forward})\n",
+        ns,
+    )
+    method = ns[fn.__name__]
+    method.__doc__ = fn.__doc__
+    method.__annotations__["return"] = str
+    return types.MethodType(method, env)
 
 
 class EpisodeEnv:
-    """One GRPO rollout's environment over a single ``EpisodeService`` episode —
-    the pack-agnostic lifecycle, with no tools of its own.
+    """One GRPO rollout's environment over a single ``EpisodeService`` episode.
 
-    Subclasses add the action surface, and TRL exposes a subclass's *public*
-    methods as the policy's tools — so each subclass owns exactly the tool set it
-    defines. ``OpenRangeEnv`` exposes file tools for SWE-style workspace tasks; a
-    second env can expose a different surface (e.g. HTTP tools against a live web
-    target) without changing this base. Tool methods are **fail-soft** (wrap the
-    body in ``_safe``) — they return an error string rather than raising, so a
-    weak model's bad call costs reward, not the run.
+    The pack-agnostic lifecycle (``reset`` → act → lazy grade) plus the caller's
+    tools. Each supplied tool becomes a public method TRL reflects as a tool;
+    everything else is underscore-prefixed (TRL skips it) or a plain data
+    attribute (``reward`` / ``turns`` / ``report``). Tool calls are **fail-soft**
+    (``_invoke`` wraps the body in ``_safe``) — a weak model's bad call costs
+    reward, not the run.
 
     Lifecycle (mirrors TRL's agentic loop): ``reset(**row)`` starts a fresh
     episode (each ``start_episode`` realizes its own ``solver_root`` / target, so
-    a group of N concurrent envs never collides), calls ``_setup`` so the subclass
-    can bind its tools, and returns ``_initial_observation`` (appended to the
-    prompt). The public tool methods drive the episode; the first ``_finalize``
-    (via the reward func) stops + grades the *final* state into ``self.reward``.
-    Everything but ``reset`` and the subclass's tools is underscore-prefixed (TRL
-    skips it) or a plain data attribute (``reward`` / ``turns`` / ``report``).
+    a group of N concurrent envs never collides), caches the live ``surface`` the
+    tools bind against, and returns ``_initial_observation`` (appended to the
+    prompt). The first ``_finalize`` (via the reward func) stops + grades the
+    *final* state into ``self.reward``.
     """
 
     def __init__(
@@ -173,6 +118,7 @@ class EpisodeEnv:
         *,
         service: EpisodeService,
         snapshots: Mapping[str, Snapshot],
+        tools: Sequence[Tool] = (),
         reward_fn: Callable[[EpisodeReport], Reward] = episode_reward,
     ) -> None:
         self.service = service
@@ -184,6 +130,19 @@ class EpisodeEnv:
         self._handle: EpisodeHandle | None = None
         self._surface: Mapping[str, Any] | None = None
         self._finalized = False
+        self._tools: dict[str, Tool] = {}
+        for fn in tools:
+            if fn.__name__ in self._tools:
+                raise ValueError(f"duplicate tool name: {fn.__name__!r}")
+            self._tools[fn.__name__] = fn
+            setattr(self, fn.__name__, _tool_method(self, fn))
+
+    if TYPE_CHECKING:
+        # Tool methods are attached dynamically from the caller's list, so the
+        # type checker can't see them; declare that any such access is a
+        # string-returning tool call. Runtime keeps normal attribute lookup
+        # (missing names still raise ``AttributeError``).
+        def __getattr__(self, name: str) -> Callable[..., str]: ...
 
     # -- lifecycle -----------------------------------------------------------
 
@@ -196,11 +155,10 @@ class EpisodeEnv:
     ) -> str:
         """Start a fresh episode and return the initial observation.
 
-        ``snapshot_id`` / ``task_id`` come straight from the dataset row (the
-        extra columns are absorbed by ``**_``). The returned text is appended to
-        the prompt by TRL — it carries the *live* state (a workspace listing, a
-        target URL) the dataset can't know, since the world is realized only at
-        episode start.
+        ``snapshot_id`` / ``task_id`` come straight from the dataset row (extra
+        columns absorbed by ``**_``). The returned text is appended to the prompt
+        by TRL — it carries the *live* interface (a target URL, a workspace
+        listing) the dataset can't know, since the world is realized only here.
         """
         snapshot = self._resolve_snapshot(snapshot_id)
         handle = self.service.start_episode(snapshot, task_id)
@@ -210,15 +168,37 @@ class EpisodeEnv:
         self.turns = []
         self.report = None
         self._finalized = False
-        self._setup(handle)
         return self._initial_observation()
 
-    def _setup(self, handle: EpisodeHandle) -> None:
-        """Bind the subclass's tools/state for the new episode (default: none)."""
-
     def _initial_observation(self) -> str:
-        """The reset text appended to the prompt (default: a bare ready marker)."""
-        return "Environment ready."
+        """The reset text appended to the prompt: the live interface contract."""
+        surface = self._surface or {}
+        base_url = surface.get("base_url")
+        if isinstance(base_url, str):
+            return (
+                f"A web service is running at {base_url}. Probe it with the "
+                "available tools, then submit your answer."
+            )
+        solver_root = surface.get("solver_root")
+        if solver_root is not None:
+            from openrange_trl.tools import FileWorkspaceTools
+
+            listing = FileWorkspaceTools(str(solver_root)).list_dir(".")
+            return f"Workspace ready at {solver_root}. Files:\n{listing}"
+        return "Environment ready. Use the available tools."
+
+    # -- tool dispatch -------------------------------------------------------
+
+    def _invoke(self, fn: Tool, **kwargs: Any) -> str:
+        """Run a tool against the live surface, fail-soft + recorded + tailed."""
+        out = self._safe(lambda: fn(self._require_surface(), **kwargs))
+        self._record(fn.__name__, kwargs, out)
+        return out[-_OUTPUT_TAIL:]
+
+    def _require_surface(self) -> Mapping[str, Any]:
+        if self._surface is None:
+            raise RuntimeError("tool called before reset()")
+        return self._surface
 
     # -- grading / lifecycle internals (underscore → TRL skips these) --------
 
@@ -265,230 +245,29 @@ class EpisodeEnv:
             self.service.record_turn(self._handle, turn)
 
 
-class OpenRangeEnv(EpisodeEnv):
-    """SWE-style env: the policy edits a sandboxed file workspace.
-
-    Adds the five file tools (``read_file`` / ``write_file`` / ``list_dir`` /
-    ``apply_patch`` / ``run_tests``) over the episode's ``solver_root``; the
-    ``run_tests`` tool defers to whatever ``run_tests`` callable the pack's
-    surface exposes.
-    """
-
-    def __init__(
-        self,
-        *,
-        service: EpisodeService,
-        snapshots: Mapping[str, Snapshot],
-        reward_fn: Callable[[EpisodeReport], Reward] = episode_reward,
-    ) -> None:
-        super().__init__(service=service, snapshots=snapshots, reward_fn=reward_fn)
-        self._tools: FileWorkspaceTools | None = None
-
-    def _setup(self, handle: EpisodeHandle) -> None:
-        self._tools = FileWorkspaceTools(self.service.solver_root(handle))
-
-    def _initial_observation(self) -> str:
-        return f"Workspace ready. Files:\n{self._require_tools().list_dir('.')}"
-
-    # -- tools (public → exposed to the policy) ------------------------------
-
-    def read_file(self, path: str) -> str:
-        """Read a UTF-8 text file from the workspace and return its contents.
-
-        Args:
-            path: Path to the file, relative to the workspace root.
-        """
-        out = self._safe(lambda: self._require_tools().read_file(path))
-        self._record("read_file", {"path": path}, out)
-        return out
-
-    def write_file(self, path: str, content: str) -> str:
-        """Create or overwrite a workspace file with the given contents.
-
-        Args:
-            path: Path to the file, relative to the workspace root.
-            content: The full text to write into the file.
-        """
-        out = self._safe(lambda: self._require_tools().write_file(path, content))
-        self._record("write_file", {"path": path, "content": content}, out)
-        return out
-
-    def list_dir(self, path: str = ".") -> str:
-        """List the entries of a workspace directory.
-
-        Args:
-            path: Directory to list, relative to the workspace root (defaults to root).
-        """
-        out = self._safe(lambda: self._require_tools().list_dir(path))
-        self._record("list_dir", {"path": path}, out)
-        return out
-
-    def apply_patch(self, path: str, find: str, replace: str) -> str:
-        """Replace exact text in a workspace file (use this for small edits).
-
-        Args:
-            path: Path to the file to edit, relative to the workspace root.
-            find: The exact text to search for in the file.
-            replace: The text to substitute in place of every match.
-        """
-        out = self._safe(lambda: self._require_tools().apply_patch(path, find, replace))
-        self._record("apply_patch", {"path": path, "find": find}, out)
-        return out
-
-    def run_tests(self, node_ids: str = "") -> str:
-        """Run the workspace's own pytest suite and return a text summary.
-
-        This runs only the tests visible in your workspace, never the held-out
-        grading suite.
-
-        Args:
-            node_ids: Space-separated pytest targets; empty runs the whole suite.
-        """
-        out = self._safe(lambda: self._run_tests(node_ids))
-        self._record("run_tests", {"node_ids": node_ids}, out)
-        return out
-
-    # -- internals (underscore → TRL skips these) ----------------------------
-
-    def _run_tests(self, node_ids: str) -> str:
-        surface = self._surface or {}
-        fn = surface.get("run_tests")
-        if not callable(fn):
-            return "error: this world exposes no run_tests tool"
-        targets = node_ids.split() or None
-        res = fn(targets)
-        ok = bool(res.get("ok"))
-        head = (
-            f"tests {'passed' if ok else 'failed'} "
-            f"(returncode={res.get('returncode')}, "
-            f"isolation={res.get('isolation')})"
-        )
-        stdout = str(res.get("stdout") or "").strip()
-        body = stdout[-_OUTPUT_TAIL:] if stdout else "(no output)"
-        return f"{head}\n{body}"
-
-    def _require_tools(self) -> FileWorkspaceTools:
-        if self._tools is None:
-            raise WorkspaceError("reset() has not been called")
-        return self._tools
-
-
-class WebTargetEnv(EpisodeEnv):
-    """Web-target env: the policy probes a live HTTP service the episode boots.
-
-    Adds two tools — ``http_get`` (send a GET to the running target and read the
-    status + body) and ``submit`` (write the final answer to the episode's
-    ``result.json``, which the pack grades). The episode surface provides the
-    target's ``base_url``; each request hits the live server (and is logged
-    there), so the pack's held-out grade reads off the *real* interaction. Used
-    for the cyber webapp pack, where a rollout exploits a planted vulnerability
-    over HTTP and submits the value it exfiltrates.
-    """
-
-    _RESULT_FILE = "result.json"
-
-    def __init__(
-        self,
-        *,
-        service: EpisodeService,
-        snapshots: Mapping[str, Snapshot],
-        reward_fn: Callable[[EpisodeReport], Reward] = episode_reward,
-    ) -> None:
-        super().__init__(service=service, snapshots=snapshots, reward_fn=reward_fn)
-        self._base_url: str | None = None
-        self._solver_root: Path | None = None
-
-    def _setup(self, handle: EpisodeHandle) -> None:
-        surface = self._surface or {}
-        base_url = surface.get("base_url")
-        self._base_url = base_url if isinstance(base_url, str) else None
-        self._solver_root = Path(self.service.solver_root(handle))
-
-    def _initial_observation(self) -> str:
-        target = self._base_url or "(no web target exposed)"
-        return (
-            f"A live web service is running at {target}. Probe it with "
-            "http_get(path); call submit(content) when you have the answer."
-        )
-
-    # -- tools (public → exposed to the policy) ------------------------------
-
-    def http_get(self, path: str) -> str:
-        """Send an HTTP GET to the running target and return its status + body.
-
-        Args:
-            path: Request path including any query string (e.g. ``/items?id=1``),
-                resolved against the target's base URL.
-        """
-        out = self._safe(lambda: self._http_get(path))
-        self._record("http_get", {"path": path}, out)
-        return out
-
-    def submit(self, content: str) -> str:
-        """Submit your final answer; the held-out grader reads ``result.json``.
-
-        Args:
-            content: A JSON object carrying the requested field, e.g.
-                ``{"flag": "<the value you recovered>"}``.
-        """
-        out = self._safe(lambda: self._submit(content))
-        self._record("submit", {"content": content}, out)
-        return out
-
-    # -- internals (underscore → TRL skips these) ----------------------------
-
-    def _http_get(self, path: str) -> str:
-        if not self._base_url:
-            return "error: this world exposes no web target"
-        try:
-            with urlopen(Request(self._base_url + path), timeout=_HTTP_TIMEOUT) as r:
-                status, body = r.status, r.read().decode("utf-8", "replace")
-        except HTTPError as exc:
-            status, body = exc.code, exc.read().decode("utf-8", "replace")
-        return f"status={status}\n{body[-_OUTPUT_TAIL:]}"
-
-    def _submit(self, content: str) -> str:
-        if self._solver_root is None:
-            raise WorkspaceError("reset() has not been called")
-        (self._solver_root / self._RESULT_FILE).write_text(content, encoding="utf-8")
-        return f"submitted {len(content)} byte(s)"
-
-
-def build_grpo_dataset(
-    snapshot: Snapshot,
-    *,
-    repeat: int = 1,
-    tool_guide: str = _TOOL_GUIDE,
-) -> list[dict[str, Any]]:
+def build_grpo_dataset(snapshot: Snapshot, *, repeat: int = 1) -> list[dict[str, Any]]:
     """Turn a snapshot's tasks into GRPO prompt rows.
 
     One row per task (optionally ``repeat``-ed so a round has enough prompts):
-    ``{"prompt": [{"role": "user", "content": ...}], "snapshot_id", "task_id"}``.
-    ``snapshot_id`` / ``task_id`` ride along as dataset columns — TRL forwards
-    them to ``reset`` (which episode to start) and to the reward func, and they
-    tag the exported trajectory to the exact (possibly evolved) world. Torch-free
-    by design; the live example wraps the rows in a ``datasets.Dataset``.
-
-    ``tool_guide`` is the tool-usage block appended to each task instruction;
-    pass ``WEB_TOOL_GUIDE`` for the ``WebTargetEnv`` action surface.
+    ``{"prompt": [{"role": "user", "content": task.instruction}], "snapshot_id",
+    "task_id"}``. ``snapshot_id`` / ``task_id`` ride along as dataset columns —
+    TRL forwards them to ``reset`` (which episode to start) and to the reward
+    func, and they tag the exported trajectory to the exact (possibly evolved)
+    world. The policy sees the available tools via TRL's tool schemas (the chat
+    template), so the row carries only the task instruction. Torch-free; the live
+    example wraps the rows in a ``datasets.Dataset``.
     """
     rows: list[dict[str, Any]] = []
     for _ in range(max(1, repeat)):
         for task in snapshot.tasks:
             rows.append(
                 {
-                    "prompt": [
-                        {"role": "user", "content": _task_prompt(task, tool_guide)}
-                    ],
+                    "prompt": [{"role": "user", "content": task.instruction}],
                     "snapshot_id": snapshot.snapshot_id,
                     "task_id": task.id,
                 }
             )
     return rows
-
-
-def _task_prompt(task: TaskSpec, tool_guide: str = _TOOL_GUIDE) -> str:
-    return f"{task.instruction}\n\n{tool_guide}"
 
 
 def make_reward_func() -> Callable[..., list[float]]:
@@ -517,65 +296,44 @@ def make_reward_func() -> Callable[..., list[float]]:
     return reward_func
 
 
-def _make_factory[E: EpisodeEnv](
-    pack: Pack,
-    snapshots: Sequence[Snapshot],
-    run_root: str | Path,
-    reward_fn: Callable[[EpisodeReport], Reward],
-    env_cls: type[E],
-    backing: Backing,
-) -> Callable[[], E]:
-    snap_map = {s.snapshot_id: s for s in snapshots}
-    base = Path(run_root)
-    base.mkdir(parents=True, exist_ok=True)
-
-    def factory() -> E:
-        service = EpisodeService(
-            pack, base / f"env-{uuid.uuid4().hex[:8]}", backing=backing
-        )
-        return env_cls(service=service, snapshots=snap_map, reward_fn=reward_fn)
-
-    return factory
-
-
 def make_environment_factory(
     pack: Pack,
     snapshots: Sequence[Snapshot],
     run_root: str | Path,
     *,
+    tools: Sequence[Tool],
     reward_fn: Callable[[EpisodeReport], Reward] = episode_reward,
     backing: Backing = Backing.PROCESS,
-) -> Callable[[], OpenRangeEnv]:
+) -> Callable[[], EpisodeEnv]:
     """Build the zero-arg factory TRL calls once per rollout slot.
 
-    Each call gets its own ``EpisodeService`` under a unique subdir, so the N
-    envs in a GRPO generation batch are fully isolated. The factory closes over
-    one round's ``snapshots`` (often a single, current world); the curriculum
-    re-roots the next round by re-building the dataset + factory against the
-    evolved snapshot. ``backing`` picks how each rollout realizes its world —
-    PROCESS by default; CONTAINER trains against the real containerized runtime.
+    The caller (the user's harness) supplies ``tools`` — the action surface the
+    policy gets — bound to the world surface each ``reset``. Each factory call
+    gets its own ``EpisodeService`` under a unique subdir, so the N envs in a
+    GRPO generation batch are fully isolated. The factory closes over one round's
+    ``snapshots`` (often a single, current world); the curriculum re-roots the
+    next round by re-building the dataset + factory against the evolved snapshot.
+    ``backing`` picks how each rollout realizes its world — PROCESS by default;
+    CONTAINER (incl. the networked multi-service runtime) trains against the real
+    containerized target.
     """
-    return _make_factory(pack, snapshots, run_root, reward_fn, OpenRangeEnv, backing)
+    snap_map = {s.snapshot_id: s for s in snapshots}
+    base = Path(run_root)
+    base.mkdir(parents=True, exist_ok=True)
+    tool_list = tuple(tools)
 
+    def factory() -> EpisodeEnv:
+        service = EpisodeService(
+            pack, base / f"env-{uuid.uuid4().hex[:8]}", backing=backing
+        )
+        return EpisodeEnv(
+            service=service,
+            snapshots=snap_map,
+            tools=tool_list,
+            reward_fn=reward_fn,
+        )
 
-def make_web_environment_factory(
-    pack: Pack,
-    snapshots: Sequence[Snapshot],
-    run_root: str | Path,
-    *,
-    reward_fn: Callable[[EpisodeReport], Reward] = episode_reward,
-    backing: Backing = Backing.PROCESS,
-) -> Callable[[], WebTargetEnv]:
-    """Like ``make_environment_factory`` but yields ``WebTargetEnv`` rollouts.
-
-    For packs whose episode realizes a live web target (e.g. the cyber webapp
-    pack): each rollout boots its own isolated service + HTTP server, and the
-    policy acts through ``http_get`` / ``submit``. Pair with
-    ``build_grpo_dataset(..., tool_guide=WEB_TOOL_GUIDE)``. ``backing`` picks the
-    runtime — PROCESS by default; CONTAINER (incl. the networked multi-service
-    runtime) trains the policy against the real containerized target.
-    """
-    return _make_factory(pack, snapshots, run_root, reward_fn, WebTargetEnv, backing)
+    return factory
 
 
 def env_trajectory(env: EpisodeEnv) -> Trajectory:
@@ -623,3 +381,14 @@ def _report_scalar(report: EpisodeReportLike) -> float:
     # CurriculumPolicy takes the EpisodeReportLike Protocol, but the trainer only
     # emits concrete EpisodeReport; this contract fallback needs a fake to hit.
     return 1.0 if report.passed else 0.0  # pragma: no cover
+
+
+__all__ = [
+    "EpisodeEnv",
+    "Tool",
+    "build_grpo_dataset",
+    "env_trajectory",
+    "make_environment_factory",
+    "make_reward_func",
+    "reward_variance_policy",
+]

--- a/packages/openrange-trl/src/openrange_trl/tools.py
+++ b/packages/openrange-trl/src/openrange_trl/tools.py
@@ -1,0 +1,191 @@
+"""Reference tools for the TRL adapter — use them, extend them, or replace them.
+
+A tool is a plain callable taking the live episode ``surface`` first, then the
+model-supplied kwargs, returning an observation string. The adapter
+(:class:`openrange_trl.EpisodeEnv`) presents each to the policy — the schema is
+derived from the signature + Google docstring, and the live ``surface`` is
+injected at call time — so a tool fn never hard-codes a world. These cover the
+surfaces OpenRange packs ship today (HTTP + a file workspace); bring your own for
+anything else (a different HTTP verb, a SQL console, a debugger, a remote shell).
+
+Convenience bundles ``WEB_TOOLS`` / ``FILE_TOOLS`` group the common sets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+_HTTP_TIMEOUT = 5
+
+
+class WorkspaceError(Exception):
+    """A file actuator call that can't be honored — most importantly a path that
+    escapes the workspace root, but also a missing file. The adapter's tool
+    boundary catches it (fail-soft): a malformed call costs reward, never the run.
+    """
+
+
+class FileWorkspaceTools:
+    """Sandboxed file IO rooted at one episode's ``solver_root``.
+
+    Every path is resolved and asserted to stay under ``root`` — a
+    ``write_file("../../etc/passwd")`` raises ``WorkspaceError``. Writing
+    *inside* a throwaway temp ``solver_root`` is safe (grading already runs
+    untrusted code sandboxed); escaping it is not.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root).resolve()
+
+    def _resolve(self, path: str) -> Path:
+        candidate = (self.root / path).resolve()
+        if candidate != self.root and self.root not in candidate.parents:
+            raise WorkspaceError(f"path {path!r} escapes the workspace root")
+        return candidate
+
+    def read_file(self, path: str) -> str:
+        target = self._resolve(path)
+        if not target.is_file():
+            raise WorkspaceError(f"no such file: {path!r}")
+        return target.read_text(encoding="utf-8")
+
+    def write_file(self, path: str, content: str) -> str:
+        target = self._resolve(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        return f"wrote {len(content)} byte(s) to {path}"
+
+    def list_dir(self, path: str = ".") -> str:
+        target = self._resolve(path)
+        if not target.exists():
+            raise WorkspaceError(f"no such directory: {path!r}")
+        if target.is_file():
+            return path
+        names = sorted(p.name + ("/" if p.is_dir() else "") for p in target.iterdir())
+        return "\n".join(names) if names else "(empty)"
+
+    def apply_patch(self, path: str, find: str, replace: str) -> str:
+        target = self._resolve(path)
+        if not target.is_file():
+            raise WorkspaceError(f"no such file: {path!r}")
+        original = target.read_text(encoding="utf-8")
+        if find not in original:
+            raise WorkspaceError(f"patch text not found in {path!r}")
+        occurrences = original.count(find)
+        target.write_text(original.replace(find, replace), encoding="utf-8")
+        return f"patched {path} ({occurrences} occurrence(s))"
+
+
+# -- HTTP target tools -------------------------------------------------------
+
+
+def http_get(surface: Mapping[str, Any], path: str) -> str:
+    """Send an HTTP GET to the running target and return its status + body.
+
+    Args:
+        path: Request path including any query string (e.g. /items?id=1),
+            resolved against the target's base URL.
+    """
+    base = str(surface["base_url"])
+    try:
+        with urlopen(Request(base + path), timeout=_HTTP_TIMEOUT) as resp:
+            return f"status={resp.status}\n{resp.read().decode('utf-8', 'replace')}"
+    except HTTPError as exc:
+        return f"status={exc.code}\n{exc.read().decode('utf-8', 'replace')}"
+
+
+def submit(surface: Mapping[str, Any], content: str) -> str:
+    """Submit your final answer; the held-out grader reads ``result.json``.
+
+    Args:
+        content: A JSON object carrying the requested field, e.g.
+            {"flag": "<the value you recovered>"}.
+    """
+    (Path(str(surface["solver_root"])) / "result.json").write_text(
+        content, encoding="utf-8"
+    )
+    return f"submitted {len(content)} byte(s)"
+
+
+# -- file-workspace tools ----------------------------------------------------
+
+
+def read_file(surface: Mapping[str, Any], path: str) -> str:
+    """Read a UTF-8 text file from the workspace and return its contents.
+
+    Args:
+        path: Path to the file, relative to the workspace root.
+    """
+    return FileWorkspaceTools(str(surface["solver_root"])).read_file(path)
+
+
+def write_file(surface: Mapping[str, Any], path: str, content: str) -> str:
+    """Create or overwrite a workspace file with the given contents.
+
+    Args:
+        path: Path to the file, relative to the workspace root.
+        content: The full text to write into the file.
+    """
+    return FileWorkspaceTools(str(surface["solver_root"])).write_file(path, content)
+
+
+def list_dir(surface: Mapping[str, Any], path: str = ".") -> str:
+    """List the entries of a workspace directory.
+
+    Args:
+        path: Directory to list, relative to the workspace root (defaults to root).
+    """
+    return FileWorkspaceTools(str(surface["solver_root"])).list_dir(path)
+
+
+def apply_patch(surface: Mapping[str, Any], path: str, find: str, replace: str) -> str:
+    """Replace exact text in a workspace file (use this for small edits).
+
+    Args:
+        path: Path to the file to edit, relative to the workspace root.
+        find: The exact text to search for in the file.
+        replace: The text to substitute in place of every match.
+    """
+    return FileWorkspaceTools(str(surface["solver_root"])).apply_patch(
+        path, find, replace
+    )
+
+
+def run_tests(surface: Mapping[str, Any], node_ids: str = "") -> str:
+    """Run the workspace's own pytest suite and return a text summary.
+
+    Runs only the tests visible in your workspace, never the held-out grader.
+
+    Args:
+        node_ids: Space-separated pytest targets; empty runs the whole suite.
+    """
+    fn = surface.get("run_tests")
+    if not callable(fn):
+        return "error: this world exposes no run_tests tool"
+    res = fn(node_ids.split() or None)
+    ok = bool(res.get("ok"))
+    head = f"tests {'passed' if ok else 'failed'} (returncode={res.get('returncode')})"
+    stdout = str(res.get("stdout") or "").strip()
+    return f"{head}\n{stdout or '(no output)'}"
+
+
+WEB_TOOLS = (http_get, submit)
+FILE_TOOLS = (read_file, write_file, list_dir, apply_patch, run_tests)
+
+__all__ = [
+    "FILE_TOOLS",
+    "WEB_TOOLS",
+    "FileWorkspaceTools",
+    "WorkspaceError",
+    "apply_patch",
+    "http_get",
+    "list_dir",
+    "read_file",
+    "run_tests",
+    "submit",
+    "write_file",
+]

--- a/packages/openrange-trl/src/openrange_trl/tools.py
+++ b/packages/openrange-trl/src/openrange_trl/tools.py
@@ -80,9 +80,6 @@ class FileWorkspaceTools:
         return f"patched {path} ({occurrences} occurrence(s))"
 
 
-# -- HTTP target tools -------------------------------------------------------
-
-
 def http_get(surface: Mapping[str, Any], path: str) -> str:
     """Send an HTTP GET to the running target and return its status + body.
 
@@ -109,9 +106,6 @@ def submit(surface: Mapping[str, Any], content: str) -> str:
         content, encoding="utf-8"
     )
     return f"submitted {len(content)} byte(s)"
-
-
-# -- file-workspace tools ----------------------------------------------------
 
 
 def read_file(surface: Mapping[str, Any], path: str) -> str:
@@ -175,17 +169,3 @@ def run_tests(surface: Mapping[str, Any], node_ids: str = "") -> str:
 
 WEB_TOOLS = (http_get, submit)
 FILE_TOOLS = (read_file, write_file, list_dir, apply_patch, run_tests)
-
-__all__ = [
-    "FILE_TOOLS",
-    "WEB_TOOLS",
-    "FileWorkspaceTools",
-    "WorkspaceError",
-    "apply_patch",
-    "http_get",
-    "list_dir",
-    "read_file",
-    "run_tests",
-    "submit",
-    "write_file",
-]

--- a/tests/test_agent_briefing.py
+++ b/tests/test_agent_briefing.py
@@ -27,11 +27,7 @@ def _task() -> TaskSpec:
 def test_briefing_gives_the_agent_the_http_target() -> None:
     ctx = EpisodeContext(
         task=_task(),
-        surface={
-            "base_url": "http://127.0.0.1:51991",
-            "solver_root": "/tmp/ep0",
-            "http_get": lambda p: b"",
-        },
+        surface={"base_url": "http://127.0.0.1:51991", "solver_root": "/tmp/ep0"},
     )
     briefing = agent_briefing(ctx)
     assert _task().instruction in briefing
@@ -44,7 +40,7 @@ def test_briefing_gives_the_agent_the_http_target() -> None:
 def test_briefing_gives_a_file_world_its_workspace() -> None:
     ctx = EpisodeContext(
         task=_task(),
-        surface={"solver_root": "/tmp/ws", "run_tests": lambda t: {}},
+        surface={"solver_root": "/tmp/ws"},
     )
     briefing = agent_briefing(ctx)
     assert _task().instruction in briefing

--- a/tests/test_agent_briefing.py
+++ b/tests/test_agent_briefing.py
@@ -1,0 +1,59 @@
+"""The example harness briefing renders the live interface contract.
+
+A harness must tell its agent which interface a world presents and where; the
+shared `agent_briefing` helper turns the task + surface into that prompt, adapting
+to whatever the world declares (HTTP target, file workspace, ...).
+"""
+
+from __future__ import annotations
+
+from openrange_pack_sdk import TaskSpec
+
+from examples._briefing import agent_briefing
+from openrange.runtime import EpisodeContext
+
+
+def _task() -> TaskSpec:
+    return TaskSpec(
+        id="t0",
+        instruction="Recover the hidden admin flag via GET /svc/orders-db/backup.",
+        entrypoints=("ep.backup",),
+        goal_nodes=("secret.flag",),
+        feasibility_check="webapp.pentest",
+        success_check="webapp.pentest",
+    )
+
+
+def test_briefing_gives_the_agent_the_http_target() -> None:
+    ctx = EpisodeContext(
+        task=_task(),
+        surface={
+            "base_url": "http://127.0.0.1:51991",
+            "solver_root": "/tmp/ep0",
+            "http_get": lambda p: b"",
+        },
+    )
+    briefing = agent_briefing(ctx)
+    assert _task().instruction in briefing
+    assert "http://127.0.0.1:51991" in briefing
+    assert "over HTTP" in briefing
+    # An HTTP world points the agent at the URL, not a directory to edit.
+    assert "working in the directory" not in briefing
+
+
+def test_briefing_gives_a_file_world_its_workspace() -> None:
+    ctx = EpisodeContext(
+        task=_task(),
+        surface={"solver_root": "/tmp/ws", "run_tests": lambda t: {}},
+    )
+    briefing = agent_briefing(ctx)
+    assert _task().instruction in briefing
+    assert "/tmp/ws" in briefing
+    assert "base_url" not in briefing and "over HTTP" not in briefing
+
+
+def test_briefing_is_just_the_instruction_when_surface_is_opaque() -> None:
+    # A world that declares neither a URL nor a workspace (e.g. a pure MCP/sim
+    # surface) still briefs the task; the harness binds the rest itself.
+    ctx = EpisodeContext(task=_task(), surface={"mcp_endpoint": "stdio://x"})
+    assert agent_briefing(ctx) == _task().instruction

--- a/tests/test_agent_briefing.py
+++ b/tests/test_agent_briefing.py
@@ -7,10 +7,14 @@ to whatever the world declares (HTTP target, file workspace, ...).
 
 from __future__ import annotations
 
-from openrange_pack_sdk import TaskSpec
+from pathlib import Path
+from urllib.request import urlopen
+
+from openrange_pack_sdk import Snapshot, TaskSpec
 
 from examples._briefing import agent_briefing
-from openrange.runtime import EpisodeContext
+from openrange.core.episode import AgentTurn
+from openrange.runtime import EpisodeContext, OpenRangeRun, RunConfig
 
 
 def _task() -> TaskSpec:
@@ -53,3 +57,32 @@ def test_briefing_is_just_the_instruction_when_surface_is_opaque() -> None:
     # surface) still briefs the task; the harness binds the rest itself.
     ctx = EpisodeContext(task=_task(), surface={"mcp_endpoint": "stdio://x"})
     assert agent_briefing(ctx) == _task().instruction
+
+
+def test_briefing_delivers_the_live_target_through_run_episode(tmp_path: Path) -> None:
+    # End-to-end via the real harness seam the example evals use: run_episode boots
+    # a cyber world, the briefing carries the LIVE base_url the static instruction
+    # can't, and a solver given ONLY the briefing reaches the running server.
+    run = OpenRangeRun(RunConfig(tmp_path / "run", dashboard=False))
+    snapshot = run.build(
+        {
+            "pack": {"id": "webapp"},
+            "runtime": {"tick": {"mode": "off"}},
+            "npc": [],
+            "seed": 0,
+        }
+    )
+    assert isinstance(snapshot, Snapshot), snapshot
+    task = next(t for t in snapshot.tasks if t.meta.get("family") == "webapp.pentest")
+    seen: dict[str, bool] = {}
+
+    def solve(ctx: EpisodeContext) -> AgentTurn:
+        brief = agent_briefing(ctx)
+        seen["url_in_brief"] = ctx.base_url in brief
+        with urlopen(ctx.base_url + "/", timeout=10) as resp:  # reach via the brief
+            seen["reached"] = resp.status == 200
+        return AgentTurn(message="probed")
+
+    run.run_episode(snapshot, solve, task_id=task.id)
+    assert seen["url_in_brief"]  # the live, dynamic base_url made it into the brief
+    assert seen["reached"]  # a solver reached the server with only the brief

--- a/tests/test_trl_adapter.py
+++ b/tests/test_trl_adapter.py
@@ -20,16 +20,13 @@ import pytest
 from openrange_pack_sdk import Backing, EpisodeResult, Snapshot
 from openrange_trl import (
     EpisodeEnv,
-    FileWorkspaceTools,
-    OpenRangeEnv,
-    WorkspaceError,
     build_grpo_dataset,
     env_trajectory,
     make_environment_factory,
     make_reward_func,
-    make_web_environment_factory,
     reward_variance_policy,
 )
+from openrange_trl.tools import FILE_TOOLS, FileWorkspaceTools, WorkspaceError
 from swe import SwePack
 from swe.instances import load_instance
 
@@ -37,7 +34,7 @@ from openrange.core.admit import AdmissionFailure, admit
 from openrange.core.curriculum import auto_evolve
 from openrange.core.episode import EpisodeReport, EpisodeService
 
-EnvMaker = Callable[[str], tuple[OpenRangeEnv, Snapshot]]
+EnvMaker = Callable[[str], tuple[EpisodeEnv, Snapshot]]
 
 
 def _admit(instance: str) -> Snapshot:
@@ -52,11 +49,15 @@ def make_env(tmp_path: Path) -> Iterator[EnvMaker]:
     every service is closed on teardown so no grading subprocess leaks."""
     services: list[EpisodeService] = []
 
-    def _make(instance: str) -> tuple[OpenRangeEnv, Snapshot]:
+    def _make(instance: str) -> tuple[EpisodeEnv, Snapshot]:
         snapshot = _admit(instance)
         service = EpisodeService(SwePack(), tmp_path / f"svc{len(services)}")
         services.append(service)
-        env = OpenRangeEnv(service=service, snapshots={snapshot.snapshot_id: snapshot})
+        env = EpisodeEnv(
+            service=service,
+            snapshots={snapshot.snapshot_id: snapshot},
+            tools=FILE_TOOLS,
+        )
         return env, snapshot
 
     yield _make
@@ -64,7 +65,7 @@ def make_env(tmp_path: Path) -> Iterator[EnvMaker]:
         service.close()
 
 
-def _solve(env: OpenRangeEnv, instance: str) -> None:
+def _solve(env: EpisodeEnv, instance: str) -> None:
     for path, content in load_instance(instance).gold_files.items():
         env.write_file(path, content)
 
@@ -73,9 +74,15 @@ def test_factories_thread_backing_into_each_rollout_service(tmp_path: Path) -> N
     # The factory builds each service before any realize, so the backing it threads
     # through is observable without booting docker — and the default must stay PROCESS.
     snapshot = _admit("calc_sum")
-    default_factory = make_environment_factory(SwePack(), [snapshot], tmp_path / "proc")
-    container_factory = make_web_environment_factory(
-        SwePack(), [snapshot], tmp_path / "cont", backing=Backing.CONTAINER
+    default_factory = make_environment_factory(
+        SwePack(), [snapshot], tmp_path / "proc", tools=FILE_TOOLS
+    )
+    container_factory = make_environment_factory(
+        SwePack(),
+        [snapshot],
+        tmp_path / "cont",
+        tools=FILE_TOOLS,
+        backing=Backing.CONTAINER,
     )
     proc_env = default_factory()
     cont_env = container_factory()
@@ -88,13 +95,13 @@ def test_factories_thread_backing_into_each_rollout_service(tmp_path: Path) -> N
 
 
 def test_base_env_resets_with_no_tools(tmp_path: Path) -> None:
-    # The tool-less EpisodeEnv base is usable directly: reset starts a real
-    # episode and returns the default observation (subclasses override it).
+    # The env is usable with no tools at all: reset starts a real episode and
+    # returns the live interface contract (here, the SWE workspace listing).
     snapshot = _admit("calc_sum")
     service = EpisodeService(SwePack(), tmp_path / "base")
     env = EpisodeEnv(service=service, snapshots={snapshot.snapshot_id: snapshot})
     try:
-        assert env.reset() == "Environment ready."
+        assert env.reset().startswith("Workspace ready")
     finally:
         service.close()
 
@@ -299,9 +306,9 @@ class TestRewardSpread:
 
     def _reward_after(
         self,
-        env: OpenRangeEnv,
+        env: EpisodeEnv,
         snapshot: Snapshot,
-        edit: Callable[[OpenRangeEnv], object],
+        edit: Callable[[EpisodeEnv], object],
     ) -> float:
         env.reset(snapshot_id=snapshot.snapshot_id)
         edit(env)
@@ -398,7 +405,9 @@ class TestTrajectoryExport:
 class TestEnvFactory:
     def test_factory_isolates_concurrent_envs(self, tmp_path: Path) -> None:
         snapshot = _admit("calc_sum")
-        factory = make_environment_factory(SwePack(), [snapshot], tmp_path)
+        factory = make_environment_factory(
+            SwePack(), [snapshot], tmp_path, tools=FILE_TOOLS
+        )
         a, b = factory(), factory()
         try:
             a.reset(snapshot_id=snapshot.snapshot_id)

--- a/tests/test_trl_cyber.py
+++ b/tests/test_trl_cyber.py
@@ -1,7 +1,7 @@
-"""The cyber webapp pack, trained through the TRL adapter's ``WebTargetEnv``.
+"""The cyber webapp pack, trained through the TRL adapter's generic ``EpisodeEnv``.
 
 Live but **torch-free**: each test boots the pack's real HTTP server (no model)
-and drives ``WebTargetEnv``'s tools by hand, exactly as a GRPO rollout would.
+and drives the env's reference tools (``WEB_TOOLS``) by hand, as a rollout would.
 Pins ``seed=0`` — a deterministic world whose pentest entrypoint is a
 SQL-injection at ``GET /svc/db/records`` — so the reward surface is reproducible.
 
@@ -28,14 +28,14 @@ import pytest
 from cyber_webapp import WebappPack
 from openrange_pack_sdk import EpisodeResult, Snapshot, TaskSpec
 from openrange_trl import (
-    WEB_TOOL_GUIDE,
-    WebTargetEnv,
+    EpisodeEnv,
     build_grpo_dataset,
     env_trajectory,
+    make_environment_factory,
     make_reward_func,
-    make_web_environment_factory,
     reward_variance_policy,
 )
+from openrange_trl.tools import WEB_TOOLS
 
 from openrange.core.admit import admit
 from openrange.core.curriculum import auto_evolve
@@ -54,7 +54,7 @@ _MANIFEST = {
     "vuln_kinds": {"sql_injection": 1},
 }
 
-EnvMaker = Callable[[], WebTargetEnv]
+EnvMaker = Callable[[], EpisodeEnv]
 
 
 @pytest.fixture(scope="module")
@@ -68,10 +68,12 @@ def snapshot() -> Snapshot:
 def make_env(snapshot: Snapshot, tmp_path: Path) -> Iterator[EnvMaker]:
     services: list[EpisodeService] = []
 
-    def _make() -> WebTargetEnv:
+    def _make() -> EpisodeEnv:
         svc = EpisodeService(WebappPack(), tmp_path / f"svc{len(services)}")
         services.append(svc)
-        return WebTargetEnv(service=svc, snapshots={snapshot.snapshot_id: snapshot})
+        return EpisodeEnv(
+            service=svc, snapshots={snapshot.snapshot_id: snapshot}, tools=WEB_TOOLS
+        )
 
     yield _make
     for svc in services:
@@ -105,11 +107,11 @@ def _sqli_params(snapshot: Snapshot) -> Mapping[str, object]:
     raise AssertionError("seed=0 should plant a sql_injection vulnerability")
 
 
-def _start(env: WebTargetEnv, snapshot: Snapshot, task: TaskSpec) -> str:
+def _start(env: EpisodeEnv, snapshot: Snapshot, task: TaskSpec) -> str:
     return env.reset(snapshot_id=snapshot.snapshot_id, task_id=task.id)
 
 
-def _grade(env: WebTargetEnv) -> float:
+def _grade(env: EpisodeEnv) -> float:
     env._finalize()
     return env.reward
 
@@ -174,9 +176,9 @@ class TestWebTargetLifecycle:
         out = env.http_get("/no/such/route")
         assert out.startswith("status=") and "error" not in out.split("\n")[0]
 
-    def test_http_get_before_reset_reports_no_target(self, make_env: EnvMaker) -> None:
-        # No episode started yet -> no base_url -> fail-soft, not a crash.
-        assert make_env().http_get("/") == "error: this world exposes no web target"
+    def test_http_get_before_reset_is_fail_soft(self, make_env: EnvMaker) -> None:
+        # No episode started yet -> no surface -> fail-soft, not a crash.
+        assert make_env().http_get("/").startswith("error:")
 
     def test_submit_before_reset_is_fail_soft(self, make_env: EnvMaker) -> None:
         assert make_env().submit('{"flag": "x"}').startswith("error:")
@@ -240,11 +242,15 @@ class TestSeams:
         assert traj.task_id == task.id
         assert 0.0 <= traj.reward.scalar <= 1.0
 
-    def test_dataset_uses_the_web_tool_guide(self, snapshot: Snapshot) -> None:
-        rows = build_grpo_dataset(snapshot, repeat=2, tool_guide=WEB_TOOL_GUIDE)
+    def test_dataset_rows_carry_instruction_and_snapshot(
+        self, snapshot: Snapshot
+    ) -> None:
+        # Tools reach the policy via TRL's tool schemas, not the prompt text, so a
+        # row is just the task instruction + its snapshot/task tags.
+        rows = build_grpo_dataset(snapshot, repeat=2)
         assert len(rows) == 2 * len(snapshot.tasks)
-        content = rows[0]["prompt"][0]["content"]
-        assert "http_get" in content and "submit" in content
+        contents = [row["prompt"][0]["content"] for row in rows]
+        assert _pentest_task(snapshot).instruction in contents
         assert all(row["snapshot_id"] == snapshot.snapshot_id for row in rows)
 
     def test_reward_func_grades_web_envs_in_order(
@@ -264,14 +270,14 @@ class TestSeams:
         rewards = make_reward_func()([], [], environments=[solved, floored])
         assert rewards == [1.0, 0.0]
 
-    def test_web_factory_builds_isolated_web_envs(
+    def test_factory_builds_isolated_envs(
         self, snapshot: Snapshot, tmp_path: Path
     ) -> None:
-        factory = make_web_environment_factory(
-            WebappPack(), [snapshot], tmp_path / "factory-envs"
+        factory = make_environment_factory(
+            WebappPack(), [snapshot], tmp_path / "factory-envs", tools=WEB_TOOLS
         )
         env = factory()
-        assert isinstance(env, WebTargetEnv)
+        assert isinstance(env, EpisodeEnv)
         task = _pentest_task(snapshot)
         try:
             obs = env.reset(snapshot_id=snapshot.snapshot_id, task_id=task.id)

--- a/tests/test_trl_live.py
+++ b/tests/test_trl_live.py
@@ -25,14 +25,13 @@ from pathlib import Path
 import pytest
 from openrange_pack_sdk import Backing
 from openrange_trl import (
-    WEB_TOOL_GUIDE,
     EpisodeEnv,
     build_grpo_dataset,
     env_trajectory,
     make_environment_factory,
     make_reward_func,
-    make_web_environment_factory,
 )
+from openrange_trl.tools import FILE_TOOLS, WEB_TOOLS
 
 from openrange.core.admit import AdmissionFailure, admit
 
@@ -85,7 +84,9 @@ def test_live_grpo_one_step(tmp_path: Path) -> None:
 
     num_generations = 2
     dataset = datasets.Dataset.from_list(build_grpo_dataset(snapshot, repeat=2))
-    factory = make_environment_factory(pack, [snapshot], tmp_path / "envs")
+    factory = make_environment_factory(
+        pack, [snapshot], tmp_path / "envs", tools=FILE_TOOLS
+    )
     config = trl.GRPOConfig(
         output_dir=str(tmp_path / "trainer"),
         per_device_train_batch_size=num_generations,
@@ -166,11 +167,13 @@ def test_live_grpo_one_step_cyber(tmp_path: Path) -> None:
     # Only the pentest task suits the HTTP action surface (build is code-gen).
     rows = [
         row
-        for row in build_grpo_dataset(snapshot, repeat=2, tool_guide=WEB_TOOL_GUIDE)
+        for row in build_grpo_dataset(snapshot, repeat=2)
         if "pentest" in row["task_id"]
     ]
     dataset = datasets.Dataset.from_list(rows)
-    factory = make_web_environment_factory(pack, [snapshot], tmp_path / "envs")
+    factory = make_environment_factory(
+        pack, [snapshot], tmp_path / "envs", tools=WEB_TOOLS
+    )
     config = trl.GRPOConfig(
         output_dir=str(tmp_path / "trainer"),
         per_device_train_batch_size=num_generations,
@@ -258,12 +261,12 @@ def test_live_grpo_one_step_cyber_container(tmp_path: Path) -> None:
     num_generations = 2
     rows = [
         row
-        for row in build_grpo_dataset(snapshot, repeat=2, tool_guide=WEB_TOOL_GUIDE)
+        for row in build_grpo_dataset(snapshot, repeat=2)
         if "pentest" in row["task_id"]
     ]
     dataset = datasets.Dataset.from_list(rows)
-    factory = make_web_environment_factory(
-        pack, [snapshot], tmp_path / "envs", backing=Backing.CONTAINER
+    factory = make_environment_factory(
+        pack, [snapshot], tmp_path / "envs", tools=WEB_TOOLS, backing=Backing.CONTAINER
     )
     config = trl.GRPOConfig(
         output_dir=str(tmp_path / "trainer"),
@@ -359,12 +362,12 @@ def test_live_grpo_one_step_cyber_container_file_loot(tmp_path: Path) -> None:
     num_generations = 2
     rows = [
         row
-        for row in build_grpo_dataset(snapshot, repeat=2, tool_guide=WEB_TOOL_GUIDE)
+        for row in build_grpo_dataset(snapshot, repeat=2)
         if "pentest" in row["task_id"]
     ]
     dataset = datasets.Dataset.from_list(rows)
-    factory = make_web_environment_factory(
-        pack, [snapshot], tmp_path / "envs", backing=backing
+    factory = make_environment_factory(
+        pack, [snapshot], tmp_path / "envs", tools=WEB_TOOLS, backing=backing
     )
     config = trl.GRPOConfig(
         output_dir=str(tmp_path / "trainer"),

--- a/tests/test_trl_tools.py
+++ b/tests/test_trl_tools.py
@@ -60,8 +60,7 @@ def _pentest_task(snapshot: Snapshot) -> Any:
 
 
 def test_user_tools_reflect_with_the_schema_trl_reads(make_env: Any) -> None:
-    pytest.importorskip("transformers")
-    from transformers.utils import get_json_schema  # type: ignore[attr-defined]
+    get_json_schema = pytest.importorskip("transformers.utils").get_json_schema
 
     env = make_env(list(WEB_TOOLS))
     fn = get_json_schema(env.http_get)["function"]

--- a/tests/test_trl_tools.py
+++ b/tests/test_trl_tools.py
@@ -1,0 +1,140 @@
+"""The TRL adapter turns USER-supplied tools into the policy's tool surface.
+
+Tools are brought by the caller (the user's harness), bound to the world surface,
+and presented to TRL by method reflection. These prove the seam end to end with no
+model: the synthesized methods carry the schema TRL reads, a *custom* tool the
+adapter has never seen works against a live world (real BYO), and name collisions
+are rejected. No mocks — a real cyber episode boots behind each tool call.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cyber_webapp import WebappPack
+from openrange_pack_sdk import Snapshot
+from openrange_trl import EpisodeEnv, Tool
+from openrange_trl.tools import WEB_TOOLS, http_get, submit
+
+from openrange.core.admit import admit
+from openrange.core.episode import EpisodeService
+
+_MANIFEST = {
+    "pack": {"id": "webapp"},
+    "runtime": {"tick": {"mode": "off"}},
+    "npc": [],
+    "seed": 0,
+    "loot_shapes": {"db": 1, "file": 0},
+    "vuln_kinds": {"sql_injection": 1},
+}
+
+
+@pytest.fixture(scope="module")
+def snapshot() -> Snapshot:
+    snap = admit(WebappPack(), manifest=_MANIFEST)
+    assert isinstance(snap, Snapshot), snap
+    return snap
+
+
+@pytest.fixture
+def make_env(snapshot: Snapshot, tmp_path: Path) -> Iterator[Any]:
+    services: list[EpisodeService] = []
+
+    def _make(tools: list[Tool]) -> EpisodeEnv:
+        svc = EpisodeService(WebappPack(), tmp_path / f"svc{len(services)}")
+        services.append(svc)
+        return EpisodeEnv(
+            service=svc, snapshots={snapshot.snapshot_id: snapshot}, tools=tools
+        )
+
+    yield _make
+    for svc in services:
+        svc.close()
+
+
+def _pentest_task(snapshot: Snapshot) -> Any:
+    return next(t for t in snapshot.tasks if t.meta.get("family") == "webapp.pentest")
+
+
+def test_user_tools_reflect_with_the_schema_trl_reads(make_env: Any) -> None:
+    pytest.importorskip("transformers")
+    from transformers.utils import get_json_schema  # type: ignore[attr-defined]
+
+    env = make_env(list(WEB_TOOLS))
+    fn = get_json_schema(env.http_get)["function"]
+    assert fn["name"] == "http_get"
+    assert "GET" in fn["description"]
+    props = fn["parameters"]["properties"]
+    assert set(props) == {"path"}  # the surface-injection param is hidden from TRL
+    assert props["path"]["type"] == "string"
+    assert props["path"]["description"]  # required by get_json_schema, carried through
+    assert get_json_schema(env.submit)["function"]["name"] == "submit"
+
+
+def test_a_custom_byo_tool_runs_against_a_live_world(
+    make_env: Any, snapshot: Snapshot
+) -> None:
+    seen: list[str] = []
+
+    def recon(surface: Mapping[str, Any], path: str) -> str:
+        """Fetch a path on the target and note that it was visited.
+
+        Args:
+            path: the request path to fetch.
+        """
+        seen.append(path)
+        return http_get(surface, path)
+
+    # The adapter has never seen `recon`; the user brings it.
+    env = make_env([recon, submit])
+    env.reset(snapshot_id=snapshot.snapshot_id, task_id=_pentest_task(snapshot).id)
+    out = env.recon("/")
+    assert out.startswith("status=200")  # the user's tool hit the live server
+    assert seen == ["/"]
+    assert env.turns[-1].tool_calls[0]["tool"] == "recon"  # logged like any tool
+
+
+def test_a_tool_with_a_default_arg_is_optional(
+    make_env: Any, snapshot: Snapshot
+) -> None:
+    def note(surface: Mapping[str, Any], text: str = "ok") -> str:
+        """Record a note.
+
+        Args:
+            text: the note text (optional).
+        """
+        return f"noted: {text}"
+
+    env = make_env([note, submit])
+    env.reset(snapshot_id=snapshot.snapshot_id, task_id=_pentest_task(snapshot).id)
+    assert env.note() == "noted: ok"  # default preserved
+    assert env.note("hi") == "noted: hi"
+
+
+def test_initial_observation_falls_back_for_an_opaque_surface(make_env: Any) -> None:
+    # A world that declares neither base_url nor solver_root still resets cleanly.
+    env = make_env([])
+    env._surface = {}
+    assert env._initial_observation() == "Environment ready. Use the available tools."
+
+
+def test_run_tests_tool_reports_when_world_has_no_runner() -> None:
+    from openrange_trl.tools import run_tests
+
+    assert run_tests({}, "").startswith("error:")  # no run_tests in the surface
+
+
+def test_duplicate_tool_names_are_rejected(make_env: Any) -> None:
+    def http_get(surface: Mapping[str, Any], path: str) -> str:
+        """A second tool that collides on name.
+
+        Args:
+            path: x.
+        """
+        return ""
+
+    with pytest.raises(ValueError, match="duplicate tool"):
+        make_env([http_get, http_get])


### PR DESCRIPTION
## What & why

OpenRange is a **gym**: a pack defines the world (a target *surface*) + the grader, and nothing of the agent runtime — the agent's tools are the user's, brought by their harness. Two gaps broke that for "bring your own tools," and this fixes both. **No pack or SDK changes** — the contract was already right; this is harness-side only.

### 1. `openrange-trl` accepts the user's tools (BYO for training, no subclassing)
The adapter used to hard-code the policy's tools as `EpisodeEnv` *subclass methods* (`OpenRangeEnv` = file tools, `WebTargetEnv` = `http_get`/`submit`). Now:
- A **tool is a plain callable** `fn(surface, **kwargs) -> str` with a Google docstring — no new type to learn.
- One generic `EpisodeEnv(tools=...)` synthesizes a TRL-introspectable method per tool (drops `surface` from the schema, injects the live surface at call) so `GRPOTrainer` reflects them. Single `make_environment_factory(..., tools=...)`.
- `openrange_trl/tools.py` ships **replaceable** reference tools (`WEB_TOOLS`, `FILE_TOOLS`). `build_grpo_dataset` drops `tool_guide` — tools reach the model via TRL's tool schemas.

```python
from openrange_trl import make_environment_factory
from openrange_trl.tools import http_get, submit      # …or bring your own
factory = make_environment_factory(pack, [snap], "envs", tools=[http_get, submit])
```

### 2. Example harnesses now hand the agent the target
`strands_eval`/`codex_eval` passed the agent the instruction + working dir but **never the dynamic `base_url`**, so a cyber agent couldn't reach the server. New `examples/_briefing.py`: `agent_briefing(ctx)` = task + the live interface (`base_url` for HTTP, the workspace dir for files), wired into both evals.

## Verification
- ruff + mypy clean (full CI scope).
- **66 torch-free tests**; **100% coverage** on the two new modules.
- A test proves a **custom tool the adapter has never seen** works against a live world (real BYO).
- **4/4 live GRPO tests** pass through the new env with `tools=` — SWE, cyber, networked container, and the auto-backed file-loot world (real TRL, real episodes, real docker).

## Note
Stacks on #274 (it migrates the file-loot live test that #274 added), so the base is that branch — merge after #274, or retarget to `main` once #274 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
