### PR TITLE
feat(trl): give each agent its own sandbox to run its tools (closes #290)

### DIFF
--- a/packages/openrange-trl/README.md
+++ b/packages/openrange-trl/README.md
@@ -35,3 +35,17 @@ constructing a real `GRPOTrainer` needs the `train` extra. End-to-end tutorials:
 A tool is a plain callable taking the live `surface` first, then the model's kwargs
 (see `openrange_trl/tools.py`). All reward/trajectory logic defers to OpenRange's
 pack-agnostic `episode_reward` / `episode_trajectory`; none is reinvented here.
+
+## Sandbox cleanup
+
+With `sandbox=True` each episode runs the agent's tools in a throwaway container on a
+private per-episode network, both torn down when the episode ends. A best-effort
+`atexit` sweep also reclaims this process's own sandboxes if a run unwinds past teardown
+(an unhandled exception or Ctrl-C) — but `atexit` can't fire on `SIGKILL`. So every
+container and network is labelled `openrange.sandbox=1`; if a hard-killed run leaks one,
+reclaim it with:
+
+```bash
+docker ps   -aq --filter label=openrange.sandbox=1 | xargs -r docker rm -f
+docker network ls -q --filter label=openrange.sandbox=1 | xargs -r docker network rm
+```

--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -204,9 +204,13 @@ class EpisodeEnv:
                     "backing) so the sandbox can join its network and reach it by alias"
                 )
             network = f"openrange-agent-net-{uuid.uuid4().hex[:12]}"
-            _run_docker("network", "create", network)
-            _run_docker("network", "connect", "--alias", "target", network, target)
+            # --internal: the network has no gateway, so the sandbox (running untrusted
+            # agent code) can reach the target by alias yet CANNOT reach the host, the
+            # internet, or other episodes' host-published ports. Record the name before
+            # connect so a failed connect still tears the network down.
+            _run_docker("network", "create", "--internal", network)
             self._network = network
+            _run_docker("network", "connect", "--alias", "target", network, target)
             self._target_container = target
             target_url = f"http://target:{surface.get('target_port', '8000')}"
             self._sandbox = AgentSandbox({"base_url": target_url}, network=network)

--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -34,6 +34,7 @@ replaceable reference set). The core public pieces map onto TRL's agentic GRPO
 from __future__ import annotations
 
 import inspect
+import subprocess
 import types
 import uuid
 from collections.abc import Callable, Mapping, Sequence
@@ -97,6 +98,10 @@ class EpisodeEnv:
     bound to the live ``surface`` at ``reset``; tool calls are fail-soft (a bad
     call costs reward, not the run). The first read of ``env.reward`` (via the
     reward func) lazily stops + grades the episode.
+
+    With ``sandbox=True`` each episode gets its own throwaway :class:`AgentSandbox`
+    (the agent's machine), and the live ``surface`` carries a ``run`` capability so a
+    brought tool can run commands there — the trainer never runs an agent command.
     """
 
     def __init__(
@@ -106,6 +111,7 @@ class EpisodeEnv:
         snapshots: Mapping[str, Snapshot],
         tools: Sequence[Tool] = (),
         reward_fn: Callable[[EpisodeReport], Reward] = episode_reward,
+        sandbox: bool = False,
     ) -> None:
         self.service = service
         self.snapshots = dict(snapshots)
@@ -116,6 +122,10 @@ class EpisodeEnv:
         self._handle: EpisodeHandle | None = None
         self._surface: Mapping[str, Any] | None = None
         self._finalized = False
+        self._use_sandbox = sandbox
+        self._sandbox: AgentSandbox | None = None
+        self._network: str | None = None
+        self._target_container: str | None = None
         self._tools: dict[str, Tool] = {}
         for fn in tools:
             if fn.__name__ in self._tools:
@@ -139,10 +149,12 @@ class EpisodeEnv:
         workspace listing the dataset can't know) is appended to the prompt.
         ``snapshot_id`` / ``task_id`` come from the dataset row.
         """
+        self._teardown_sandbox()
         snapshot = self._resolve_snapshot(snapshot_id)
         handle = self.service.start_episode(snapshot, task_id)
         self._handle = handle
-        self._surface = self.service.surface(handle)
+        surface = self.service.surface(handle)
+        self._surface = self._start_sandbox(surface) if self._use_sandbox else surface
         self.reward = 0.0
         self.turns = []
         self.report = None
@@ -173,6 +185,59 @@ class EpisodeEnv:
             raise RuntimeError("tool called before reset()")
         return self._surface
 
+    def _start_sandbox(self, surface: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Give the agent its own sandbox for this episode and hand it to the tools.
+
+        The agent's tools run here, never in the trainer. An HTTP world (``base_url``)
+        is a network target: the sandbox joins a private per-episode network the world
+        is also on, so the agent reaches it by alias over the wire (not the host). A
+        code world (``solver_root``) is mounted so the agent edits it as its own files.
+        Either way the live ``run`` is injected into the surface, so a brought tool can
+        call ``surface["run"](command)`` with the trainer unchanged.
+        """
+        base_url = surface.get("base_url")
+        if isinstance(base_url, str):
+            target = surface.get("target_container")
+            if not isinstance(target, str):
+                raise SandboxError(
+                    "a sandboxed HTTP world needs a containerized target (CONTAINER "
+                    "backing) so the sandbox can join its network and reach it by alias"
+                )
+            network = f"openrange-agent-net-{uuid.uuid4().hex[:12]}"
+            _run_docker("network", "create", network)
+            _run_docker("network", "connect", "--alias", "target", network, target)
+            self._network = network
+            self._target_container = target
+            target_url = f"http://target:{surface.get('target_port', '8000')}"
+            self._sandbox = AgentSandbox({"base_url": target_url}, network=network)
+            self._sandbox.start()
+            # The agent reaches the target by its in-network alias, not the host URL.
+            return {**surface, "base_url": target_url, "run": self._sandbox.run}
+        self._sandbox = AgentSandbox({"solver_root": surface.get("solver_root")})
+        self._sandbox.start()
+        return {**surface, "run": self._sandbox.run}
+
+    def _teardown_sandbox(self) -> None:
+        # Disposable: the sandbox dies with the episode so no state leaks to the next.
+        if self._sandbox is not None:
+            self._sandbox.close()
+            self._sandbox = None
+        if self._network is not None:
+            # Detach the world (best-effort: stop_episode usually removed it already),
+            # then drop the network so nothing dangles even on an un-finalized re-reset.
+            if self._target_container is not None:
+                _run_docker(
+                    "network",
+                    "disconnect",
+                    "-f",
+                    self._network,
+                    self._target_container,
+                    check=False,
+                )
+            _run_docker("network", "rm", self._network, check=False)
+            self._network = None
+            self._target_container = None
+
     def _finalize(self) -> None:
         # Idempotent: the reward func may read env.reward more than once, and
         # stop_episode caches, so a double read is safe.
@@ -183,6 +248,7 @@ class EpisodeEnv:
         report = self.service.stop_episode(self._handle)
         self.report = report
         self.reward = self.reward_fn(report).scalar
+        self._teardown_sandbox()
 
     def _resolve_snapshot(self, snapshot_id: str | None) -> Snapshot:
         if snapshot_id is not None:
@@ -211,6 +277,10 @@ class EpisodeEnv:
         self.turns.append(turn)
         if self._handle is not None:
             self.service.record_turn(self._handle, turn)
+
+
+def _run_docker(*args: str, check: bool = True) -> None:
+    subprocess.run(["docker", *args], check=check, capture_output=True, timeout=60)
 
 
 def build_grpo_dataset(snapshot: Snapshot, *, repeat: int = 1) -> list[dict[str, Any]]:
@@ -272,6 +342,7 @@ def make_environment_factory(
     tools: Sequence[Tool],
     reward_fn: Callable[[EpisodeReport], Reward] = episode_reward,
     backing: Backing = Backing.PROCESS,
+    sandbox: bool = False,
 ) -> Callable[[], EpisodeEnv]:
     """Build the zero-arg factory TRL calls once per rollout slot.
 
@@ -283,7 +354,9 @@ def make_environment_factory(
     next round by re-building the dataset + factory against the evolved snapshot.
     ``backing`` picks how each rollout realizes its world — PROCESS by default;
     CONTAINER (incl. the networked multi-service runtime) trains against the real
-    containerized target.
+    containerized target. ``sandbox=True`` runs each episode's tools in their own
+    throwaway :class:`AgentSandbox` (HTTP worlds need the CONTAINER backing so the
+    sandbox can join the target's network).
     """
     snap_map = {s.snapshot_id: s for s in snapshots}
     base = Path(run_root)
@@ -299,6 +372,7 @@ def make_environment_factory(
             snapshots=snap_map,
             tools=tool_list,
             reward_fn=reward_fn,
+            sandbox=sandbox,
         )
 
     return factory

--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -56,7 +56,14 @@ from openrange.training import (
     episode_reward,
     episode_trajectory,
 )
-from openrange_trl.sandbox import AgentSandbox, CommandResult, SandboxError
+from openrange_trl.sandbox import (
+    SANDBOX_LABEL,
+    AgentSandbox,
+    CommandResult,
+    SandboxError,
+    track_resource,
+    untrack_resource,
+)
 
 Tool = Callable[..., str]
 
@@ -206,10 +213,14 @@ class EpisodeEnv:
             network = f"openrange-agent-net-{uuid.uuid4().hex[:12]}"
             # --internal: the network has no gateway, so the sandbox (running untrusted
             # agent code) can reach the target by alias yet CANNOT reach the host, the
-            # internet, or other episodes' host-published ports. Record the name before
-            # connect so a failed connect still tears the network down.
-            _run_docker("network", "create", "--internal", network)
+            # internet, or other episodes' host-published ports. The label makes a
+            # leaked network prunable; record + track the name before connect so a
+            # failed connect still tears it down (here and via the atexit sweep).
+            _run_docker(
+                "network", "create", "--internal", "--label", SANDBOX_LABEL, network
+            )
             self._network = network
+            track_resource("network", network)
             _run_docker("network", "connect", "--alias", "target", network, target)
             self._target_container = target
             target_url = f"http://target:{surface.get('target_port', '8000')}"
@@ -239,6 +250,7 @@ class EpisodeEnv:
                     check=False,
                 )
             _run_docker("network", "rm", self._network, check=False)
+            untrack_resource("network", self._network)
             self._network = None
             self._target_container = None
 
@@ -430,6 +442,7 @@ def _report_scalar(report: EpisodeReportLike) -> float:
 
 
 __all__ = [
+    "SANDBOX_LABEL",
     "AgentSandbox",
     "CommandResult",
     "EpisodeEnv",

--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -55,6 +55,7 @@ from openrange.training import (
     episode_reward,
     episode_trajectory,
 )
+from openrange_trl.sandbox import AgentSandbox, CommandResult, SandboxError
 
 Tool = Callable[..., str]
 
@@ -351,7 +352,10 @@ def _report_scalar(report: EpisodeReportLike) -> float:
 
 
 __all__ = [
+    "AgentSandbox",
+    "CommandResult",
     "EpisodeEnv",
+    "SandboxError",
     "Tool",
     "build_grpo_dataset",
     "env_trajectory",

--- a/packages/openrange-trl/src/openrange_trl/sandbox.py
+++ b/packages/openrange-trl/src/openrange_trl/sandbox.py
@@ -1,0 +1,201 @@
+"""A throwaway machine the agent runs its own commands in — never the trainer.
+
+The in-process TRL path hands the policy function-tools only because a token-emitting
+model has no shell. The real model — the one SkyRL-Agent uses — is this: give the
+agent its **own** hardened container with ``bash``/``curl``/``python``, let it run
+**its own** commands against the world, and ship no tools from the harness. The
+sandbox binds to whatever the world's ``surface`` exposes:
+
+* an HTTP world (``base_url``) is a network target — the sandbox joins the world's
+  docker network and the agent reaches it by alias (``curl http://target:8000/...``);
+* a code world (``solver_root``) is a workspace — the sandbox bind-mounts it so the
+  agent edits the tree as its own filesystem and the grader reads the edited tree.
+
+Either way it is one :meth:`AgentSandbox.run` primitive (a real shell, like SkyRL's
+``CmdRunAction``); only the binding differs. Untrusted agent code runs here under the
+same hardening the worlds use — cap-drop ALL, no-new-privileges, memory/cpu/pid caps,
+reachable only on the episode network — and never in the trainer process.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import tempfile
+import uuid
+from collections.abc import Mapping
+from pathlib import Path
+from types import TracebackType
+from typing import Any, NamedTuple
+
+# Same base the worlds build on (container.py), plus a shell and the tools an agent
+# reaches for; bash is already in the slim image, curl/git/certs are not.
+_AGENT_DOCKERFILE = (
+    "FROM python:3.13-slim\n"
+    "RUN apt-get update \\\n"
+    " && apt-get install -y --no-install-recommends bash curl ca-certificates git \\\n"
+    " && rm -rf /var/lib/apt/lists/*\n"
+)
+
+# Mirrors the worlds' container hardening (cyber_webapp ``hardening_run_args``); kept
+# here so the adapter doesn't depend on a pack. Contains attacker-controlled code: no
+# capabilities, no privilege gain, bounded memory/cpu/pids.
+_HARDENING = [
+    "--cap-drop",
+    "ALL",
+    "--security-opt",
+    "no-new-privileges",
+    "--memory",
+    "512m",
+    "--cpus",
+    "1.0",
+    "--pids-limit",
+    "256",
+]
+
+
+class SandboxError(RuntimeError):
+    """The sandbox could not start, bind, or run — surfaced, never swallowed."""
+
+
+class CommandResult(NamedTuple):
+    """One command's outcome: its exit code and its combined stdout+stderr."""
+
+    exit_code: int
+    output: str
+
+
+class AgentSandbox:
+    """A hardened throwaway container the agent runs its own commands in.
+
+    Bind it to a world ``surface``: an HTTP world (``base_url``) joins ``network`` and
+    the target is reached by alias; a code world (``solver_root``) is bind-mounted at
+    ``/workspace``. :meth:`run` executes one shell command; :meth:`close` removes the
+    container (the network, if any, is the caller's). Usable as a context manager.
+    """
+
+    def __init__(
+        self,
+        surface: Mapping[str, Any],
+        *,
+        network: str | None = None,
+        image: str | None = None,
+    ) -> None:
+        self._surface = surface
+        self._network = network
+        self._image = image
+        self._cname: str | None = None
+
+    def __enter__(self) -> AgentSandbox:
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def start(self) -> None:
+        """Build the agent image (once, reused) and run an idle hardened container
+        bound to the world surface. The binding is validated before any image build,
+        so a misconfigured surface fails fast without touching docker."""
+        if self._cname is not None:
+            raise SandboxError("sandbox already started")
+        cname = f"openrange-agent-{uuid.uuid4().hex[:12]}"
+        bindings = self._surface_bindings(cname)
+        image = self._image or _build_agent_image()
+        # Run as the invoking user, never root: it matches the owner of a bind-mounted
+        # workspace (so the agent can edit it — cap-drop ALL strips root's DAC
+        # override), and keeps the contained code off uid 0.
+        user = f"{os.getuid()}:{os.getgid()}"
+        subprocess.run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--name",
+                cname,
+                *_HARDENING,
+                "--user",
+                user,
+                *bindings,
+                image,
+                "sleep",
+                "infinity",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self._cname = cname
+
+    def run(self, command: str, *, timeout: float = 120.0) -> CommandResult:
+        """Run one shell command in the sandbox and return its exit code + output.
+        The agent composes ``curl`` / ``python`` / file edits itself — this is the
+        single generic primitive, not a fixed tool set."""
+        done = subprocess.run(
+            ["docker", "exec", self._require_started(), "bash", "-lc", command],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return CommandResult(done.returncode, done.stdout + done.stderr)
+
+    def close(self) -> None:
+        """Remove the sandbox container (its network, if any, is the caller's)."""
+        if self._cname is None:
+            return
+        subprocess.run(["docker", "rm", "-f", self._cname], capture_output=True)
+        self._cname = None
+
+    def _surface_bindings(self, cname: str) -> list[str]:
+        base_url = self._surface.get("base_url")
+        solver_root = self._surface.get("solver_root")
+        if isinstance(base_url, str):
+            if self._network is None:
+                raise SandboxError(
+                    "an HTTP world (base_url) needs a docker network to reach the "
+                    "target by alias; pass network=..."
+                )
+            # Join the world's network; the agent reaches the target by its alias.
+            return ["--network", self._network, "--network-alias", cname]
+        if solver_root is not None:
+            # Mount the workspace so the agent edits the code as its own filesystem;
+            # the grader later reads the edited tree back on the host.
+            root = Path(str(solver_root)).resolve()
+            return ["-v", f"{root}:/workspace", "-w", "/workspace"]
+        return []
+
+    def _require_started(self) -> str:
+        if self._cname is None:
+            raise SandboxError("sandbox not started")
+        return self._cname
+
+
+def _build_agent_image() -> str:
+    """Build the agent image once and reuse it: a content-derived tag means a second
+    sandbox finds the image already present and skips the build."""
+    digest = hashlib.sha256(_AGENT_DOCKERFILE.encode()).hexdigest()[:12]
+    tag = f"openrange-agent:{digest}"
+    present = subprocess.run(["docker", "image", "inspect", tag], capture_output=True)
+    if present.returncode == 0:
+        return tag
+    context = Path(tempfile.mkdtemp(prefix="openrange-agent-"))
+    try:
+        (context / "Dockerfile").write_text(_AGENT_DOCKERFILE, encoding="utf-8")
+        subprocess.run(
+            ["docker", "build", "-q", "-t", tag, str(context)],
+            check=True,
+            capture_output=True,
+            timeout=600,
+        )
+    finally:
+        shutil.rmtree(context, ignore_errors=True)
+    return tag

--- a/packages/openrange-trl/src/openrange_trl/sandbox.py
+++ b/packages/openrange-trl/src/openrange_trl/sandbox.py
@@ -19,11 +19,14 @@ reachable only on the episode network — and never in the trainer process.
 
 from __future__ import annotations
 
+import atexit
+import contextlib
 import hashlib
 import os
 import shutil
 import subprocess
 import tempfile
+import threading
 import uuid
 from collections.abc import Mapping
 from pathlib import Path
@@ -54,6 +57,60 @@ _HARDENING = [
     "--pids-limit",
     "256",
 ]
+
+# Every sandbox container and every per-episode network carries this label, so the
+# resources an interrupted run leaks (a detached ``sleep infinity`` agent container and
+# its ``openrange-agent-net-*`` network) stay discoverable and prunable by an operator:
+#   docker ps -aq      --filter label=openrange.sandbox=1 | xargs -r docker rm -f
+#   docker network ls -q --filter label=openrange.sandbox=1 | xargs -r docker network rm
+# The same string works as both ``--label openrange.sandbox=1`` and the filter value.
+SANDBOX_LABEL = "openrange.sandbox=1"
+
+# Best-effort, in-process safety net for the *common* interruption — an unhandled
+# exception or a Ctrl-C that unwinds past ``close``/``_teardown_sandbox`` before the
+# resources are removed. Everything this process created but didn't tear down is swept
+# at normal interpreter shutdown via ``atexit`` (which installs no signal handler, so
+# the trainer's own signal handling is untouched). It removes only *this* process's
+# tracked resources, never another concurrent trainer's. ``atexit`` does not run on
+# SIGKILL — the label above is the backstop there. Entries are ``(kind, name)``, kind
+# a "container" or "network".
+_TRACKED: set[tuple[str, str]] = set()
+_TRACKED_LOCK = threading.Lock()
+_SWEEP_ARMED = False
+
+
+def track_resource(kind: str, name: str) -> None:
+    """Track a resource so the atexit sweep removes it if teardown is skipped."""
+    global _SWEEP_ARMED
+    with _TRACKED_LOCK:
+        _TRACKED.add((kind, name))
+        if not _SWEEP_ARMED:
+            atexit.register(_sweep_tracked)
+            _SWEEP_ARMED = True
+
+
+def untrack_resource(kind: str, name: str) -> None:
+    """Drop a resource from the sweep set once it has been removed normally."""
+    with _TRACKED_LOCK:
+        _TRACKED.discard((kind, name))
+
+
+def _sweep_tracked() -> None:
+    with _TRACKED_LOCK:
+        leaked = list(_TRACKED)
+        _TRACKED.clear()
+    # Containers first: a network still holding an attached container won't remove.
+    leaked.sort(key=lambda kn: 0 if kn[0] == "container" else 1)
+    for kind, name in leaked:
+        argv = (
+            ["docker", "rm", "-f", name]
+            if kind == "container"
+            else ["docker", "network", "rm", name]
+        )
+        # A shutdown sweep never raises on the way out (a wedged daemon, a docker that
+        # has gone away); the labelled resource stays prunable by hand regardless.
+        with contextlib.suppress(Exception):
+            subprocess.run(argv, capture_output=True, timeout=30)
 
 
 class SandboxError(RuntimeError):
@@ -120,6 +177,9 @@ class AgentSandbox:
                 "-d",
                 "--name",
                 cname,
+                # Label every container so a leak from an interrupted run is prunable.
+                "--label",
+                SANDBOX_LABEL,
                 *_HARDENING,
                 "--user",
                 user,
@@ -134,6 +194,7 @@ class AgentSandbox:
             timeout=60,
         )
         self._cname = cname
+        track_resource("container", cname)
 
     def run(self, command: str, *, timeout: float = 120.0) -> CommandResult:
         """Run one shell command in the sandbox and return its exit code + output.
@@ -152,11 +213,11 @@ class AgentSandbox:
         """Remove the sandbox container (its network, if any, is the caller's)."""
         if self._cname is None:
             return
+        cname = self._cname
         # Bounded so a wedged daemon can't hang teardown (this is the only docker call
         # on the code-world teardown path); best-effort, so no check.
-        subprocess.run(
-            ["docker", "rm", "-f", self._cname], capture_output=True, timeout=60
-        )
+        subprocess.run(["docker", "rm", "-f", cname], capture_output=True, timeout=60)
+        untrack_resource("container", cname)
         self._cname = None
 
     def _surface_bindings(self, cname: str) -> list[str]:

--- a/packages/openrange-trl/src/openrange_trl/sandbox.py
+++ b/packages/openrange-trl/src/openrange_trl/sandbox.py
@@ -152,7 +152,11 @@ class AgentSandbox:
         """Remove the sandbox container (its network, if any, is the caller's)."""
         if self._cname is None:
             return
-        subprocess.run(["docker", "rm", "-f", self._cname], capture_output=True)
+        # Bounded so a wedged daemon can't hang teardown (this is the only docker call
+        # on the code-world teardown path); best-effort, so no check.
+        subprocess.run(
+            ["docker", "rm", "-f", self._cname], capture_output=True, timeout=60
+        )
         self._cname = None
 
     def _surface_bindings(self, cname: str) -> list[str]:

--- a/packages/openrange-trl/src/openrange_trl/sandbox.py
+++ b/packages/openrange-trl/src/openrange_trl/sandbox.py
@@ -184,8 +184,8 @@ class AgentSandbox:
 
 
 def _build_agent_image() -> str:
-    """Build the agent image once and reuse it: a content-derived tag means a second
-    sandbox finds the image already present and skips the build."""
+    # Content-derived tag: built once and reused. A second sandbox finds it already
+    # present and skips the build.
     digest = hashlib.sha256(_AGENT_DOCKERFILE.encode()).hexdigest()[:12]
     tag = f"openrange-agent:{digest}"
     present = subprocess.run(["docker", "image", "inspect", tag], capture_output=True)

--- a/packs/cyber_webapp/cyber_webapp/realize.py
+++ b/packs/cyber_webapp/cyber_webapp/realize.py
@@ -305,7 +305,15 @@ class ContainerWebappRuntime(WebappRuntime):
         host_port = mapping.splitlines()[0].rsplit(":", 1)[-1]
         self._base_url = f"http://127.0.0.1:{host_port}"
         self._log_offset = 0
-        return {"base_url": self._base_url}
+        # Also expose the world's container + in-container port so a harness can put an
+        # agent sandbox on the same docker network and let it reach the target by alias
+        # (over the wire, not via the host). Agent-invisible — the brief renders only
+        # base_url. See the openrange-trl AgentSandbox integration.
+        return {
+            "base_url": self._base_url,
+            "target_container": self._cname,
+            "target_port": _CONTAINER_PORT,
+        }
 
     def _read_log_bytes(self) -> bytes | None:
         if self._cname is None:

--- a/tests/test_agent_sandbox.py
+++ b/tests/test_agent_sandbox.py
@@ -17,6 +17,7 @@ import subprocess
 import tempfile
 import time
 import urllib.request
+import uuid
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -26,6 +27,7 @@ from cyber_webapp.container import hardening_run_args, image_files
 from cyber_webapp.realize_admit import cmdi_exploit_and_benign
 from openrange_pack_sdk import Snapshot
 from openrange_trl import AgentSandbox, SandboxError
+from openrange_trl import sandbox as sandbox_mod
 
 from openrange.core.admit import admit
 
@@ -68,6 +70,22 @@ class TestLifecycleGuards:
 
     def test_close_before_start_is_a_noop(self) -> None:
         AgentSandbox({}).close()  # nothing started — must not raise
+
+
+class TestLeakSafety:
+    def test_track_and_untrack_manage_the_sweep_set(self) -> None:
+        # track_resource records a (kind, name) for the atexit sweep; untrack_resource
+        # drops it once teardown removed the resource. Pure set logic — no docker.
+        sandbox_mod._TRACKED.clear()
+        try:
+            sandbox_mod.track_resource("container", "c-x")
+            sandbox_mod.track_resource("network", "n-x")
+            assert ("container", "c-x") in sandbox_mod._TRACKED
+            assert ("network", "n-x") in sandbox_mod._TRACKED
+            sandbox_mod.untrack_resource("container", "c-x")
+            assert ("container", "c-x") not in sandbox_mod._TRACKED
+        finally:
+            sandbox_mod._TRACKED.clear()
 
 
 # --- gated: the real engine (build + run real containers) -----------------------------
@@ -284,3 +302,76 @@ def test_sandbox_is_hardened_reuses_the_image_and_cleans_up(tmp_path: Path) -> N
         ["docker", "inspect", cname], capture_output=True, text=True, timeout=10
     )
     assert gone.returncode != 0  # close() removed the container
+
+
+@gated
+def test_the_atexit_sweep_removes_a_tracked_container_and_network(
+    tmp_path: Path,
+) -> None:
+    # The shutdown safety net: the sweep force-removes every resource this process
+    # tracked but didn't tear down. Track a real container (via start) and a real
+    # network, sweep, and assert both are gone and the set is cleared — no test doubles.
+    sandbox_mod._TRACKED.clear()
+    network = f"openrange-agent-net-sweep-{uuid.uuid4().hex[:8]}"
+    subprocess.run(
+        ["docker", "network", "create", network],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    sandbox = AgentSandbox({"solver_root": str(tmp_path)})
+    sandbox.start()
+    cname = sandbox._cname
+    assert cname is not None
+    sandbox_mod.track_resource("network", network)
+    try:
+        sandbox_mod._sweep_tracked()
+        assert not sandbox_mod._TRACKED  # the sweep clears what it handled
+        assert (
+            subprocess.run(
+                ["docker", "inspect", cname], capture_output=True, timeout=10
+            ).returncode
+            != 0
+        )
+        assert (
+            subprocess.run(
+                ["docker", "network", "inspect", network],
+                capture_output=True,
+                timeout=10,
+            ).returncode
+            != 0
+        )
+    finally:
+        sandbox_mod._TRACKED.clear()
+        subprocess.run(["docker", "rm", "-f", cname], capture_output=True)
+        subprocess.run(["docker", "network", "rm", network], capture_output=True)
+
+
+@gated
+def test_a_leaked_sandbox_is_discoverable_by_its_label(tmp_path: Path) -> None:
+    # The interruption backstop on the real engine: even without a clean teardown the
+    # container is found by the documented label filter, so an operator (or the one-line
+    # prune) can reclaim it. We start without closing, then assert the filter finds it.
+    sandbox = AgentSandbox({"solver_root": str(tmp_path)})
+    sandbox.start()
+    cname = sandbox._cname
+    assert cname is not None
+    try:
+        listed = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-q",
+                "--filter",
+                "label=openrange.sandbox=1",
+                "--filter",
+                f"name={cname}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout
+        assert listed.strip(), "labelled sandbox not found by the documented filter"
+    finally:
+        sandbox.close()

--- a/tests/test_agent_sandbox.py
+++ b/tests/test_agent_sandbox.py
@@ -1,0 +1,286 @@
+"""The agent runs its own commands in its sandbox; OpenRange ships no tools.
+
+The pure tests pin the binding contract (an HTTP world joins the network by alias; a
+code world is bind-mounted; an opaque world binds nothing) and the lifecycle guards,
+with no docker. The gated tests prove the model end to end on a real engine: an agent
+exploits a containerized cyber world from its sandbox using its **own** ``curl`` — no
+shipped tool — and edits a workspace as its own filesystem through the bind mount.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from cyber_webapp import WebappPack
+from cyber_webapp.container import hardening_run_args, image_files
+from cyber_webapp.realize_admit import cmdi_exploit_and_benign
+from openrange_pack_sdk import Snapshot
+from openrange_trl import AgentSandbox, SandboxError
+
+from openrange.core.admit import admit
+
+# --- pure: the binding contract and lifecycle guards (no docker) ----------------------
+
+
+class TestSurfaceBinding:
+    def test_http_world_joins_the_network_by_alias(self) -> None:
+        sandbox = AgentSandbox({"base_url": "http://target:8000"}, network="net-x")
+        assert sandbox._surface_bindings("agent-1") == [
+            "--network",
+            "net-x",
+            "--network-alias",
+            "agent-1",
+        ]
+
+    def test_http_world_without_a_network_is_refused(self) -> None:
+        # An HTTP world is reached only over the wire; with no network to join there is
+        # no target to reach, so this fails fast rather than starting a blind sandbox.
+        with pytest.raises(SandboxError, match="network"):
+            AgentSandbox({"base_url": "http://target:8000"})._surface_bindings("a")
+
+    def test_code_world_bind_mounts_the_workspace(self, tmp_path: Path) -> None:
+        sandbox = AgentSandbox({"solver_root": str(tmp_path)})
+        assert sandbox._surface_bindings("agent-1") == [
+            "-v",
+            f"{tmp_path.resolve()}:/workspace",
+            "-w",
+            "/workspace",
+        ]
+
+    def test_opaque_world_binds_nothing(self) -> None:
+        assert AgentSandbox({})._surface_bindings("agent-1") == []
+
+
+class TestLifecycleGuards:
+    def test_run_before_start_is_refused(self) -> None:
+        with pytest.raises(SandboxError, match="not started"):
+            AgentSandbox({}).run("echo hi")
+
+    def test_close_before_start_is_a_noop(self) -> None:
+        AgentSandbox({}).close()  # nothing started — must not raise
+
+
+# --- gated: the real engine (build + run real containers) -----------------------------
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        probe = subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=10, check=False
+        )
+    except Exception:  # noqa: BLE001 - a best-effort probe; any failure means "no"
+        return False
+    return probe.returncode == 0
+
+
+gated = pytest.mark.skipif(
+    not _docker_available(), reason="docker engine not reachable"
+)
+
+
+def _bind_mount_writeback_works() -> bool:
+    # Whether a container's writes to a host bind mount sync back. True on native Linux
+    # (CI); false where the OS temp dir isn't file-shared with the docker VM (e.g. the
+    # macOS /var/folders TMPDIR under Docker Desktop) — there reads leak through but
+    # writes don't, so a mount-writeback assertion would be a false negative.
+    probe = Path(tempfile.mkdtemp())
+    try:
+        (probe / "p").write_text("0", encoding="utf-8")
+        subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--user",
+                f"{os.getuid()}:{os.getgid()}",  # mirror the sandbox's non-root user
+                "-v",
+                f"{probe}:/w",
+                "-w",
+                "/w",
+                "python:3.13-slim",
+                "bash",
+                "-lc",
+                "echo 1 > p",
+            ],
+            check=False,  # a failed write (no perms / no file-share) just means False
+            capture_output=True,
+            timeout=60,
+        )
+        return (probe / "p").read_text(encoding="utf-8").strip() == "1"
+    finally:
+        shutil.rmtree(probe, ignore_errors=True)
+
+
+def _admit_cmdi() -> Snapshot:
+    snap = admit(
+        WebappPack(),
+        manifest={
+            "pack": {"id": "webapp"},
+            "runtime": {"tick": {"mode": "off"}},
+            "npc": [],
+            "seed": 7,
+            "loot_shapes": {"file": 1, "db": 0},
+            "vuln_kinds": {"command_injection": 1},
+        },
+        max_repairs=3,
+    )
+    assert isinstance(snap, Snapshot), snap
+    return snap
+
+
+def _wait_ready(base: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            urllib.request.urlopen(base + "/", timeout=2)
+            return
+        except OSError:  # URLError is an OSError subclass
+            time.sleep(0.3)
+    raise AssertionError(f"world did not become ready at {base}")
+
+
+@contextlib.contextmanager
+def _world_on_network(
+    build_files: dict[str, str], tmp_path: Path, tag: str, network: str, alias: str
+) -> Iterator[None]:
+    # Build the world image and run it on the given network under `alias` (so a sandbox
+    # on the same network reaches it by name), also host-published so we can wait ready.
+    context = tmp_path / "world-ctx"
+    context.mkdir()
+    for name, content in build_files.items():
+        (context / name).write_text(content, encoding="utf-8")
+    subprocess.run(
+        ["docker", "build", "-q", "-t", tag, str(context)],
+        check=True,
+        capture_output=True,
+        timeout=600,
+    )
+    cid = subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "-p",
+            "0:8000",
+            "--network",
+            network,
+            "--network-alias",
+            alias,
+            *hardening_run_args(),
+            tag,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    ).stdout.strip()
+    try:
+        mapping = subprocess.run(
+            ["docker", "port", cid, "8000"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout.strip()
+        _wait_ready(f"http://127.0.0.1:{mapping.rsplit(':', 1)[-1]}", timeout=30)
+        yield
+    finally:
+        subprocess.run(["docker", "rm", "-f", cid], capture_output=True)
+        subprocess.run(["docker", "rmi", "-f", tag], capture_output=True)
+
+
+@gated
+def test_agent_exploits_an_http_world_from_its_sandbox(tmp_path: Path) -> None:
+    # The model end to end: the world is a network target; the agent, in its own
+    # sandbox, exploits it with its OWN curl and recovers the flag. No shipped tool.
+    snap = _admit_cmdi()
+    graph = snap.graph
+    exploit_path, _benign = cmdi_exploit_and_benign(graph)
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+
+    network = f"openrange-agent-net-{snap.snapshot_id[:12]}"
+    tag = f"openrange-agent-world-{snap.snapshot_id[:12]}"
+    subprocess.run(
+        ["docker", "network", "create", network],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    try:
+        with (
+            _world_on_network(image_files(graph), tmp_path, tag, network, "target"),
+            AgentSandbox({"base_url": "http://target:8000"}, network=network) as sb,
+        ):
+            result = sb.run(f"curl -s 'http://target:8000{exploit_path}'")
+        assert result.exit_code == 0, result.output
+        assert flag in result.output, result.output[:300]
+    finally:
+        subprocess.run(["docker", "network", "rm", network], capture_output=True)
+
+
+@gated
+def test_agent_edits_a_code_world_as_its_filesystem(tmp_path: Path) -> None:
+    # A code world is the agent's filesystem: it edits the bind-mounted workspace, and
+    # the change is visible back on the host (the foundation for edit-and-grade).
+    if not _bind_mount_writeback_works():
+        pytest.skip("docker bind-mount writeback unavailable (e.g. macOS TMPDIR)")
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "a.py").write_text("x = 1\n", encoding="utf-8")
+    with AgentSandbox({"solver_root": str(workspace)}) as sandbox:
+        edit = sandbox.run("echo 'y = 2' >> a.py")
+        assert edit.exit_code == 0, edit.output
+        shown = sandbox.run("cat a.py")
+        assert "y = 2" in shown.output
+    assert "y = 2" in (workspace / "a.py").read_text(encoding="utf-8")
+
+
+@gated
+def test_sandbox_is_hardened_reuses_the_image_and_cleans_up(tmp_path: Path) -> None:
+    surface = {"solver_root": str(tmp_path)}
+    first = AgentSandbox(surface)
+    first.start()
+    cname = first._cname
+    assert cname is not None
+    try:
+        record = json.loads(
+            subprocess.run(
+                ["docker", "inspect", cname],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            ).stdout
+        )[0]
+        host = record["HostConfig"]
+        assert host["CapDrop"] == ["ALL"], host["CapDrop"]
+        assert any("no-new-privileges" in opt for opt in host.get("SecurityOpt") or [])
+        assert host["Memory"] > 0 and host["PidsLimit"] and host["PidsLimit"] > 0
+        assert record["Config"]["User"] == f"{os.getuid()}:{os.getgid()}"  # never root
+
+        with pytest.raises(SandboxError, match="already started"):
+            first.start()  # the guard holds — no second container for one sandbox
+
+        # The image is content-tagged, so a second sandbox reuses it (no rebuild).
+        second = AgentSandbox(surface)
+        second.start()
+        second.close()
+    finally:
+        first.close()
+
+    gone = subprocess.run(
+        ["docker", "inspect", cname], capture_output=True, text=True, timeout=10
+    )
+    assert gone.returncode != 0  # close() removed the container

--- a/tests/test_trl_sandbox_episode.py
+++ b/tests/test_trl_sandbox_episode.py
@@ -1,11 +1,11 @@
 """The sandbox, wired into the bring-your-own-tools seam (#288) through ``EpisodeEnv``.
 
-This is the #290 close: a *brought* tool runs in the episode's own throwaway sandbox,
-the trainer runs no agent command, and it plugs into the same ``tools=`` seam with the
-trainer unchanged. The shell tool below is the user's — the package ships none; it just
-reads the ``run`` capability the env injects into the live surface. The gated test boots
-a REAL cyber episode on the CONTAINER backing and an agent recovers the flag with its
-OWN curl, over the network, from its sandbox — then the real grader returns 1.0.
+A *brought* tool runs in the episode's own throwaway sandbox, the trainer runs no agent
+command, and it plugs into the same ``tools=`` seam (#288) with the trainer unchanged.
+The shell tool below is the user's — the package ships none; it just reads the ``run``
+capability the env injects into the live surface. The gated test boots a REAL cyber
+episode on the CONTAINER backing and an agent recovers the flag with its OWN curl, over
+the network, from its sandbox — then the real grader returns 1.0.
 """
 
 from __future__ import annotations
@@ -144,9 +144,9 @@ def _bind_mount_writeback_works() -> bool:
 
 @gated
 def test_byo_shell_tool_exploits_a_real_episode_in_its_sandbox(tmp_path: Path) -> None:
-    # The #290 close, end to end through the real harness: a real CONTAINER cyber world,
-    # the agent in its OWN sandbox exploits it with its OWN curl over the network, the
-    # trainer runs no agent command, and the real grader returns full reward.
+    # End to end through the real harness: a real CONTAINER cyber world. The agent, in
+    # its OWN sandbox, exploits it with its OWN curl over the network; the trainer runs
+    # no agent command, and the real grader returns full reward.
     snap = _admit_cmdi()
     graph = snap.graph
     exploit_path, _benign = cmdi_exploit_and_benign(graph)
@@ -178,9 +178,9 @@ def test_byo_shell_tool_exploits_a_real_episode_in_its_sandbox(tmp_path: Path) -
 def test_the_sandbox_can_reach_the_target_but_not_the_host_or_internet(
     tmp_path: Path,
 ) -> None:
-    # #290 criterion 1 ENFORCED, not just claimed: the per-episode net is --internal, so
-    # the agent (untrusted code) reaches the target by alias but has no route off the
-    # network — no host, no internet, no other episode's published ports.
+    # The per-episode net is --internal — no gateway — so the agent (untrusted code)
+    # reaches the target by alias but has no route off the network: no host, no
+    # internet, no other episode's published ports.
     snap = _admit_cmdi()
     service = EpisodeService(WebappPack(), tmp_path / "svc", backing=Backing.CONTAINER)
     env = EpisodeEnv(

--- a/tests/test_trl_sandbox_episode.py
+++ b/tests/test_trl_sandbox_episode.py
@@ -18,10 +18,12 @@ import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlencode
 
 import pytest
-from cyber_webapp import WebappPack
+from cyber_webapp import NetworkedContainerWebappRuntime, WebappPack
 from cyber_webapp.realize_admit import cmdi_exploit_and_benign
+from graphschema import WorldGraph
 from openrange_pack_sdk import Backing, Snapshot
 from openrange_trl import EpisodeEnv, SandboxError
 
@@ -35,6 +37,18 @@ _CMDI_MANIFEST = {
     "seed": 7,
     "loot_shapes": {"file": 1, "db": 0},
     "vuln_kinds": {"command_injection": 1},
+}
+
+# An SSRF on a public endpoint pivoting to an internal service -> _is_networked is True,
+# so this world realizes as the NetworkedContainerWebappRuntime (public + internal
+# containers on one net) rather than a single container. seed 3 matches the proven
+# networked tests (tests/test_cyber_networked.py).
+_SSRF_MANIFEST = {
+    "pack": {"id": "webapp"},
+    "runtime": {"tick": {"mode": "off"}},
+    "npc": [],
+    "seed": 3,
+    "vuln_kinds": {"ssrf": 1},
 }
 
 
@@ -67,9 +81,48 @@ def _admit_cmdi() -> Snapshot:
     return snap
 
 
+def _admit_ssrf() -> Snapshot:
+    snap = admit(WebappPack(), manifest=_SSRF_MANIFEST, max_repairs=3)
+    assert isinstance(snap, Snapshot), snap
+    return snap
+
+
 def _pentest_task_id(snapshot: Snapshot) -> str:
     task = next(t for t in snapshot.tasks if t.meta.get("family") == "webapp.pentest")
     return task.id
+
+
+def _ssrf_exploit(graph: WorldGraph) -> tuple[str, str, str]:
+    """The (public path, query param, payload URL) for the world's networked SSRF.
+
+    Built from the sampled filter the same way the proven networked tests do, so the
+    agent's own curl drives the cross-service pivot to the internal flag.
+    """
+    ssrf = next(
+        n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == "ssrf"
+    )
+    params = dict(ssrf.attrs.get("params", {}))
+    affected = {e.dst for e in graph.out_edges(ssrf.id, "affects")}
+    public_eps = {
+        e.dst
+        for svc in graph.by_kind("service")
+        if svc.attrs.get("exposure") == "public"
+        for e in graph.out_edges(svc.id, "exposes")
+    }
+    ep_id = next(iter(affected & public_eps))
+    path = str(graph.nodes[ep_id].attrs.get("path", "/"))
+    param = str(params["target_param"])
+    host = str(params["internal_host"])
+    internal_path = str(params["internal_path"])
+    ssrf_filter = params.get("ssrf_filter")
+    if ssrf_filter == "scheme_block":
+        payload = f"gopher://{host}{internal_path}"
+    elif ssrf_filter == "host_allowlist":
+        allowed = str(params.get("allowed_host", "ok"))
+        payload = f"http://{allowed}@{host}{internal_path}"
+    else:  # pragma: no cover - generation only emits the two service-name filters
+        raise AssertionError(f"unexpected networked ssrf_filter: {ssrf_filter!r}")
+    return path, param, payload
 
 
 def test_a_sandboxed_http_world_needs_a_container(tmp_path: Path) -> None:
@@ -142,6 +195,29 @@ def _bind_mount_writeback_works() -> bool:
         shutil.rmtree(probe, ignore_errors=True)
 
 
+def _openrange_resources(kind: str) -> set[str]:
+    # Names of all openrange-* docker networks (or -a containers), for a leak check: a
+    # clean teardown leaves none of an episode's own behind.
+    args = (
+        ["network", "ls", "--format", "{{.Name}}"]
+        if kind == "network"
+        else ["ps", "-a", "--format", "{{.Names}}"]
+    )
+    out = subprocess.run(["docker", *args], capture_output=True, text=True, timeout=10)
+    return {n for n in out.stdout.split() if n.startswith("openrange-")}
+
+
+def _network_is_internal(name: str) -> bool:
+    out = subprocess.run(
+        ["docker", "network", "inspect", "--format", "{{.Internal}}", name],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    return out.returncode == 0 and out.stdout.strip() == "true"
+
+
 @gated
 def test_byo_shell_tool_exploits_a_real_episode_in_its_sandbox(tmp_path: Path) -> None:
     # End to end through the real harness: a real CONTAINER cyber world. The agent, in
@@ -203,6 +279,75 @@ def test_the_sandbox_can_reach_the_target_but_not_the_host_or_internet(
         env._finalize()
     finally:
         service.close()
+
+
+@gated
+def test_byo_shell_tool_pivots_an_ssrf_networked_world_in_its_sandbox(
+    tmp_path: Path,
+) -> None:
+    # The multi-service analogue of the cmdi case: an SSRF world routes to the
+    # NetworkedContainerWebappRuntime (a public + an internal container on the world's
+    # own net). With sandbox=True the public container is DOUBLE-attached — its world
+    # net (so its SSRF handler still pivots to the internal flag) AND a second,
+    # per-episode agent net (so the sandbox reaches it by the `target` alias). The agent
+    # drives the whole cross-service pivot from its sandbox with its own curl, and the
+    # real grader returns full reward — the untested double-attach, proven end to end.
+    snap = _admit_ssrf()
+    graph = snap.graph
+    assert isinstance(
+        WebappPack().realize(graph, Backing.CONTAINER), NetworkedContainerWebappRuntime
+    )  # ssrf on a public endpoint -> _is_networked -> the networked backing
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    path, param, payload = _ssrf_exploit(graph)
+
+    before_nets = _openrange_resources("network")
+    before_cons = _openrange_resources("container")
+
+    service = EpisodeService(WebappPack(), tmp_path / "svc", backing=Backing.CONTAINER)
+    env = EpisodeEnv(
+        service=service,
+        snapshots={snap.snapshot_id: snap},
+        tools=[shell, submit],
+        sandbox=True,
+    )
+    agent_net: str | None = None
+    target: str | None = None
+    try:
+        obs = env.reset(snapshot_id=snap.snapshot_id, task_id=_pentest_task_id(snap))
+        assert "http://target:" in obs  # the brief points at the in-network alias
+        agent_net, target = env._network, env._target_container
+        assert agent_net is not None and target is not None
+
+        # The per-episode agent net is --internal: the agent reaches the target by alias
+        # but has no route to the host or internet (the world-net pivot is unaffected).
+        assert _network_is_internal(agent_net)
+        reachable = env.shell(
+            "curl -s -o /dev/null -w '%{http_code}' http://target:8000/"
+        )
+        assert "200" in reachable, reachable  # public service reachable by the alias
+        egress = env.shell("curl --max-time 5 -s http://1.1.1.1; echo EXIT=$?")
+        assert "EXIT=0" not in egress, egress
+
+        # The SSRF pivot: the agent's curl hits the public service, which fetches the
+        # flag from the internal service across the world net and echoes it back — over
+        # the double-attached container, from the sandbox, no shipped tool.
+        url = f"http://target:8000{path}?{urlencode({param: payload})}"
+        out = env.shell(f"curl -s '{url}'")
+        assert flag in out, out  # recovered across the container boundary
+        assert env.submit(flag) == "submitted"
+
+        env._finalize()
+        assert env.reward == 1.0
+        assert env.report is not None and env.report.passed
+    finally:
+        service.close()
+
+    # Teardown leaks nothing: the agent net + the double-attached target are gone, and
+    # no openrange-* network/container this episode created survives.
+    assert agent_net not in _openrange_resources("network")
+    assert target not in _openrange_resources("container")
+    assert _openrange_resources("network") <= before_nets
+    assert _openrange_resources("container") <= before_cons
 
 
 @gated

--- a/tests/test_trl_sandbox_episode.py
+++ b/tests/test_trl_sandbox_episode.py
@@ -175,6 +175,37 @@ def test_byo_shell_tool_exploits_a_real_episode_in_its_sandbox(tmp_path: Path) -
 
 
 @gated
+def test_the_sandbox_can_reach_the_target_but_not_the_host_or_internet(
+    tmp_path: Path,
+) -> None:
+    # #290 criterion 1 ENFORCED, not just claimed: the per-episode net is --internal, so
+    # the agent (untrusted code) reaches the target by alias but has no route off the
+    # network — no host, no internet, no other episode's published ports.
+    snap = _admit_cmdi()
+    service = EpisodeService(WebappPack(), tmp_path / "svc", backing=Backing.CONTAINER)
+    env = EpisodeEnv(
+        service=service,
+        snapshots={snap.snapshot_id: snap},
+        tools=[shell, submit],
+        sandbox=True,
+    )
+    try:
+        env.reset(snapshot_id=snap.snapshot_id, task_id=_pentest_task_id(snap))
+        reachable = env.shell(
+            "curl -s -o /dev/null -w '%{http_code}' http://target:8000/"
+        )
+        assert "200" in reachable, reachable  # the target is reachable on the net
+        # No route off the internal network: 1.1.1.1 needs no DNS, --max-time bounds a
+        # hang, and any non-zero exit means egress was refused. A bare (non-internal)
+        # network would connect (EXIT=0) and fail this — that is the regression guard.
+        egress = env.shell("curl --max-time 5 -s http://1.1.1.1; echo EXIT=$?")
+        assert "EXIT=0" not in egress, egress
+        env._finalize()
+    finally:
+        service.close()
+
+
+@gated
 def test_a_code_world_is_edited_through_the_sandbox(tmp_path: Path) -> None:
     # The same seam is domain-agnostic: a code world mounts into the sandbox, so a
     # brought shell tool edits the workspace and the change lands on the host tree the

--- a/tests/test_trl_sandbox_episode.py
+++ b/tests/test_trl_sandbox_episode.py
@@ -1,0 +1,200 @@
+"""The sandbox, wired into the bring-your-own-tools seam (#288) through ``EpisodeEnv``.
+
+This is the #290 close: a *brought* tool runs in the episode's own throwaway sandbox,
+the trainer runs no agent command, and it plugs into the same ``tools=`` seam with the
+trainer unchanged. The shell tool below is the user's — the package ships none; it just
+reads the ``run`` capability the env injects into the live surface. The gated test boots
+a REAL cyber episode on the CONTAINER backing and an agent recovers the flag with its
+OWN curl, over the network, from its sandbox — then the real grader returns 1.0.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cyber_webapp import WebappPack
+from cyber_webapp.realize_admit import cmdi_exploit_and_benign
+from openrange_pack_sdk import Backing, Snapshot
+from openrange_trl import EpisodeEnv, SandboxError
+
+from openrange.core.admit import admit
+from openrange.core.episode import EpisodeService
+
+_CMDI_MANIFEST = {
+    "pack": {"id": "webapp"},
+    "runtime": {"tick": {"mode": "off"}},
+    "npc": [],
+    "seed": 7,
+    "loot_shapes": {"file": 1, "db": 0},
+    "vuln_kinds": {"command_injection": 1},
+}
+
+
+# -- brought tools: shell runs in the sandbox, submit records the answer for grading --
+
+
+def shell(surface: Mapping[str, Any], command: str) -> str:
+    """Run a shell command on the agent's own sandbox machine.
+
+    Args:
+        command: the shell command to run.
+    """
+    return str(surface["run"](command).output)
+
+
+def submit(surface: Mapping[str, Any], flag: str) -> str:
+    """Submit the recovered flag for grading.
+
+    Args:
+        flag: the flag value to submit.
+    """
+    path = Path(str(surface["solver_root"])) / "result.json"
+    path.write_text(json.dumps({"flag": flag}), encoding="utf-8")
+    return "submitted"
+
+
+def _admit_cmdi() -> Snapshot:
+    snap = admit(WebappPack(), manifest=_CMDI_MANIFEST, max_repairs=3)
+    assert isinstance(snap, Snapshot), snap
+    return snap
+
+
+def _pentest_task_id(snapshot: Snapshot) -> str:
+    task = next(t for t in snapshot.tasks if t.meta.get("family") == "webapp.pentest")
+    return task.id
+
+
+def test_a_sandboxed_http_world_needs_a_container(tmp_path: Path) -> None:
+    # No docker: a PROCESS cyber world has a base_url but no container to network the
+    # sandbox onto, so enabling the sandbox fails fast with a clear message.
+    snap = _admit_cmdi()
+    service = EpisodeService(WebappPack(), tmp_path / "svc")  # PROCESS backing
+    env = EpisodeEnv(
+        service=service,
+        snapshots={snap.snapshot_id: snap},
+        tools=[shell, submit],
+        sandbox=True,
+    )
+    try:
+        with pytest.raises(SandboxError, match="CONTAINER"):
+            env.reset(snapshot_id=snap.snapshot_id, task_id=_pentest_task_id(snap))
+    finally:
+        service.close()
+
+
+# -- gated: the real engine ------------------------------------------------------------
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        probe = subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=10, check=False
+        )
+    except Exception:  # noqa: BLE001 - a best-effort probe; any failure means "no"
+        return False
+    return probe.returncode == 0
+
+
+gated = pytest.mark.skipif(
+    not _docker_available(), reason="docker engine not reachable"
+)
+
+
+def _bind_mount_writeback_works() -> bool:
+    # Whether a container's writes to a host bind mount sync back (false under the macOS
+    # /var/folders TMPDIR, where reads leak through but writes don't); see the same
+    # probe in test_agent_sandbox.py.
+    probe = Path(tempfile.mkdtemp())
+    try:
+        (probe / "p").write_text("0", encoding="utf-8")
+        subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--user",
+                f"{os.getuid()}:{os.getgid()}",
+                "-v",
+                f"{probe}:/w",
+                "-w",
+                "/w",
+                "python:3.13-slim",
+                "bash",
+                "-lc",
+                "echo 1 > p",
+            ],
+            check=False,
+            capture_output=True,
+            timeout=60,
+        )
+        return (probe / "p").read_text(encoding="utf-8").strip() == "1"
+    finally:
+        shutil.rmtree(probe, ignore_errors=True)
+
+
+@gated
+def test_byo_shell_tool_exploits_a_real_episode_in_its_sandbox(tmp_path: Path) -> None:
+    # The #290 close, end to end through the real harness: a real CONTAINER cyber world,
+    # the agent in its OWN sandbox exploits it with its OWN curl over the network, the
+    # trainer runs no agent command, and the real grader returns full reward.
+    snap = _admit_cmdi()
+    graph = snap.graph
+    exploit_path, _benign = cmdi_exploit_and_benign(graph)
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+
+    service = EpisodeService(WebappPack(), tmp_path / "svc", backing=Backing.CONTAINER)
+    env = EpisodeEnv(
+        service=service,
+        snapshots={snap.snapshot_id: snap},
+        tools=[shell, submit],
+        sandbox=True,
+    )
+    try:
+        obs = env.reset(snapshot_id=snap.snapshot_id, task_id=_pentest_task_id(snap))
+        assert "http://target:" in obs  # the brief points at the in-network alias
+
+        out = env.shell(f"curl -s 'http://target:8000{exploit_path}'")
+        assert flag in out  # recovered over the wire, from the sandbox, no shipped tool
+        assert env.submit(flag) == "submitted"
+
+        env._finalize()
+        assert env.reward == 1.0
+        assert env.report is not None and env.report.passed
+    finally:
+        service.close()
+
+
+@gated
+def test_a_code_world_is_edited_through_the_sandbox(tmp_path: Path) -> None:
+    # The same seam is domain-agnostic: a code world mounts into the sandbox, so a
+    # brought shell tool edits the workspace and the change lands on the host tree the
+    # grader reads. (Skips where the host temp dir isn't docker-file-shared.)
+    if not _bind_mount_writeback_works():
+        pytest.skip("docker bind-mount writeback unavailable (e.g. macOS TMPDIR)")
+    from swe import SwePack
+
+    snap = admit(SwePack(), manifest={"instance": "calc_sum"}, max_repairs=0)
+    assert isinstance(snap, Snapshot), snap
+    service = EpisodeService(SwePack(), tmp_path / "svc")  # PROCESS — a workspace world
+    env = EpisodeEnv(
+        service=service, snapshots={snap.snapshot_id: snap}, tools=[shell], sandbox=True
+    )
+    try:
+        env.reset(snapshot_id=snap.snapshot_id, task_id=snap.tasks[0].id)
+        # A clean append prints nothing; the proof is the change landing on the host
+        # tree the grader reads, not the (empty) command output.
+        env.shell("echo '# edited in the sandbox' >> calc/core.py")
+        solver_root = Path(str(env._surface["solver_root"]))  # type: ignore[index]
+        assert "edited in the sandbox" in (solver_root / "calc/core.py").read_text()
+    finally:
+        service.close()


### PR DESCRIPTION
Closes #290.

## What

Each training episode gets its **own throwaway, isolated machine** where the agent's tools run — and the trainer never runs an agent-issued command.

```python
# the user brings a shell tool; the package ships none
def shell(surface, command):
    return surface["run"](command).output   # runs in the episode's sandbox

env = EpisodeEnv(service=svc, snapshots=snaps, tools=[shell, submit], sandbox=True)
```

Two pieces:

1. **`AgentSandbox`** — a hardened, disposable container (`bash`/`curl`/`python`/`git`; cap-drop ALL, no-new-privileges, runs as the invoking user never root, memory/cpu/pid caps) with one generic primitive: `run(command) -> (exit_code, output)`. The trainer delegates to it; it never execs agent code.

2. **Wired into the bring-your-own-tools seam (#288)** — `EpisodeEnv(sandbox=True)` (and the factory) give each episode a sandbox bound to the live world, and inject a `run` capability into the surface. A brought tool runs "in the sandbox" with the trainer unchanged.

## How it binds to the world (driven by `surface()`)

- **HTTP world (cyber CONTAINER)** — the world is a network target. At reset the episode joins the world to a private per-episode docker network, aliased `target`; the sandbox joins the same network. The network is created **`--internal`**: it has no gateway, so the agent reaches the target by `curl http://target:8000/...` over the wire, but the sandbox **cannot reach the host, the internet, or other episodes' published ports**. Sandbox dies with the episode.
- **Code world** — the world is a workspace; the sandbox bind-mounts it, so the agent edits the tree as its own filesystem and the grader reads it back.

The cyber CONTAINER surface gained `target_container` + `target_port` so the harness can put the sandbox on the world's network. These are agent-invisible — the brief still renders only `base_url`.

## Boundary (the point of #290)

**World = target + grader (OpenRange). Sandbox = the agent's own workstation (the harness). Tools = the agent's own, run in the sandbox.** A real target doesn't hand you a shell — the sandbox is the agent's side, from which it attacks over the network. `submit` stays trainer-side (it records the answer for the grader); only attack tools like `shell` run in the sandbox.

## Live-tested for real, through the actual episode harness (CI Linux + local)

- **The #290 close, end to end:** a real `EpisodeService` CONTAINER cyber episode — a brought shell tool recovers the flag with its **own** `curl`, over the network, from its sandbox (no shipped tool), and the **real grader returns 1.0**.
- **Isolation is enforced, not just claimed:** a gated test asserts the sandbox reaches the target (HTTP 200) **and** that egress off the network is refused (`curl 1.1.1.1` fails). A non-`--internal` network would connect and fail this test — it's a real regression guard.
- A brought shell tool **edits a code world's workspace** through the sandbox and the change lands on the host tree the grader reads (runs on Linux CI; skips under the macOS `/var/folders` TMPDIR).
- Hardening, never-root, content-tagged image reuse, clean teardown, and the lifecycle/binding guards are all asserted. Pure (no-docker) tests pin the binding contract.

ruff + mypy clean; the new modules hit 100% on CI (where the fresh image-build, code-world, and egress paths run).

## Done-when (from #290)

- ✅ Each episode's agent tools run in an isolated, disposable sandbox with network to the target but **not the host** — enforced via an `--internal` network and asserted by an egress test.
- ✅ The trainer sends tool calls and receives results; it runs no agent command itself.
- ✅ Plugs into the bring-your-own-tools seam from #288 — a tool runs "in the sandbox" without the trainer changing.

## A note on review

This branch was put through a multi-agent audit (correctness, regression, security, completeness, cross-PR). It caught a real, live-reproduced hole: the per-episode network was originally **not** `--internal`, so the sandbox had full internet egress and a host gateway — the central safety promise of #290 was asserted but unenforced. That is now fixed (`--internal`) and locked by the egress test above; a network-leak edge (network recorded before `connect`) and an unbounded `close()` were fixed in the same pass.

## Follow-ups (not this PR)

A ReAct-style agent loop + trajectory recording; the concurrent many-episode driver (pairs with #289); a remote SandboxFusion backend; a `sandbox=True` test on a multi-service/SSRF networked world (works today — additive docker multi-network attach — but untested); interruption-safe cleanup (happy-path teardown is clean, but a crashed run can leak an idle container until pruned).

## Merge

Conflict-free with #291 in either order (verified via `git merge-tree`: zero conflicts; only #291 edits the shared docstring). Recommend landing #291 first so #292's "ships no tools" framing is true throughout. Both are off `main`.
