### PR TITLE
feat(trl): async concurrent rollout engine — run many episodes at once (#289 slice 1)

### DIFF
--- a/packages/openrange-trl/pyproject.toml
+++ b/packages/openrange-trl/pyproject.toml
@@ -29,6 +29,9 @@ train = [
     "peft>=0.14",
     "jmespath>=1.0",
 ]
+engine = [
+    "httpx>=0.27",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/openrange_trl"]

--- a/packages/openrange-trl/src/openrange_trl/engine/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/engine/__init__.py
@@ -1,0 +1,28 @@
+"""Async concurrent rollout engine — run many episodes at once against a model server.
+
+The synchronous TRL path generates in-process, one episode at a time. This engine
+runs N episodes concurrently (overlapping the model-wait), drives each with a
+domain-agnostic ReAct loop against a configurable OpenAI-style endpoint, and reuses
+the existing ``EpisodeEnv`` / sandbox / grading / trajectory pieces. Trainer-side only
+— core OpenRange is untouched. Importing it pulls in no torch/transformers/httpx.
+"""
+
+from openrange_trl.engine.backend import InferBackend, OpenAIBackend
+from openrange_trl.engine.dispatch import batch
+from openrange_trl.engine.protocol import Action, Finish, ToolCall
+from openrange_trl.engine.react import Policy, run_react
+from openrange_trl.engine.rollout import AsyncRollout
+from openrange_trl.engine.schema import tool_schema
+
+__all__ = [
+    "Action",
+    "AsyncRollout",
+    "Finish",
+    "InferBackend",
+    "OpenAIBackend",
+    "Policy",
+    "ToolCall",
+    "batch",
+    "run_react",
+    "tool_schema",
+]

--- a/packages/openrange-trl/src/openrange_trl/engine/async_utils.py
+++ b/packages/openrange-trl/src/openrange_trl/engine/async_utils.py
@@ -1,0 +1,32 @@
+"""A bounded thread pool for the blocking work an async rollout offloads.
+
+Only the model round-trip is async; everything else a rollout does — ``EpisodeEnv``
+reset, brought-tool calls, ``AgentSandbox.run`` (a blocking ``docker exec``), grading —
+is synchronous, so it runs here instead of on the event loop. The pool is sized to the
+dispatcher's concurrency: the default loop executor caps at ``min(32, cpu+4)`` (≈14 <
+the 16-world target), and a single ``docker exec`` can hold its thread up to the
+sandbox's 120s timeout, so a too-small pool would head-of-line-block other rollouts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
+
+
+class BlockingPool:
+    """A thread pool plus an awaitable that runs a blocking call on it."""
+
+    def __init__(self, workers: int) -> None:
+        self._executor = ThreadPoolExecutor(max_workers=max(1, workers))
+
+    async def run(self, fn: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, lambda: fn(*args, **kwargs))
+
+    def close(self) -> None:
+        self._executor.shutdown(wait=True)

--- a/packages/openrange-trl/src/openrange_trl/engine/backend.py
+++ b/packages/openrange-trl/src/openrange_trl/engine/backend.py
@@ -1,0 +1,67 @@
+"""The model-server seam: an async ``InferBackend`` + an OpenAI-compatible client.
+
+The engine never generates in-process; it talks to a configurable OpenAI-style HTTP
+endpoint (vLLM, TGI, a hosted API, …). The request/response *shaping* lives in
+``protocol`` (pure, unit-covered); ``OpenAIBackend.generate`` is only the thin round
+trip, so its I/O is exercised by the ``OPENRANGE_LIVE_MODEL_URL``-gated live test.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Protocol
+
+from openrange_trl.engine.protocol import (
+    Action,
+    build_chat_request,
+    parse_chat_response,
+)
+
+
+class InferBackend(Protocol):
+    """A policy that maps the running message log + tool schemas to the next action."""
+
+    async def generate(
+        self, messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+    ) -> Action: ...
+
+
+class OpenAIBackend:
+    """Generate via an OpenAI-style ``/v1/chat/completions`` endpoint.
+
+    ``client`` is injectable (the live test passes a configured one); when omitted, a
+    default async ``httpx`` client is created — ``httpx`` is imported lazily here so
+    ``import openrange_trl.engine`` stays HTTP-free and needs only the ``engine`` extra
+    when a backend is actually constructed.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        model: str,
+        *,
+        api_key: str | None = None,
+        client: Any = None,
+    ) -> None:
+        self._model = model
+        self._url = base_url.rstrip("/") + "/v1/chat/completions"
+        self._headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        if client is None:  # pragma: no cover - real use only; tests inject a client
+            httpx = importlib.import_module("httpx")
+            client = httpx.AsyncClient(timeout=120.0)
+        self._client = client
+
+    async def generate(
+        self, messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+    ) -> Action:
+        # Live I/O — this whole body is covered only by the gated live-model test.
+        request = build_chat_request(self._model, messages, tools)  # pragma: no cover
+        response = await self._client.post(  # pragma: no cover
+            self._url, json=request, headers=self._headers
+        )
+        response.raise_for_status()  # pragma: no cover
+        payload: dict[str, Any] = response.json()  # pragma: no cover
+        return parse_chat_response(payload)  # pragma: no cover
+
+    async def aclose(self) -> None:  # pragma: no cover - live I/O cleanup
+        await self._client.aclose()

--- a/packages/openrange-trl/src/openrange_trl/engine/dispatch.py
+++ b/packages/openrange-trl/src/openrange_trl/engine/dispatch.py
@@ -1,0 +1,48 @@
+"""Run many rollouts concurrently, at most ``concurrency`` in flight.
+
+While one rollout waits on the model, the others make progress; the cap bounds how
+many worlds/sandboxes boot at once. ``pipeline`` (overlapping grade with model-wait via
+a separate eval pool) lands with the world-reuse slice, where its payoff is real.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+
+from openrange.training import Trajectory
+from openrange_trl.engine.async_utils import BlockingPool
+from openrange_trl.engine.rollout import AsyncRollout
+
+
+async def batch(
+    rollouts: Sequence[AsyncRollout], *, concurrency: int
+) -> list[Trajectory]:
+    """Run each rollout's init → run → eval, with at most ``concurrency`` running.
+
+    A rollout that fails (e.g. a model-server error) still tears its own world + sandbox
+    down — ``aclose`` runs in a ``finally`` and ``return_exceptions`` lets every sibling
+    finish its cleanup — so a failed batch leaks nothing; the first error is re-raised.
+    """
+    pool = BlockingPool(concurrency)
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def _one(rollout: AsyncRollout) -> Trajectory:
+        async with semaphore:
+            try:
+                await rollout.init(pool)
+                await rollout.run(pool)
+                return await rollout.eval(pool)
+            finally:
+                await rollout.aclose(pool)
+
+    try:
+        results = await asyncio.gather(
+            *(_one(r) for r in rollouts), return_exceptions=True
+        )
+    finally:
+        pool.close()
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
+    return [r for r in results if isinstance(r, Trajectory)]

--- a/packages/openrange-trl/src/openrange_trl/engine/protocol.py
+++ b/packages/openrange-trl/src/openrange_trl/engine/protocol.py
@@ -1,0 +1,55 @@
+"""Pure shaping of OpenAI chat/completions requests and responses.
+
+Kept free of I/O so every branch is unit-testable with plain dicts; ``OpenAIBackend``
+is only the thin HTTP round-trip around these.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCall:
+    """The model asked to call a tool."""
+
+    id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class Finish:
+    """The model returned a final answer (no tool call) — the loop ends."""
+
+    content: str
+
+
+Action = ToolCall | Finish
+
+
+def build_chat_request(
+    model: str, messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """The /v1/chat/completions request body for one turn."""
+    return {"model": model, "messages": messages, "tools": tools}
+
+
+def parse_chat_response(payload: dict[str, Any]) -> Action:
+    """The next :data:`Action` from a chat/completions response — a tool call if the
+    model emitted one, else a final answer. Unparseable tool arguments degrade to an
+    empty dict (the tool then fails soft) rather than crashing the rollout."""
+    message = payload["choices"][0]["message"]
+    tool_calls = message.get("tool_calls")
+    if tool_calls:
+        call = tool_calls[0]
+        fn = call["function"]
+        raw = fn.get("arguments") or ""
+        try:
+            arguments = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            arguments = {}
+        return ToolCall(id=call.get("id", ""), name=fn["name"], arguments=arguments)
+    return Finish(content=message.get("content") or "")

--- a/packages/openrange-trl/src/openrange_trl/engine/react.py
+++ b/packages/openrange-trl/src/openrange_trl/engine/react.py
@@ -1,0 +1,64 @@
+"""The domain-agnostic agent loop: model → tool call → observation → … until done.
+
+Tools are dispatched through ``getattr(env, name)`` — the exact brought-tool methods
+``EpisodeEnv`` reflects to TRL — so the sandbox seam, fail-soft handling, and turn
+recording all carry over. The tool call runs on the blocking pool (``docker exec``),
+never the event loop.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from openrange_trl import EpisodeEnv
+from openrange_trl.engine.async_utils import BlockingPool
+from openrange_trl.engine.protocol import Action, Finish
+
+Policy = Callable[[list[dict[str, Any]], list[dict[str, Any]]], Awaitable[Action]]
+
+
+async def run_react(
+    env: EpisodeEnv,
+    *,
+    policy: Policy,
+    tool_schemas: list[dict[str, Any]],
+    first_prompt: str,
+    max_iters: int,
+    pool: BlockingPool,
+) -> list[dict[str, Any]]:
+    """Drive ``env`` with ``policy`` until it finishes (or ``max_iters``); return the
+    message log. Tool effects + turn recording happen on ``env`` itself."""
+    messages: list[dict[str, Any]] = [{"role": "user", "content": first_prompt}]
+    for _ in range(max_iters):
+        action = await policy(messages, tool_schemas)
+        if isinstance(action, Finish):
+            messages.append({"role": "assistant", "content": action.content})
+            break
+        messages.append(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": action.id,
+                        "type": "function",
+                        "function": {
+                            "name": action.name,
+                            "arguments": json.dumps(action.arguments),
+                        },
+                    }
+                ],
+            }
+        )
+        output = await pool.run(_call_tool, env, action.name, action.arguments)
+        messages.append({"role": "tool", "tool_call_id": action.id, "content": output})
+    return messages
+
+
+def _call_tool(env: EpisodeEnv, name: str, arguments: dict[str, Any]) -> str:
+    method = getattr(env, name, None)
+    if method is None:
+        return f"error: no tool named {name!r}"
+    return str(method(**arguments))

--- a/packages/openrange-trl/src/openrange_trl/engine/rollout.py
+++ b/packages/openrange-trl/src/openrange_trl/engine/rollout.py
@@ -1,0 +1,93 @@
+"""One episode as three async stages over an ``EpisodeEnv``: init → run → eval.
+
+Each rollout owns an isolated ``EpisodeService`` (the factory builds a fresh one per
+call), so N rollouts run on threads without sharing world/episode state. The first
+prompt is built here from the task instruction + ``reset()``'s observation — which
+already carries the live, sandbox-correct interface URL — so the engine depends on no
+example harness code.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from openrange.training import Trajectory
+from openrange_trl import EpisodeEnv, env_trajectory
+from openrange_trl.engine.async_utils import BlockingPool
+from openrange_trl.engine.react import Policy, run_react
+from openrange_trl.engine.schema import tool_schema
+
+
+class AsyncRollout:
+    """Drive one episode concurrently: realize + reset, run the ReAct loop, grade."""
+
+    def __init__(
+        self,
+        factory: Callable[[], EpisodeEnv],
+        *,
+        policy: Policy,
+        snapshot_id: str | None = None,
+        task_id: str | None = None,
+        max_iters: int = 8,
+    ) -> None:
+        self._factory = factory
+        self._policy = policy
+        self._snapshot_id = snapshot_id
+        self._task_id = task_id
+        self._max_iters = max_iters
+        self._env: EpisodeEnv | None = None
+        self._tool_schemas: list[dict[str, Any]] = []
+        self._first_prompt = ""
+        self._closed = False
+        self.messages: list[dict[str, Any]] = []
+
+    async def init(self, pool: BlockingPool) -> None:
+        env = self._factory()
+        self._env = env
+        self._tool_schemas = [tool_schema(fn) for fn in env._tools.values()]
+        obs = await pool.run(
+            env.reset, snapshot_id=self._snapshot_id, task_id=self._task_id
+        )
+        instruction = self._instruction(env)
+        self._first_prompt = f"{instruction}\n\n{obs}" if instruction else obs
+
+    async def run(self, pool: BlockingPool) -> None:
+        env = self._require_env()
+        self.messages = await run_react(
+            env,
+            policy=self._policy,
+            tool_schemas=self._tool_schemas,
+            first_prompt=self._first_prompt,
+            max_iters=self._max_iters,
+            pool=pool,
+        )
+
+    async def eval(self, pool: BlockingPool) -> Trajectory:
+        # env_trajectory finalizes the episode (grades + tears down the sandbox); the
+        # world service is closed in aclose so cleanup also runs on the failure path.
+        return await pool.run(env_trajectory, self._require_env())
+
+    async def aclose(self, pool: BlockingPool) -> None:
+        """Tear the episode's world + sandbox down, once. Safe on any exit — success,
+        a mid-rollout failure, or cancellation — so a failed batch leaks nothing."""
+        if self._env is None or self._closed:
+            return
+        self._closed = True
+        env = self._env
+        # _finalize is idempotent; it tears the sandbox down if eval() never ran.
+        await pool.run(env._finalize)
+        await pool.run(env.service.close)
+
+    def _require_env(self) -> EpisodeEnv:
+        if self._env is None:
+            raise RuntimeError("rollout not initialized; call init() first")
+        return self._env
+
+    def _instruction(self, env: EpisodeEnv) -> str:
+        snapshot_id = self._snapshot_id or next(iter(env.snapshots))
+        snapshot = env.snapshots[snapshot_id]
+        for task in snapshot.tasks:
+            if self._task_id is None or task.id == self._task_id:
+                return str(task.instruction)
+        return ""

--- a/packages/openrange-trl/src/openrange_trl/engine/schema.py
+++ b/packages/openrange-trl/src/openrange_trl/engine/schema.py
@@ -1,0 +1,79 @@
+"""Derive a chat/completions tool schema for a brought tool — transformers-free.
+
+The sync TRL path lets TRL reflect the tools via ``transformers.get_json_schema``;
+the async engine must stay transformers-free, so it builds the same shape here from
+the tool's signature + Google-style docstring. The first parameter (the live surface
+``EpisodeEnv`` injects) is dropped by POSITION, matching ``_tool_method``'s ``[1:]`` —
+the contract is positional, not "a param literally named ``surface``".
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from collections.abc import Callable
+from typing import Any
+
+# Annotations may be runtime types or strings (``from __future__ import annotations``),
+# so map by the type's name rather than the type object.
+_JSON_TYPES = {"str": "string", "int": "integer", "float": "number", "bool": "boolean"}
+
+
+def tool_schema(fn: Callable[..., str]) -> dict[str, Any]:
+    """The OpenAI tool dict for a brought tool ``fn(surface, **params)``."""
+    params = list(inspect.signature(fn).parameters.values())[1:]
+    descriptions = _arg_descriptions(fn.__doc__ or "")
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for p in params:
+        prop: dict[str, Any] = {"type": _json_type(p.annotation)}
+        if p.name in descriptions:
+            prop["description"] = descriptions[p.name]
+        properties[p.name] = prop
+        if p.default is inspect.Parameter.empty:
+            required.append(p.name)
+    return {
+        "type": "function",
+        "function": {
+            "name": fn.__name__,
+            "description": _summary(fn.__doc__ or ""),
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+            },
+        },
+    }
+
+
+def _json_type(annotation: Any) -> str:
+    if annotation is inspect.Parameter.empty:
+        return "string"
+    name = (
+        annotation
+        if isinstance(annotation, str)
+        else getattr(annotation, "__name__", "str")
+    )
+    return _JSON_TYPES.get(name, "string")
+
+
+def _summary(doc: str) -> str:
+    # The text before the Google-style ``Args:`` block is the tool description.
+    head = re.split(r"\n\s*Args:", doc, maxsplit=1)[0]
+    return " ".join(head.split())
+
+
+def _arg_descriptions(doc: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    in_args = False
+    for line in doc.splitlines():
+        if line.strip() == "Args:":
+            in_args = True
+            continue
+        if in_args:
+            match = re.match(r"\s+(\w+):\s*(.+)", line)
+            if match:
+                out[match.group(1)] = match.group(2).strip()
+            elif line.strip():
+                break
+    return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
     "openrange-cyber-webapp",
     "openrange-trading",
     "openrange-swe",
-    "openrange-trl",
+    "openrange-trl[engine]",
 ]
 
 [tool.uv.workspace]

--- a/tests/test_engine_import.py
+++ b/tests/test_engine_import.py
@@ -1,0 +1,26 @@
+"""Importing the engine must pull in no torch/transformers/trl/httpx/examples.
+
+Run in a fresh interpreter (not this polluted pytest process) so sys.modules is a
+true reflection of what `import openrange_trl.engine` drags in — this is the guard
+that catches an accidental shipped-code dependency on the non-wheel `examples`
+package or a non-lazy heavy import.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_importing_the_engine_pulls_in_no_heavy_or_example_deps() -> None:
+    code = (
+        "import openrange_trl.engine, sys; "
+        "roots = {'torch', 'transformers', 'trl', 'httpx', 'examples'}; "
+        "bad = sorted(m for m in sys.modules if m.split('.')[0] in roots); "
+        "print(bad); "
+        "assert not bad, bad"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_engine_live_model.py
+++ b/tests/test_engine_live_model.py
@@ -1,0 +1,137 @@
+"""The OpenAI-style backend, against a real server — gated, never mocked.
+
+The construction test needs only ``httpx`` (no network). The generation and
+full-episode tests need a real OpenAI-style endpoint: set ``OPENRANGE_LIVE_MODEL_URL``
+(and optionally ``OPENRANGE_LIVE_MODEL``) — same gating as ``OPENRANGE_LIVE_TRL``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cyber_webapp import WebappPack
+from openrange_pack_sdk import Backing, Snapshot
+from openrange_trl import make_environment_factory
+from openrange_trl.engine import Action, AsyncRollout, OpenAIBackend, batch
+
+from openrange.core.admit import admit
+from openrange.training import Trajectory
+
+_MODEL_URL = os.environ.get("OPENRANGE_LIVE_MODEL_URL")
+_MODEL = os.environ.get("OPENRANGE_LIVE_MODEL", "default")
+needs_model = pytest.mark.skipif(
+    not _MODEL_URL,
+    reason="set OPENRANGE_LIVE_MODEL_URL to a real OpenAI-style endpoint",
+)
+
+
+def test_openai_backend_builds_the_endpoint_and_headers() -> None:
+    httpx = pytest.importorskip("httpx")
+    client = httpx.AsyncClient()
+    backend = OpenAIBackend("http://srv:8000/", "m", api_key="k", client=client)
+    assert backend._url == "http://srv:8000/v1/chat/completions"
+    assert backend._headers == {"Authorization": "Bearer k"}
+    assert backend._model == "m"
+    asyncio.run(client.aclose())
+
+
+@needs_model
+def test_openai_backend_generates_against_a_real_server() -> None:
+    async def go() -> Action:
+        backend = OpenAIBackend(str(_MODEL_URL), _MODEL)
+        try:
+            return await backend.generate(
+                [{"role": "user", "content": "Reply with the single word: hi."}], []
+            )
+        finally:
+            await backend.aclose()
+
+    action = asyncio.run(go())
+    assert action is not None  # a ToolCall or a Finish came back
+
+
+def shell(surface: Mapping[str, Any], command: str) -> str:
+    """Run a shell command on the agent's own sandbox machine.
+
+    Args:
+        command: the shell command to run.
+    """
+    return str(surface["run"](command).output)
+
+
+def submit(surface: Mapping[str, Any], flag: str) -> str:
+    """Submit the recovered flag for grading.
+
+    Args:
+        flag: the flag value to submit.
+    """
+    path = Path(str(surface["solver_root"])) / "result.json"
+    path.write_text(json.dumps({"flag": flag}), encoding="utf-8")
+    return "submitted"
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        probe = subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=10, check=False
+        )
+    except Exception:  # noqa: BLE001 - a best-effort probe; any failure means "no"
+        return False
+    return probe.returncode == 0
+
+
+@needs_model
+@pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
+def test_a_real_model_drives_a_sandboxed_episode(tmp_path: Path) -> None:
+    # The full slice end to end: a real model, in its own sandbox, drives a real cyber
+    # episode via the engine. Asserts the MECHANICS (a graded trajectory comes back),
+    # not that the model solves it — solving is a model-capability matter, not the seam.
+    snap = admit(
+        WebappPack(),
+        manifest={
+            "pack": {"id": "webapp"},
+            "runtime": {"tick": {"mode": "off"}},
+            "npc": [],
+            "seed": 7,
+            "loot_shapes": {"db": 1, "file": 0},
+            "vuln_kinds": {"sql_injection": 1},
+        },
+    )
+    assert isinstance(snap, Snapshot), snap
+    task_id = next(t.id for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+    factory = make_environment_factory(
+        WebappPack(),
+        [snap],
+        tmp_path / "envs",
+        tools=[shell, submit],
+        backing=Backing.CONTAINER,
+        sandbox=True,
+    )
+
+    async def go() -> list[Trajectory]:
+        backend = OpenAIBackend(str(_MODEL_URL), _MODEL)
+        rollout = AsyncRollout(
+            factory,
+            policy=backend.generate,
+            snapshot_id=snap.snapshot_id,
+            task_id=task_id,
+            max_iters=6,
+        )
+        try:
+            return await batch([rollout], concurrency=1)
+        finally:
+            await backend.aclose()
+
+    [trajectory] = asyncio.run(go())
+    assert 0.0 <= trajectory.reward.scalar <= 1.0
+    assert trajectory.snapshot_id == snap.snapshot_id

--- a/tests/test_engine_protocol.py
+++ b/tests/test_engine_protocol.py
@@ -1,0 +1,53 @@
+"""Pure chat/completions request/response shaping — every branch, with real dicts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openrange_trl.engine import Finish, ToolCall
+from openrange_trl.engine.protocol import build_chat_request, parse_chat_response
+
+
+def test_build_chat_request_carries_model_messages_and_tools() -> None:
+    msgs = [{"role": "user", "content": "go"}]
+    tools = [{"type": "function", "function": {"name": "shell"}}]
+    assert build_chat_request("m", msgs, tools) == {
+        "model": "m",
+        "messages": msgs,
+        "tools": tools,
+    }
+
+
+def _tool_message(name: str, arguments: str | None) -> dict[str, Any]:
+    fn: dict[str, Any] = {"name": name}
+    if arguments is not None:
+        fn["arguments"] = arguments
+    return {"choices": [{"message": {"tool_calls": [{"id": "c1", "function": fn}]}}]}
+
+
+def test_parse_returns_a_toolcall_with_parsed_arguments() -> None:
+    action = parse_chat_response(_tool_message("shell", '{"command": "ls"}'))
+    assert action == ToolCall(id="c1", name="shell", arguments={"command": "ls"})
+
+
+def test_parse_toolcall_with_empty_arguments_is_an_empty_dict() -> None:
+    action = parse_chat_response(_tool_message("submit", ""))
+    assert isinstance(action, ToolCall)
+    assert action.arguments == {}
+
+
+def test_parse_toolcall_with_malformed_arguments_degrades_to_empty() -> None:
+    # A model emitting non-JSON args shouldn't crash the rollout — the tool fails soft.
+    action = parse_chat_response(_tool_message("submit", "{not json"))
+    assert isinstance(action, ToolCall)
+    assert action.arguments == {}
+
+
+def test_parse_returns_finish_when_no_tool_call() -> None:
+    payload = {"choices": [{"message": {"content": "the answer"}}]}
+    assert parse_chat_response(payload) == Finish(content="the answer")
+
+
+def test_parse_returns_empty_finish_when_content_is_null() -> None:
+    payload = {"choices": [{"message": {"content": None}}]}
+    assert parse_chat_response(payload) == Finish(content="")

--- a/tests/test_engine_react.py
+++ b/tests/test_engine_react.py
@@ -1,0 +1,138 @@
+"""``run_react`` + ``AsyncRollout`` guards over a real PROCESS world (no docker).
+
+A PROCESS cyber world boots an in-process HTTP server (no docker), so the loop and the
+rollout guards are driven over a real ``EpisodeEnv`` without a sandbox or a model.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cyber_webapp import WebappPack
+from openrange_pack_sdk import Snapshot
+from openrange_trl import EpisodeEnv, make_environment_factory
+from openrange_trl.engine import AsyncRollout, Finish, ToolCall
+from openrange_trl.engine.async_utils import BlockingPool
+from openrange_trl.engine.react import run_react
+
+from openrange.core.admit import admit
+from openrange.core.episode import EpisodeService
+
+_MANIFEST = {
+    "pack": {"id": "webapp"},
+    "runtime": {"tick": {"mode": "off"}},
+    "npc": [],
+    "seed": 0,
+    "loot_shapes": {"db": 1, "file": 0},
+    "vuln_kinds": {"sql_injection": 1},
+}
+
+
+def note(surface: Mapping[str, Any], text: str = "ok") -> str:
+    """Record a note.
+
+    Args:
+        text: the note text.
+    """
+    return f"noted: {text}"
+
+
+def _snapshot() -> Snapshot:
+    snap = admit(WebappPack(), manifest=_MANIFEST)
+    assert isinstance(snap, Snapshot), snap
+    return snap
+
+
+def _pentest_task_id(snap: Snapshot) -> str:
+    return next(t.id for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+
+
+def test_run_react_runs_to_max_iters_and_reports_unknown_tools(tmp_path: Path) -> None:
+    # A policy that keeps calling tools and never finishes runs the loop to max_iters;
+    # an unknown tool name fails soft instead of crashing the rollout.
+    snap = _snapshot()
+    service = EpisodeService(WebappPack(), tmp_path / "svc")  # PROCESS backing
+    env = EpisodeEnv(service=service, snapshots={snap.snapshot_id: snap}, tools=[note])
+    pool = BlockingPool(1)
+    calls = {"i": 0}
+
+    async def policy(
+        messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+    ) -> ToolCall:
+        calls["i"] += 1
+        if calls["i"] == 1:
+            return ToolCall(id="c1", name="note", arguments={"text": "hi"})
+        return ToolCall(id="c2", name="ghost", arguments={})
+
+    try:
+        env.reset(snapshot_id=snap.snapshot_id, task_id=_pentest_task_id(snap))
+        messages = asyncio.run(
+            run_react(
+                env,
+                policy=policy,
+                tool_schemas=[],
+                first_prompt="go",
+                max_iters=3,
+                pool=pool,
+            )
+        )
+    finally:
+        pool.close()
+        service.close()
+
+    tool_outputs = [m["content"] for m in messages if m["role"] == "tool"]
+    assert len(tool_outputs) == 3  # the loop ran the full max_iters (never finished)
+    assert "noted: hi" in tool_outputs[0]
+    assert "error: no tool named 'ghost'" in tool_outputs[1]
+
+
+def test_instruction_falls_back_when_no_task_matches(tmp_path: Path) -> None:
+    snap = _snapshot()
+    service = EpisodeService(WebappPack(), tmp_path / "svc")
+    env = EpisodeEnv(service=service, snapshots={snap.snapshot_id: snap}, tools=[note])
+
+    async def policy(
+        messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+    ) -> Finish:
+        return Finish(content="")
+
+    rollout = AsyncRollout(
+        lambda: env, policy=policy, snapshot_id=snap.snapshot_id, task_id="no-such-task"
+    )
+    try:
+        assert rollout._instruction(env) == ""  # no task matches → empty instruction
+    finally:
+        service.close()
+
+
+def test_run_or_eval_before_init_is_refused(tmp_path: Path) -> None:
+    factory = make_environment_factory(
+        WebappPack(), [_snapshot()], tmp_path / "envs", tools=[note]
+    )
+
+    async def policy(
+        messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+    ) -> Finish:
+        return Finish(content="")
+
+    rollout = AsyncRollout(factory, policy=policy)
+    with pytest.raises(RuntimeError, match="not initialized"):
+        rollout._require_env()
+
+
+def test_rollout_aclose_is_a_safe_noop_before_init() -> None:
+    async def policy(
+        messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+    ) -> Finish:
+        return Finish(content="")
+
+    rollout = AsyncRollout(lambda: pytest.fail("factory must not run"), policy=policy)
+    pool = BlockingPool(1)
+    try:
+        asyncio.run(rollout.aclose(pool))  # env is None → tears down nothing, no raise
+    finally:
+        pool.close()

--- a/tests/test_engine_rollout.py
+++ b/tests/test_engine_rollout.py
@@ -1,0 +1,255 @@
+"""The async engine, end to end on real episodes — concurrency, grading, isolation.
+
+No model: a deterministic policy (a real :data:`Policy`-shaped callable, not a mock)
+issues the known cmdi exploit + submit over real CONTAINER cyber worlds. Proves a
+rollout grades to 1.0, that ``batch`` truly runs episodes concurrently (an
+``asyncio.Barrier`` all N must reach at once — serialization would hang), and that a
+no-op rollout scores 0.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cyber_webapp import WebappPack
+from cyber_webapp.realize_admit import cmdi_exploit_and_benign
+from openrange_pack_sdk import Backing, Snapshot
+from openrange_trl import make_environment_factory
+from openrange_trl.engine import Action, AsyncRollout, Finish, Policy, ToolCall, batch
+
+from openrange.core.admit import admit
+from openrange.training import Trajectory
+
+_CMDI_MANIFEST = {
+    "pack": {"id": "webapp"},
+    "runtime": {"tick": {"mode": "off"}},
+    "npc": [],
+    "seed": 7,
+    "loot_shapes": {"file": 1, "db": 0},
+    "vuln_kinds": {"command_injection": 1},
+}
+
+
+def shell(surface: Mapping[str, Any], command: str) -> str:
+    """Run a shell command on the agent's own sandbox machine.
+
+    Args:
+        command: the shell command to run.
+    """
+    return str(surface["run"](command).output)
+
+
+def submit(surface: Mapping[str, Any], flag: str) -> str:
+    """Submit the recovered flag for grading.
+
+    Args:
+        flag: the flag value to submit.
+    """
+    path = Path(str(surface["solver_root"])) / "result.json"
+    path.write_text(json.dumps({"flag": flag}), encoding="utf-8")
+    return "submitted"
+
+
+def _admit_cmdi() -> Snapshot:
+    snap = admit(WebappPack(), manifest=_CMDI_MANIFEST, max_repairs=3)
+    assert isinstance(snap, Snapshot), snap
+    return snap
+
+
+def _pentest_task_id(snapshot: Snapshot) -> str:
+    task = next(t for t in snapshot.tasks if t.meta.get("family") == "webapp.pentest")
+    return task.id
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        probe = subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=10, check=False
+        )
+    except Exception:  # noqa: BLE001 - a best-effort probe; any failure means "no"
+        return False
+    return probe.returncode == 0
+
+
+gated = pytest.mark.skipif(
+    not _docker_available(), reason="docker engine not reachable"
+)
+
+
+def _solver(
+    exploit_path: str, flag: str, *, gate: asyncio.Barrier | None = None
+) -> Policy:
+    # A fresh per-rollout policy: curl the exploit, submit the flag, finish. `gate`, if
+    # given, blocks the first action until every rollout has reached it (overlap proof).
+    state = {"step": 0}
+
+    async def policy(
+        messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+    ) -> Action:
+        step = state["step"]
+        state["step"] += 1
+        if step == 0:
+            if gate is not None:
+                await gate.wait()
+            cmd = f"curl -s 'http://target:8000{exploit_path}'"
+            return ToolCall(id="c1", name="shell", arguments={"command": cmd})
+        if step == 1:
+            return ToolCall(id="c2", name="submit", arguments={"flag": flag})
+        return Finish(content="done")
+
+    return policy
+
+
+@gated
+def test_a_rollout_solves_a_real_cyber_episode(tmp_path: Path) -> None:
+    snap = _admit_cmdi()
+    exploit_path, _ = cmdi_exploit_and_benign(snap.graph)
+    flag = str(snap.graph.nodes["secret_flag"].attrs["value_ref"])
+    factory = make_environment_factory(
+        WebappPack(),
+        [snap],
+        tmp_path / "envs",
+        tools=[shell, submit],
+        backing=Backing.CONTAINER,
+        sandbox=True,
+    )
+    rollout = AsyncRollout(
+        factory,
+        policy=_solver(exploit_path, flag),
+        snapshot_id=snap.snapshot_id,
+        task_id=_pentest_task_id(snap),
+    )
+    [trajectory] = asyncio.run(batch([rollout], concurrency=1))
+    assert trajectory.reward.scalar == 1.0
+    assert trajectory.success
+    assert trajectory.snapshot_id == snap.snapshot_id
+
+
+@gated
+def test_batch_runs_episodes_concurrently(tmp_path: Path) -> None:
+    n = 3
+    snap = _admit_cmdi()
+    exploit_path, _ = cmdi_exploit_and_benign(snap.graph)
+    flag = str(snap.graph.nodes["secret_flag"].attrs["value_ref"])
+    task_id = _pentest_task_id(snap)
+    factory = make_environment_factory(
+        WebappPack(),
+        [snap],
+        tmp_path / "envs",
+        tools=[shell, submit],
+        backing=Backing.CONTAINER,
+        sandbox=True,
+    )
+
+    async def go() -> list[Trajectory]:
+        gate = asyncio.Barrier(n)  # releases only when all n rollouts arrive at once
+        rollouts = [
+            AsyncRollout(
+                factory,
+                policy=_solver(exploit_path, flag, gate=gate),
+                snapshot_id=snap.snapshot_id,
+                task_id=task_id,
+            )
+            for _ in range(n)
+        ]
+        # If batch() serialized, the first rollout blocks at the barrier forever and
+        # this times out; overlap is what lets all n arrive and release.
+        return await asyncio.wait_for(batch(rollouts, concurrency=n), timeout=240)
+
+    trajectories = asyncio.run(go())
+    assert len(trajectories) == n
+    assert all(t.reward.scalar == 1.0 for t in trajectories)
+
+
+@gated
+def test_a_rollout_that_does_nothing_scores_zero(tmp_path: Path) -> None:
+    snap = _admit_cmdi()
+    factory = make_environment_factory(
+        WebappPack(),
+        [snap],
+        tmp_path / "envs",
+        tools=[shell, submit],
+        backing=Backing.CONTAINER,
+        sandbox=True,
+    )
+
+    async def idle(
+        messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+    ) -> Finish:
+        return Finish(content="")
+
+    rollout = AsyncRollout(
+        factory,
+        policy=idle,
+        snapshot_id=snap.snapshot_id,
+        task_id=_pentest_task_id(snap),
+    )
+    [trajectory] = asyncio.run(batch([rollout], concurrency=1))
+    assert trajectory.reward.scalar == 0.0
+    assert not trajectory.success
+
+
+def _agent_resource_count() -> tuple[int, int]:
+    # The leak-prone per-episode resources: sandbox containers + their --internal nets.
+    containers = subprocess.run(
+        ["docker", "ps", "-aq", "--filter", "name=openrange-agent"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    ).stdout.split()
+    networks = subprocess.run(
+        ["docker", "network", "ls", "-q", "--filter", "name=openrange-agent-net"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    ).stdout.split()
+    return len(containers), len(networks)
+
+
+@gated
+def test_batch_cleans_up_when_a_rollout_fails(tmp_path: Path) -> None:
+    # A mid-batch failure must leak nothing: a sibling raises after both worlds and
+    # sandboxes are up, yet every container and per-episode network is torn down (and
+    # the error surfaces). Guards the failure path the happy-path tests can't.
+    snap = _admit_cmdi()
+    exploit_path, _ = cmdi_exploit_and_benign(snap.graph)
+    flag = str(snap.graph.nodes["secret_flag"].attrs["value_ref"])
+    task_id = _pentest_task_id(snap)
+    factory = make_environment_factory(
+        WebappPack(),
+        [snap],
+        tmp_path / "envs",
+        tools=[shell, submit],
+        backing=Backing.CONTAINER,
+        sandbox=True,
+    )
+
+    async def boom(
+        messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+    ) -> Finish:
+        raise RuntimeError("model server down")
+
+    before = _agent_resource_count()
+    rollouts = [
+        AsyncRollout(
+            factory,
+            policy=_solver(exploit_path, flag),
+            snapshot_id=snap.snapshot_id,
+            task_id=task_id,
+        ),
+        AsyncRollout(
+            factory, policy=boom, snapshot_id=snap.snapshot_id, task_id=task_id
+        ),
+    ]
+    with pytest.raises(RuntimeError, match="model server down"):
+        asyncio.run(batch(rollouts, concurrency=2))
+    assert _agent_resource_count() == before  # no leaked container or network

--- a/tests/test_engine_schema.py
+++ b/tests/test_engine_schema.py
@@ -1,0 +1,79 @@
+"""The vendored tool-schema builder turns a brought tool into a chat/completions dict.
+
+Pure — no transformers, no HTTP. Pins the position-drop of the injected surface arg,
+per-parameter descriptions from the Google docstring, and the type mapping (including
+string annotations under ``from __future__ import annotations``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from openrange_trl.engine import tool_schema
+from openrange_trl.engine.schema import _json_type
+
+
+def recon(ctx: Mapping[str, Any], path: str, depth: int = 1) -> str:
+    """Fetch a path on the target.
+
+    Args:
+        path: the request path.
+        depth: how deep to crawl.
+    """
+    return ""
+
+
+def test_tool_schema_drops_the_first_arg_by_position_and_reads_the_docstring() -> None:
+    # The first param is named `ctx` (not `surface`) on purpose: the contract is
+    # positional, so `ctx` must be dropped and never appear in the schema.
+    assert tool_schema(recon) == {
+        "type": "function",
+        "function": {
+            "name": "recon",
+            "description": "Fetch a path on the target.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "the request path."},
+                    "depth": {"type": "integer", "description": "how deep to crawl."},
+                },
+                "required": ["path"],  # `depth` has a default → optional
+            },
+        },
+    }
+
+
+def test_tool_schema_falls_back_with_no_docstring() -> None:
+    def bare(surface: Any, value: Any) -> str:
+        return ""
+
+    schema = tool_schema(bare)["function"]
+    assert schema["description"] == ""
+    assert schema["parameters"]["properties"] == {"value": {"type": "string"}}
+    assert schema["parameters"]["required"] == ["value"]
+
+
+def test_json_type_defaults_to_string_for_missing_or_unknown() -> None:
+    import inspect
+
+    assert _json_type(inspect.Parameter.empty) == "string"  # no annotation
+    assert _json_type(dict) == "string"  # unmapped type
+
+
+def with_trailing_block(surface: Any, x: str) -> str:
+    """Do a thing.
+
+    Args:
+        x: the x value.
+
+    Returns:
+        nothing useful.
+    """
+    return ""
+
+
+def test_arg_parsing_stops_at_the_next_docstring_block() -> None:
+    # A non-"name:" line after the Args block (here ``Returns:``) ends arg parsing.
+    props = tool_schema(with_trailing_block)["function"]["parameters"]["properties"]
+    assert props == {"x": {"type": "string", "description": "the x value."}}

--- a/uv.lock
+++ b/uv.lock
@@ -1204,7 +1204,7 @@ dev = [
     { name = "openrange-cyber-webapp" },
     { name = "openrange-swe" },
     { name = "openrange-trading" },
-    { name = "openrange-trl" },
+    { name = "openrange-trl", extra = ["engine"] },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -1227,7 +1227,7 @@ dev = [
     { name = "openrange-cyber-webapp", editable = "packs/cyber_webapp" },
     { name = "openrange-swe", editable = "packs/swe" },
     { name = "openrange-trading", editable = "packs/trading" },
-    { name = "openrange-trl", editable = "packages/openrange-trl" },
+    { name = "openrange-trl", extras = ["engine"], editable = "packages/openrange-trl" },
     { name = "pytest", specifier = ">=9.0" },
     { name = "ruff", specifier = ">=0.15.6" },
 ]
@@ -1302,6 +1302,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+engine = [
+    { name = "httpx" },
+]
 train = [
     { name = "accelerate" },
     { name = "datasets" },
@@ -1316,6 +1319,7 @@ train = [
 requires-dist = [
     { name = "accelerate", marker = "extra == 'train'", specifier = ">=1.0" },
     { name = "datasets", marker = "extra == 'train'", specifier = ">=4.0" },
+    { name = "httpx", marker = "extra == 'engine'", specifier = ">=0.27" },
     { name = "jmespath", marker = "extra == 'train'", specifier = ">=1.0" },
     { name = "openrange", editable = "." },
     { name = "openrange-pack-sdk", editable = "packages/openrange-pack-sdk" },
@@ -1324,7 +1328,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'train'", specifier = ">=5.2" },
     { name = "trl", marker = "extra == 'train'", specifier = ">=1.5" },
 ]
-provides-extras = ["train"]
+provides-extras = ["train", "engine"]
 
 [[package]]
 name = "opentelemetry-api"


### PR DESCRIPTION
First slice of #289 — run many training episodes at once.

## What

Training rollouts today are synchronous: TRL's `GRPOTrainer` runs one episode at a time, sitting idle while the model thinks. This adds an async rollout engine (`openrange_trl.engine`) that runs **N episodes concurrently** against a **configurable OpenAI-style model server**, driving each with a domain-agnostic ReAct loop over the agent sandbox (#290). It's **trainer-side only** — `src/openrange` (the core gym) is untouched.

This covers #289's first two capabilities; the third (reuse booted worlds / a pool) is deferred to the next slice — there's no "reset world state without rebuild" in the codebase today, so a pool is a separate, larger piece.

```python
from openrange_trl.engine import AsyncRollout, OpenAIBackend, batch

backend = OpenAIBackend("http://localhost:8000", "my-model")   # any OpenAI-style server
rollouts = [AsyncRollout(factory, policy=backend.generate, snapshot_id=s, task_id=t)
            for s, t in dataset]
trajectories = await batch(rollouts, concurrency=16)           # 16 in flight at once
```

## How it works

- **`AsyncRollout`** — one episode as three async stages: `init` (realize + reset, over its own isolated `EpisodeService`), `run` (the ReAct loop), `eval` (grade + export a `Trajectory`). `batch()` runs many under a concurrency cap.
- **Async where it matters, threads where it must** — only the model round-trip is on the event loop (`httpx`); every blocking call (reset, tool calls, `AgentSandbox.run`'s `docker exec`, grading) runs on a bounded thread pool sized to the concurrency, so a slow tool call can't head-of-line-block the others. Safe by **isolation**: each rollout owns its own service + sandbox container + per-episode network.
- **`OpenAIBackend`** — a thin `/v1/chat/completions` client. Request/response shaping is pure (`protocol.py`, fully unit-tested); a vendored `tool_schema` keeps the engine transformers-free. The **policy seam** (`(messages, tools) -> Action`) means a deterministic test solver and the real model backend are both genuine `InferBackend`-shaped callables — no test doubles.
- Reuses `EpisodeEnv` / `make_environment_factory` / `env_trajectory` / `episode_reward` / `AgentSandbox`; the first prompt is built from the task instruction + `reset()`'s observation (the sandbox-correct in-network URL), so the engine imports nothing from `examples/`.

## Tested (no mocks — `.rules` line 33)

- **Pure:** the schema builder (position-drop of the injected arg, per-param docstrings, type mapping) and the request/response shaping — every branch, real dicts.
- **Clean-import guard:** a subprocess asserts `import openrange_trl.engine` pulls in **no** torch/transformers/httpx/`examples`.
- **Docker-gated, real:** a deterministic solver drives real CONTAINER cyber episodes to reward 1.0; an **`asyncio.Barrier` overlap proof** (all N must arrive at once — a serialized regression would hang and time out) confirms real concurrency; a no-op scores 0; and a **failure-path leak guard** confirms a mid-batch error tears every world + sandbox down (no leaked containers/networks).
- **Model-endpoint-gated:** `OPENRANGE_LIVE_MODEL_URL` runs a real model end-to-end (mirrors the live-TRL gate).

100% engine coverage, ruff + mypy clean.

## A note on review

Both the design and the implementation were put through multi-agent audits. The design audit caught two would-be failures (a prompt-builder that imported the non-shipped `examples` package, and a concurrency test that only proved isolation) — fixed before coding. The implementation audit caught a real **resource leak**: a bare `asyncio.gather` plus teardown living only in `eval()` meant a single mid-batch failure (e.g. a model-server 5xx) leaked every in-flight rollout's container + network. Fixed: rollouts are now self-cleaning (`aclose` in a `finally`) and `batch` uses `return_exceptions` so every sibling finishes its cleanup before the first error is re-raised — guarded by the failure-path test above.

## Next slices of #289
- World-reuse pool (capability 3) + the `pipeline()` dispatcher — both want "reset world state without rebuild".
- Wiring the engine's trajectories into a gradient step (SkyRL/GRPO) is #244.
