### PR TITLE
docs(trl): cyber example runs many episodes at once via TRL; fix its live SQLi

### DIFF
--- a/examples/trl_grpo_cyber.ipynb
+++ b/examples/trl_grpo_cyber.ipynb
@@ -4,7 +4,26 @@
    "cell_type": "markdown",
    "id": "80d85d85",
    "metadata": {},
-   "source": "# Train a model to exploit a live web service with TRL GRPO + LoRA\n\nOpenRange admits **content-addressed** agent-training worlds. This notebook trains\na small model on the *cyber* pack: every rollout boots a **real HTTP server** with\na planted vulnerability, and the policy must **exploit it over the wire** and\nexfiltrate a hidden flag — graded by the world itself, no static dataset of\n\"correct\" attacks.\n\nIt is the same torch-free TRL seam that also trains file-editing agents, with a cyber **action surface**:\nthe policy gets the `http_get` and `submit` tools you pass in. The adapter is\nunchanged — the generic `EpisodeEnv` reflects whatever tools you bring (these are\nOpenRange's reference `WEB_TOOLS`; bring your own to change the surface).\n\nRuns on a laptop (MPS or CUDA). The point is the **mechanics and a reward you can\nsee is real** — §3 maps the whole reward surface *before* any GPU work.\n\nFor the simplest file-editing surface (a one-line bug fix), see\n`trl_grpo_lora.ipynb`."
+   "source": [
+    "# Train a model to exploit a live web service with TRL GRPO + LoRA\n",
+    "\n",
+    "OpenRange admits **content-addressed** agent-training worlds. This notebook trains\n",
+    "a small model on the *cyber* pack: every rollout boots a **real HTTP server** with\n",
+    "a planted vulnerability, and the policy must **exploit it over the wire** and\n",
+    "exfiltrate a hidden flag — graded by the world itself, no static dataset of\n",
+    "\"correct\" attacks.\n",
+    "\n",
+    "It is the same torch-free TRL seam that also trains file-editing agents, with a cyber **action surface**:\n",
+    "the policy gets the `http_get` and `submit` tools you pass in. The adapter is\n",
+    "unchanged — the generic `EpisodeEnv` reflects whatever tools you bring (these are\n",
+    "OpenRange's reference `WEB_TOOLS`; bring your own to change the surface).\n",
+    "\n",
+    "Runs on a laptop (MPS or CUDA). The point is the **mechanics and a reward you can\n",
+    "see is real** — §3 maps the whole reward surface *before* any GPU work.\n",
+    "\n",
+    "For the simplest file-editing surface (a one-line bug fix), see\n",
+    "`trl_grpo_lora.ipynb`."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -28,9 +47,9 @@
     "## 2. Admit a cyber world\n",
     "\n",
     "`admit` freezes a procedural cyber world into a **content-addressed snapshot**. We\n",
-    "pin `seed=0`: a deterministic world whose pentest entrypoint is a **SQL injection**\n",
-    "at `GET /svc/db/records`. Each world yields two tasks (`webapp.build`,\n",
-    "`webapp.pentest`); we train on the offensive one."
+    "pin a **SQL-injection** world (`vuln_kinds`, `seed=0`): a deterministic target whose\n",
+    "pentest entrypoint is an injectable `GET` over a `db`-backed endpoint. Each world\n",
+    "yields two tasks (`webapp.build`, `webapp.pentest`); we train on the offensive one."
    ]
   },
   {
@@ -39,17 +58,17 @@
    "id": "873c9d13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T13:23:01.653123Z",
-     "iopub.status.busy": "2026-06-09T13:23:01.652996Z",
-     "iopub.status.idle": "2026-06-09T13:23:02.183538Z",
-     "shell.execute_reply": "2026-06-09T13:23:02.182886Z"
+     "iopub.execute_input": "2026-06-15T06:36:45.603592Z",
+     "iopub.status.busy": "2026-06-15T06:36:45.603423Z",
+     "iopub.status.idle": "2026-06-15T06:36:45.883754Z",
+     "shell.execute_reply": "2026-06-15T06:36:45.883389Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'sha256:36581a76edc521016450462359734fc2fa9e3d16826f4ca23588ad4e0023b0e6'"
+       "'sha256:0279d1d5a9df43477abdf88d277fd91e44db3f5dd8a01f66d82ee9148c8625f6'"
       ]
      },
      "execution_count": 1,
@@ -71,6 +90,11 @@
     "        \"runtime\": {\"tick\": {\"mode\": \"off\"}},\n",
     "        \"npc\": [],\n",
     "        \"seed\": 0,\n",
+    "        # Pin the shape so the world is reproducibly a SQL-injection-over-the-response\n",
+    "        # target (a `db` response-leak + the `sql_injection` oracle), independent of the\n",
+    "        # pack's default vuln mix.\n",
+    "        \"loot_shapes\": {\"db\": 1, \"file\": 0},\n",
+    "        \"vuln_kinds\": {\"sql_injection\": 1},\n",
     "    },\n",
     ")\n",
     "assert not isinstance(snapshot, AdmissionFailure), snapshot\n",
@@ -81,7 +105,18 @@
    "cell_type": "markdown",
    "id": "452b67a0",
    "metadata": {},
-   "source": "## 3. See the reward before you train\n\nThe reward is the world's held-out verdict over the **HTTP path**. The pentest\nfamily scores three subgoals — reach the endpoint, extract *something*, submit the\n*right* flag — so `episode_reward` yields a four-rung surface. Driving the env's\ntools by hand maps it: no model, no GPU, one fresh booted server per call.\n\nWe read the exploit's coordinates (endpoint, injection param, the ground-truth\nflag) from the world graph, then run a **real SQL injection** for the top rung."
+   "source": [
+    "## 3. See the reward before you train\n",
+    "\n",
+    "The reward is the world's held-out verdict over the **HTTP path**. The pentest\n",
+    "family scores three subgoals — reach the endpoint, extract *something*, submit the\n",
+    "*right* flag — so `episode_reward` yields a four-rung surface. Driving the env's\n",
+    "tools by hand maps it: no model, no GPU, one fresh booted server per call.\n",
+    "\n",
+    "We read the injection's coordinates (endpoint, parameter, table/column, quote\n",
+    "context) from the world graph, run a **real SQL injection** that leaks the hidden\n",
+    "column, and exfiltrate the flag from the response — the top rung."
+   ]
   },
   {
    "cell_type": "code",
@@ -89,10 +124,10 @@
    "id": "a812c6ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T13:23:02.185883Z",
-     "iopub.status.busy": "2026-06-09T13:23:02.185658Z",
-     "iopub.status.idle": "2026-06-09T13:23:02.567118Z",
-     "shell.execute_reply": "2026-06-09T13:23:02.566576Z"
+     "iopub.execute_input": "2026-06-15T06:36:45.885059Z",
+     "iopub.status.busy": "2026-06-15T06:36:45.884942Z",
+     "iopub.status.idle": "2026-06-15T06:36:46.091426Z",
+     "shell.execute_reply": "2026-06-15T06:36:46.091025Z"
     }
    },
    "outputs": [
@@ -102,13 +137,7 @@
      "text": [
       "no-op (no request)     reward=0.000  resolved=False\n",
       "reach endpoint         reward=0.333  resolved=False\n",
-      "reach + wrong flag     reward=0.667  resolved=False\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "reach + wrong flag     reward=0.667  resolved=False\n",
       "exploit + submit       reward=1.000  resolved=True\n"
      ]
     }
@@ -126,14 +155,19 @@
     "# Coordinates read from the world itself — no hardcoded secrets.\n",
     "task = next(t for t in snapshot.tasks if t.meta.get(\"family\") == \"webapp.pentest\")\n",
     "entry = snapshot.graph.nodes[task.entrypoints[0]].attrs[\"public_url\"]\n",
-    "truth = snapshot.graph.nodes[task.goal_nodes[0]].attrs[\"value_ref\"]\n",
-    "param = next(\n",
-    "    v.attrs[\"params\"][\"target_param\"]\n",
+    "vuln = next(\n",
+    "    v\n",
     "    for v in snapshot.graph.by_kind(\"vulnerability\")\n",
     "    if v.attrs.get(\"kind\") == \"sql_injection\"\n",
     ")\n",
-    "payload = \"' OR '1'='1\"  # WHERE key = '' OR '1'='1'  -> dumps every row\n",
-    "exploit_path = f\"{entry}?{urlencode({param: payload})}\"\n",
+    "params = vuln.attrs[\"params\"]\n",
+    "\n",
+    "# The hidden flag lives in a column the base query never selects, so a boolean\n",
+    "# dump can't reach it — a UNION pulls it directly. The prefix closes the\n",
+    "# injectable literal in *this* world's quote context (numeric / double / single).\n",
+    "union = f\"UNION SELECT key, {params['leak_column']} FROM {params['table']} -- \"\n",
+    "prefix = {\"numeric\": \"0 \", \"double\": '\" '}.get(params.get(\"context\"), \"' \")\n",
+    "exploit_path = f\"{entry}?{urlencode({params['target_param']: prefix + union})}\"\n",
     "\n",
     "\n",
     "def exfiltrate(response):\n",
@@ -204,18 +238,31 @@
    "cell_type": "markdown",
    "id": "7ee84019",
    "metadata": {},
-   "source": "## 4. Wrap the world as a TRL environment\n\nThe torch-free adapter exposes the three seams TRL needs, with the web action\nsurface — the tools you bring (here OpenRange's reference `WEB_TOOLS`):\n\n- **`build_grpo_dataset`** — the prompt rows (we keep the pentest task), tagged\n  with `snapshot_id`. The policy sees the tools via TRL's tool schemas, so a row\n  is just the task instruction.\n- **`make_environment_factory(..., tools=WEB_TOOLS)`** — one `EpisodeEnv` per\n  rollout: a fresh booted server, with the tools you pass (`http_get`, `submit`)\n  bound to it.\n- **`make_reward_func`** — grades the final interaction with the held-out verdict."
+   "source": [
+    "## 4. Wrap the world as a TRL environment\n",
+    "\n",
+    "The torch-free adapter exposes the three seams TRL needs, with the web action\n",
+    "surface — the tools you bring (here OpenRange's reference `WEB_TOOLS`):\n",
+    "\n",
+    "- **`build_grpo_dataset`** — the prompt rows (we keep the pentest task), tagged\n",
+    "  with `snapshot_id`. The policy sees the tools via TRL's tool schemas, so a row\n",
+    "  is just the task instruction.\n",
+    "- **`make_environment_factory(..., tools=WEB_TOOLS)`** — one `EpisodeEnv` per\n",
+    "  rollout: a fresh booted server, with the tools you pass (`http_get`, `submit`)\n",
+    "  bound to it.\n",
+    "- **`make_reward_func`** — grades the final interaction with the held-out verdict."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "5f042eb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T13:23:02.569112Z",
-     "iopub.status.busy": "2026-06-09T13:23:02.568987Z",
-     "iopub.status.idle": "2026-06-09T13:23:03.355727Z",
-     "shell.execute_reply": "2026-06-09T13:23:03.355051Z"
+     "iopub.execute_input": "2026-06-15T06:36:46.092700Z",
+     "iopub.status.busy": "2026-06-15T06:36:46.092629Z",
+     "iopub.status.idle": "2026-06-15T06:36:46.487173Z",
+     "shell.execute_reply": "2026-06-15T06:36:46.486827Z"
     }
    },
    "outputs": [],
@@ -255,10 +302,10 @@
    "id": "43d60920",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T13:23:03.357373Z",
-     "iopub.status.busy": "2026-06-09T13:23:03.357246Z",
-     "iopub.status.idle": "2026-06-09T13:23:06.376883Z",
-     "shell.execute_reply": "2026-06-09T13:23:06.376219Z"
+     "iopub.execute_input": "2026-06-15T06:36:46.488151Z",
+     "iopub.status.busy": "2026-06-15T06:36:46.488087Z",
+     "iopub.status.idle": "2026-06-15T06:36:48.501513Z",
+     "shell.execute_reply": "2026-06-15T06:36:48.501060Z"
     }
    },
    "outputs": [
@@ -275,7 +322,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Loading weights: 100%|██████████| 290/290 [00:00<00:00, 6304.61it/s]"
+      "Loading weights: 100%|██████████| 290/290 [00:00<00:00, 11601.84it/s]"
      ]
     },
     {
@@ -310,10 +357,17 @@
    "source": [
     "## 6. Configure GRPO\n",
     "\n",
-    "Each step samples `num_generations` completions of the **same** prompt, grades\n",
-    "them, and turns their reward *spread* into advantages. `beta=0` drops the reference\n",
-    "model; `use_vllm=False` generates through transformers;\n",
-    "`max_tool_calling_iterations` bounds the recon→exploit→submit turns."
+    "Each step samples `num_generations` completions of the **same** prompt — and\n",
+    "`make_environment_factory` boots **one fresh server per completion**, so those N\n",
+    "rollouts are N live worlds attacked **at once** and graded together. That batch *is*\n",
+    "running many training episodes at the same time. `beta=0` drops the reference model;\n",
+    "`use_vllm=False` generates through transformers; `max_tool_calling_iterations` bounds\n",
+    "the recon→exploit→submit turns.\n",
+    "\n",
+    "For production scale — hundreds of episodes in flight against a separate vLLM server —\n",
+    "TRL's experimental `AsyncGRPOTrainer` takes the **same** `make_environment_factory`.\n",
+    "OpenRange owns the world + the grade; TRL owns the rollout + the gradient, here and at\n",
+    "scale — no custom rollout engine needed on our side."
    ]
   },
   {
@@ -322,10 +376,10 @@
    "id": "977bf84b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T13:23:06.379619Z",
-     "iopub.status.busy": "2026-06-09T13:23:06.378845Z",
-     "iopub.status.idle": "2026-06-09T13:23:06.540478Z",
-     "shell.execute_reply": "2026-06-09T13:23:06.539695Z"
+     "iopub.execute_input": "2026-06-15T06:36:48.503187Z",
+     "iopub.status.busy": "2026-06-15T06:36:48.502897Z",
+     "iopub.status.idle": "2026-06-15T06:36:48.576645Z",
+     "shell.execute_reply": "2026-06-15T06:36:48.576266Z"
     }
    },
    "outputs": [],
@@ -360,7 +414,19 @@
    "cell_type": "markdown",
    "id": "d78733aa",
    "metadata": {},
-   "source": "## 7. Train\n\n`GRPOTrainer` discovers the env's tool methods by reflection, runs the multi-turn\nrollouts (each against its own booted server), reads `reward_func`, and steps the\nLoRA adapters.\n\nA 0.5B policy will usually **floor low** here — popping a SQL injection is much\nharder than a one-line fix, so most rollouts only `reach` the endpoint (0.333). That\nis the honest starting point, not a failure: §3 proved 1.0 is reachable, and the\ngradient appears once a rollout diverges (a stronger model, higher temperature, more\nsamples)."
+   "source": [
+    "## 7. Train\n",
+    "\n",
+    "`GRPOTrainer` discovers the env's tool methods by reflection, runs the multi-turn\n",
+    "rollouts (each against its own booted server), reads `reward_func`, and steps the\n",
+    "LoRA adapters.\n",
+    "\n",
+    "A 0.5B policy will usually **floor low** here — popping a SQL injection is much\n",
+    "harder than a one-line fix, so most rollouts only `reach` the endpoint (0.333). That\n",
+    "is the honest starting point, not a failure: §3 proved 1.0 is reachable, and the\n",
+    "gradient appears once a rollout diverges (a stronger model, higher temperature, more\n",
+    "samples)."
+   ]
   },
   {
    "cell_type": "code",
@@ -368,10 +434,10 @@
    "id": "b9e469dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T13:23:06.542419Z",
-     "iopub.status.busy": "2026-06-09T13:23:06.542291Z",
-     "iopub.status.idle": "2026-06-09T13:23:48.350839Z",
-     "shell.execute_reply": "2026-06-09T13:23:48.350060Z"
+     "iopub.execute_input": "2026-06-15T06:36:48.577761Z",
+     "iopub.status.busy": "2026-06-15T06:36:48.577698Z",
+     "iopub.status.idle": "2026-06-15T06:37:08.258601Z",
+     "shell.execute_reply": "2026-06-15T06:37:08.257804Z"
     }
    },
    "outputs": [
@@ -379,14 +445,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0.03239', 'grad_norm': '882', 'learning_rate': '0.0001', 'num_tokens': '2432', 'completions/mean_length': '147', 'completions/min_length': '49', 'completions/max_length': '256', 'completions/clipped_ratio': '0.25', 'completions/mean_terminated_length': '110.7', 'completions/min_terminated_length': '49', 'completions/max_terminated_length': '198', 'tools/call_frequency': '0.75', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.1667', 'rewards/reward_func/std': '0.1925', 'reward': '0.1667', 'reward_std': '0.1925', 'frac_reward_zero_std': '0', 'entropy': '3.184', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '40.16', 'epoch': '0.25'}\n",
-      "{'train_runtime': '40.76', 'train_samples_per_second': '0.098', 'train_steps_per_second': '0.025', 'train_loss': '0.03239', 'epoch': '0.25'}\n"
+      "{'loss': '0.4862', 'grad_norm': '1.919e+06', 'learning_rate': '0.0001', 'num_tokens': '2019', 'completions/mean_length': '129.8', 'completions/min_length': '83', 'completions/max_length': '256', 'completions/clipped_ratio': '0.25', 'completions/mean_terminated_length': '87.67', 'completions/min_terminated_length': '83', 'completions/max_terminated_length': '95', 'tools/call_frequency': '0.75', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.25', 'rewards/reward_func/std': '0.1667', 'reward': '0.25', 'reward_std': '0.1667', 'frac_reward_zero_std': '0', 'entropy': '3.299', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '18.72', 'epoch': '0.25'}\n",
+      "{'train_runtime': '19.03', 'train_samples_per_second': '0.21', 'train_steps_per_second': '0.053', 'train_loss': '0.4862', 'epoch': '0.25'}\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "TrainOutput(global_step=1, training_loss=0.032385483384132385, metrics={'train_runtime': 40.7609, 'train_samples_per_second': 0.098, 'train_steps_per_second': 0.025, 'train_loss': 0.032385483384132385, 'epoch': 0.25})"
+       "TrainOutput(global_step=1, training_loss=0.48622068762779236, metrics={'train_runtime': 19.0294, 'train_samples_per_second': 0.21, 'train_steps_per_second': 0.053, 'train_loss': 0.48622068762779236, 'epoch': 0.25})"
       ]
      },
      "execution_count": 6,
@@ -428,10 +494,10 @@
    "id": "a374702f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-09T13:23:48.352421Z",
-     "iopub.status.busy": "2026-06-09T13:23:48.352312Z",
-     "iopub.status.idle": "2026-06-09T13:23:48.356046Z",
-     "shell.execute_reply": "2026-06-09T13:23:48.355536Z"
+     "iopub.execute_input": "2026-06-15T06:37:08.261882Z",
+     "iopub.status.busy": "2026-06-15T06:37:08.261766Z",
+     "iopub.status.idle": "2026-06-15T06:37:08.265294Z",
+     "shell.execute_reply": "2026-06-15T06:37:08.264949Z"
     }
    },
    "outputs": [
@@ -439,11 +505,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "rewards : [0.0, 0.333, 0.333, 0.0]\n",
+      "rewards : [0.0, 0.333, 0.333, 0.333]\n",
       "spread  : 0.333   (>0 => a real GRPO gradient)\n",
       "resolved: 0/4\n",
-      "world   : sha256:36581a76edc521016450462359734fc2fa9e3d16826f4ca23588ad4e0023b0e6\n",
-      "turns   : 0   success: False\n"
+      "world   : sha256:0279d1d5a9df43477abdf88d277fd91e44db3f5dd8a01f66d82ee9148c8625f6\n",
+      "turns   : 1   success: False\n"
      ]
     }
    ],
@@ -459,7 +525,8 @@
     "print(f\"spread  : {spread:.3f}   (>0 => a real GRPO gradient)\")\n",
     "print(f\"resolved: {resolved}/{len(envs)}\")\n",
     "\n",
-    "trajectory = env_trajectory(envs[0])\n",
+    "# Export the best rollout's trajectory — the seam downstream consumers read.\n",
+    "trajectory = env_trajectory(max(envs, key=lambda e: e.reward))\n",
     "print(f\"world   : {trajectory.snapshot_id}\")\n",
     "print(f\"turns   : {len(trajectory.steps)}   success: {trajectory.success}\")\n",
     "\n",
@@ -474,7 +541,7 @@
    "source": [
     "## Where this goes\n",
     "\n",
-    "You saw the reward is real (§3) and the loop runs end-to-end (§7–8). Two seams\n",
+    "You saw the reward is real (§3) and the loop runs end-to-end (§7–8). Three seams\n",
     "carry it further:\n",
     "\n",
     "- **Curriculum, in-place.** Unlike the SWE pack, the cyber pentest family ships\n",
@@ -484,6 +551,11 @@
     "  The gym tracks the policy, live.\n",
     "- **Provenance.** Every trajectory is tagged with the `snapshot_id`, so an evolved\n",
     "  curriculum stays fully attributable.\n",
+    "- **Scale.** The batch above runs `num_generations` episodes at once on a laptop;\n",
+    "  TRL's `AsyncGRPOTrainer` pipelines hundreds against a vLLM server with the same\n",
+    "  `make_environment_factory`. The one OpenRange-side lever is world-boot cost — both\n",
+    "  trainers reset worlds serially, so a pooled / fast world realization keeps a big\n",
+    "  batch from stalling on boots (a gym-side follow-up).\n",
     "\n",
     "The deterministic, torch-free seam and its reward-dynamics tests live in\n",
     "the `openrange-trl` package + `tests/test_trl_cyber.py`, and the gated live\n",


### PR DESCRIPTION
## What

Updates the cyber GRPO example (`examples/trl_grpo_cyber.ipynb`) to reflect what we learned researching #289: **TRL already runs many training episodes at once** — we don't build that ourselves.

- **Concurrency framing (the #289 lesson).** §6 now spells it out: one GRPO step samples `num_generations` completions, and `make_environment_factory` boots **one live cyber world per completion**, so the batch attacks N worlds at once and grades them together. The "Where this goes" section notes the *same* adapter scales out to TRL's experimental `AsyncGRPOTrainer` (a slot-pool against a vLLM server) — no custom rollout engine on our side. OpenRange owns the world + the grade; TRL owns the rollout + the gradient.
- **Fixes the §3 reward-ladder demo.** The pack's `seed=0` world evolved to a **numeric-context** SQL injection, so the old boolean payload `' OR '1'='1'` threw a 500 and the "exploit" rung tied the "reach" rung at `0.333`. The exploit is now a **context-aware UNION** that reads the quote context, table, and leak column from the world graph and exfiltrates the flag — the top rung reaches `1.0` again. This mirrors the proven path already asserted in `tests/test_trl_cyber.py`.

## Tested

- **Re-executed live on this Mac**, end to end, with the `train` extra (torch 2.12 / trl 1.5 / transformers 5.10). The committed outputs are from that run: the §3 ladder is `0.0 → 0.333 → 0.667 → 1.0`, and §7 runs a real GRPO step with a non-zero reward spread.
- Outputs trimmed to match the other example notebooks (only the `Loading weights` progress bars; environment warnings stripped).
- Local CI mirror is green: `ruff check .`, boundary check, `mypy`, and the full `pytest tests` suite (772 passed, 8 skipped, 88% coverage). The reward surface the notebook depends on is pinned by `tests/test_trl_cyber.py` (14 passed).

## Issues

The async-rollout engine that began as slice 1 of #289 was, on inspection, ~85% a re-implementation of SkyRL's loop and captured no token log-probs (so it could never reach a gradient). It's been dropped; the thin `openrange-trl` adapter already satisfies TRL's `environment_factory` / `reset()` / tools-as-methods contract.

- **Closes #289** — capabilities 1 (many at once) and 2 (separate model server, via TRL's vLLM server mode) are delivered by TRL natively and now shown in the example.
- Capability 3 (reuse expensive worlds) was the one genuine gap, and it lives on the **gym** side, not the trainer side — reframed and tracked in #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
