### PR TITLE
feat(trl): make the cyber tutorial teach curriculum training — the world evolves

### DIFF
--- a/examples/trl_grpo_cyber.ipynb
+++ b/examples/trl_grpo_cyber.ipynb
@@ -18,8 +18,11 @@
     "unchanged — the generic `EpisodeEnv` reflects whatever tools you bring (these are\n",
     "OpenRange's reference `WEB_TOOLS`; bring your own to change the surface).\n",
     "\n",
-    "Runs on a laptop (MPS or CUDA). The point is the **mechanics and a reward you can\n",
-    "see is real** — §3 maps the whole reward surface *before* any GPU work.\n",
+    "Runs on a laptop (MPS or CUDA). The point is that **training is a loop that evolves\n",
+    "the world**: §3 maps the reward surface, then §7 runs the loop — and you watch the\n",
+    "gym **harden the world** as it gets solved (driven by a reference policy on a\n",
+    "laptop, by the model's own climb on a GPU). The opposite of grinding one fixed\n",
+    "benchmark.\n",
     "\n",
     "For the simplest file-editing surface (a one-line bug fix), see\n",
     "`trl_grpo_lora.ipynb`."
@@ -58,10 +61,10 @@
    "id": "873c9d13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T06:36:45.603592Z",
-     "iopub.status.busy": "2026-06-15T06:36:45.603423Z",
-     "iopub.status.idle": "2026-06-15T06:36:45.883754Z",
-     "shell.execute_reply": "2026-06-15T06:36:45.883389Z"
+     "iopub.execute_input": "2026-06-15T19:33:44.308723Z",
+     "iopub.status.busy": "2026-06-15T19:33:44.308586Z",
+     "iopub.status.idle": "2026-06-15T19:33:44.605965Z",
+     "shell.execute_reply": "2026-06-15T19:33:44.605507Z"
     }
    },
    "outputs": [
@@ -124,10 +127,10 @@
    "id": "a812c6ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T06:36:45.885059Z",
-     "iopub.status.busy": "2026-06-15T06:36:45.884942Z",
-     "iopub.status.idle": "2026-06-15T06:36:46.091426Z",
-     "shell.execute_reply": "2026-06-15T06:36:46.091025Z"
+     "iopub.execute_input": "2026-06-15T19:33:44.607155Z",
+     "iopub.status.busy": "2026-06-15T19:33:44.607048Z",
+     "iopub.status.idle": "2026-06-15T19:33:44.844546Z",
+     "shell.execute_reply": "2026-06-15T19:33:44.844169Z"
     }
    },
    "outputs": [
@@ -152,26 +155,28 @@
     "from examples.tools import WEB_TOOLS  # the reference http_get + submit tools\n",
     "from openrange.core.episode import EpisodeService\n",
     "\n",
-    "# Coordinates read from the world itself — no hardcoded secrets.\n",
-    "task = next(t for t in snapshot.tasks if t.meta.get(\"family\") == \"webapp.pentest\")\n",
-    "entry = snapshot.graph.nodes[task.entrypoints[0]].attrs[\"public_url\"]\n",
-    "vuln = next(\n",
-    "    v\n",
-    "    for v in snapshot.graph.by_kind(\"vulnerability\")\n",
-    "    if v.attrs.get(\"kind\") == \"sql_injection\"\n",
-    ")\n",
-    "params = vuln.attrs[\"params\"]\n",
     "\n",
-    "# The hidden flag lives in a column the base query never selects, so a boolean\n",
-    "# dump can't reach it — a UNION pulls it directly. The prefix closes the\n",
-    "# injectable literal in *this* world's quote context (numeric / double / single).\n",
-    "union = f\"UNION SELECT key, {params['leak_column']} FROM {params['table']} -- \"\n",
-    "prefix = {\"numeric\": \"0 \", \"double\": '\" '}.get(params.get(\"context\"), \"' \")\n",
-    "exploit_path = f\"{entry}?{urlencode({params['target_param']: prefix + union})}\"\n",
+    "def pentest_task(snap):\n",
+    "    return next(t for t in snap.tasks if t.meta.get(\"family\") == \"webapp.pentest\")\n",
+    "\n",
+    "\n",
+    "def exploit_path(snap):\n",
+    "    # Read the injection's coordinates from *this* world's graph and match its\n",
+    "    # quote context — a constant payload breaks as the world evolves. The hidden\n",
+    "    # flag sits in a column the base query never selects, so a UNION pulls it.\n",
+    "    task = pentest_task(snap)\n",
+    "    entry = snap.graph.nodes[task.entrypoints[0]].attrs[\"public_url\"]\n",
+    "    p = next(\n",
+    "        v.attrs[\"params\"]\n",
+    "        for v in snap.graph.by_kind(\"vulnerability\")\n",
+    "        if v.attrs.get(\"kind\") == \"sql_injection\"\n",
+    "    )\n",
+    "    union = f\"UNION SELECT key, {p['leak_column']} FROM {p['table']} -- \"\n",
+    "    prefix = {\"numeric\": \"0 \", \"double\": '\" '}.get(p.get(\"context\"), \"' \")\n",
+    "    return f\"{entry}?{urlencode({p['target_param']: prefix + union})}\"\n",
     "\n",
     "\n",
     "def exfiltrate(response):\n",
-    "    # A real attacker's step: pull the leaked secret out of the dumped rows.\n",
     "    body = response.split(chr(10), 1)[-1]\n",
     "    uuid = r\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"\n",
     "    for row in json.loads(body).get(\"rows\", []):\n",
@@ -181,18 +186,23 @@
     "    return \"\"\n",
     "\n",
     "\n",
-    "def grade(name, actions):\n",
+    "def solve(env, snap):\n",
+    "    env.submit(json.dumps({\"flag\": exfiltrate(env.http_get(exploit_path(snap)))}))\n",
+    "\n",
+    "\n",
+    "def grade(name, act):\n",
     "    svc = EpisodeService(pack, f\"or-runs/cyber/{name}\")\n",
-    "    # The policy's tools are the caller's — here the reference WEB_TOOLS; the env\n",
-    "    # reflects them as http_get / submit and binds them to the live target.\n",
     "    env = EpisodeEnv(\n",
     "        service=svc, snapshots={snapshot.snapshot_id: snapshot}, tools=WEB_TOOLS\n",
     "    )\n",
-    "    env.reset(snapshot_id=snapshot.snapshot_id, task_id=task.id)\n",
-    "    actions(env)\n",
+    "    env.reset(snapshot_id=snapshot.snapshot_id, task_id=pentest_task(snapshot).id)\n",
+    "    act(env)\n",
     "    env._finalize()\n",
     "    print(f\"{name:<22} reward={env.reward:.3f}  resolved={env.report.passed}\")\n",
     "    svc.close()\n",
+    "\n",
+    "\n",
+    "entry = snapshot.graph.nodes[pentest_task(snapshot).entrypoints[0]].attrs[\"public_url\"]\n",
     "\n",
     "\n",
     "def reach(e):\n",
@@ -204,15 +214,10 @@
     "    e.submit(json.dumps({\"flag\": \"guess\"}))\n",
     "\n",
     "\n",
-    "def exploit(e):\n",
-    "    dump = e.http_get(exploit_path)\n",
-    "    e.submit(json.dumps({\"flag\": exfiltrate(dump)}))\n",
-    "\n",
-    "\n",
     "grade(\"no-op (no request)\", lambda e: None)\n",
     "grade(\"reach endpoint\", reach)\n",
     "grade(\"reach + wrong flag\", wrong)\n",
-    "grade(\"exploit + submit\", exploit)"
+    "grade(\"exploit + submit\", lambda e: solve(e, snapshot))"
    ]
   },
   {
@@ -259,10 +264,10 @@
    "id": "5f042eb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T06:36:46.092700Z",
-     "iopub.status.busy": "2026-06-15T06:36:46.092629Z",
-     "iopub.status.idle": "2026-06-15T06:36:46.487173Z",
-     "shell.execute_reply": "2026-06-15T06:36:46.486827Z"
+     "iopub.execute_input": "2026-06-15T19:33:44.845781Z",
+     "iopub.status.busy": "2026-06-15T19:33:44.845708Z",
+     "iopub.status.idle": "2026-06-15T19:33:45.910116Z",
+     "shell.execute_reply": "2026-06-15T19:33:45.909749Z"
     }
    },
    "outputs": [],
@@ -302,10 +307,10 @@
    "id": "43d60920",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T06:36:46.488151Z",
-     "iopub.status.busy": "2026-06-15T06:36:46.488087Z",
-     "iopub.status.idle": "2026-06-15T06:36:48.501513Z",
-     "shell.execute_reply": "2026-06-15T06:36:48.501060Z"
+     "iopub.execute_input": "2026-06-15T19:33:45.911299Z",
+     "iopub.status.busy": "2026-06-15T19:33:45.911233Z",
+     "iopub.status.idle": "2026-06-15T19:33:48.532785Z",
+     "shell.execute_reply": "2026-06-15T19:33:48.532342Z"
     }
    },
    "outputs": [
@@ -322,7 +327,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Loading weights: 100%|██████████| 290/290 [00:00<00:00, 11601.84it/s]"
+      "Loading weights: 100%|██████████| 290/290 [00:00<00:00, 10377.51it/s]"
      ]
     },
     {
@@ -359,15 +364,10 @@
     "\n",
     "Each step samples `num_generations` completions of the **same** prompt — and\n",
     "`make_environment_factory` boots **one fresh server per completion**, so those N\n",
-    "rollouts are N live worlds attacked **at once** and graded together. That batch *is*\n",
-    "running many training episodes at the same time. `beta=0` drops the reference model;\n",
-    "`use_vllm=False` generates through transformers; `max_tool_calling_iterations` bounds\n",
-    "the recon→exploit→submit turns.\n",
-    "\n",
-    "For production scale — hundreds of episodes in flight against a separate vLLM server —\n",
-    "TRL's experimental `AsyncGRPOTrainer` takes the **same** `make_environment_factory`.\n",
-    "OpenRange owns the world + the grade; TRL owns the rollout + the gradient, here and at\n",
-    "scale — no custom rollout engine needed on our side."
+    "rollouts are N live worlds attacked **at once** and graded together. `beta=0` drops\n",
+    "the reference model; `use_vllm=False` generates through transformers;\n",
+    "`max_tool_calling_iterations` bounds the recon→exploit→submit turns. `max_steps=1`\n",
+    "makes one call here **one training round** — §7 wraps rounds into the curriculum."
    ]
   },
   {
@@ -376,10 +376,10 @@
    "id": "977bf84b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T06:36:48.503187Z",
-     "iopub.status.busy": "2026-06-15T06:36:48.502897Z",
-     "iopub.status.idle": "2026-06-15T06:36:48.576645Z",
-     "shell.execute_reply": "2026-06-15T06:36:48.576266Z"
+     "iopub.execute_input": "2026-06-15T19:33:48.534502Z",
+     "iopub.status.busy": "2026-06-15T19:33:48.534188Z",
+     "iopub.status.idle": "2026-06-15T19:33:48.617126Z",
+     "shell.execute_reply": "2026-06-15T19:33:48.616635Z"
     }
    },
    "outputs": [],
@@ -415,17 +415,15 @@
    "id": "d78733aa",
    "metadata": {},
    "source": [
-    "## 7. Train\n",
+    "## 7. Train — and the world trains back\n",
     "\n",
-    "`GRPOTrainer` discovers the env's tool methods by reflection, runs the multi-turn\n",
-    "rollouts (each against its own booted server), reads `reward_func`, and steps the\n",
-    "LoRA adapters.\n",
-    "\n",
-    "A 0.5B policy will usually **floor low** here — popping a SQL injection is much\n",
-    "harder than a one-line fix, so most rollouts only `reach` the endpoint (0.333). That\n",
-    "is the honest starting point, not a failure: §3 proved 1.0 is reachable, and the\n",
-    "gradient appears once a rollout diverges (a stronger model, higher temperature, more\n",
-    "samples)."
+    "Training here is a **loop**, not gradient steps on a fixed task. Each round runs\n",
+    "GRPO on the current world; then `auto_evolve` reads the round's reward spread and\n",
+    "moves the world toward the policy's frontier — **harden** when the group is solving,\n",
+    "**soften** when it's stuck — re-admits it (so the new world is still provably\n",
+    "solvable), and the next round trains on *that*. One round is one\n",
+    "`GRPOTrainer.train()`. The gym tracks the agent — this is what \"not a static\n",
+    "benchmark\" means in practice."
    ]
   },
   {
@@ -434,10 +432,10 @@
    "id": "b9e469dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T06:36:48.577761Z",
-     "iopub.status.busy": "2026-06-15T06:36:48.577698Z",
-     "iopub.status.idle": "2026-06-15T06:37:08.258601Z",
-     "shell.execute_reply": "2026-06-15T06:37:08.257804Z"
+     "iopub.execute_input": "2026-06-15T19:33:48.618562Z",
+     "iopub.status.busy": "2026-06-15T19:33:48.618482Z",
+     "iopub.status.idle": "2026-06-15T19:34:10.255197Z",
+     "shell.execute_reply": "2026-06-15T19:34:10.254612Z"
     }
    },
    "outputs": [
@@ -445,34 +443,154 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0.4862', 'grad_norm': '1.919e+06', 'learning_rate': '0.0001', 'num_tokens': '2019', 'completions/mean_length': '129.8', 'completions/min_length': '83', 'completions/max_length': '256', 'completions/clipped_ratio': '0.25', 'completions/mean_terminated_length': '87.67', 'completions/min_terminated_length': '83', 'completions/max_terminated_length': '95', 'tools/call_frequency': '0.75', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.25', 'rewards/reward_func/std': '0.1667', 'reward': '0.25', 'reward_std': '0.1667', 'frac_reward_zero_std': '0', 'entropy': '3.299', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '18.72', 'epoch': '0.25'}\n",
-      "{'train_runtime': '19.03', 'train_samples_per_second': '0.21', 'train_steps_per_second': '0.053', 'train_loss': '0.4862', 'epoch': '0.25'}\n"
+      "{'loss': '0.5017', 'grad_norm': '2.517e+05', 'learning_rate': '0.0001', 'num_tokens': '2011', 'completions/mean_length': '127.8', 'completions/min_length': '74', 'completions/max_length': '256', 'completions/clipped_ratio': '0.25', 'completions/mean_terminated_length': '85', 'completions/min_terminated_length': '74', 'completions/max_terminated_length': '98', 'tools/call_frequency': '0.75', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.25', 'rewards/reward_func/std': '0.1667', 'reward': '0.25', 'reward_std': '0.1667', 'frac_reward_zero_std': '0', 'entropy': '3.35', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '20.19', 'epoch': '0.25'}\n",
+      "{'train_runtime': '20.5', 'train_samples_per_second': '0.195', 'train_steps_per_second': '0.049', 'train_loss': '0.5017', 'epoch': '0.25'}\n",
+      "one real GRPO round → rewards [0.0, 0.333, 0.333, 0.333]\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "TrainOutput(global_step=1, training_loss=0.48622068762779236, metrics={'train_runtime': 19.0294, 'train_samples_per_second': 0.21, 'train_steps_per_second': 0.053, 'train_loss': 0.48622068762779236, 'epoch': 0.25})"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
+    "from openrange_trl import reward_variance_policy\n",
     "from trl import GRPOTrainer\n",
     "\n",
-    "trainer = GRPOTrainer(\n",
-    "    model=model,\n",
-    "    reward_funcs=[reward_func],\n",
-    "    args=config,\n",
-    "    train_dataset=dataset,\n",
-    "    processing_class=tokenizer,\n",
-    "    environment_factory=environment_factory,\n",
-    "    peft_config=lora,\n",
-    ")\n",
-    "trainer.train()"
+    "from openrange.core.curriculum import auto_evolve\n",
+    "from openrange.training import episode_reward\n",
+    "\n",
+    "\n",
+    "def grpo_round(snap):\n",
+    "    rows = [\n",
+    "        r\n",
+    "        for r in build_grpo_dataset(snap, repeat=num_generations)\n",
+    "        if \"pentest\" in r[\"task_id\"]\n",
+    "    ]\n",
+    "    factory = make_environment_factory(\n",
+    "        pack, [snap], f\"or-runs/cyber/{snap.snapshot_id[-12:]}\", tools=WEB_TOOLS\n",
+    "    )\n",
+    "    trainer = GRPOTrainer(\n",
+    "        model=model,\n",
+    "        reward_funcs=[reward_func],\n",
+    "        args=config,\n",
+    "        train_dataset=Dataset.from_list(rows),\n",
+    "        processing_class=tokenizer,\n",
+    "        environment_factory=factory,\n",
+    "        peft_config=lora,\n",
+    "    )\n",
+    "    trainer.train()\n",
+    "    return [e.report for e in (trainer.environments or ()) if e.report is not None]\n",
+    "\n",
+    "\n",
+    "reports = grpo_round(snapshot)\n",
+    "rewards = [round(episode_reward(r).scalar, 3) for r in reports]\n",
+    "print(\"one real GRPO round → rewards\", rewards)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18c21237",
+   "metadata": {},
+   "source": [
+    "On a laptop the 0.5B mostly **reaches the endpoint but never lands the flag**, so the\n",
+    "reward spread stays alive and `auto_evolve` *holds* the world (mastery needs a bigger\n",
+    "model + GPU, where the policy's climb collapses the spread and drives the curriculum).\n",
+    "To watch the loop **move** now, drive each round with the reference `solve` from §3 —\n",
+    "a stand-in for a trained policy. Swap `grpo_round` back in on a GPU; the loop below is\n",
+    "identical."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9eea1ccb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-15T19:34:10.257835Z",
+     "iopub.status.busy": "2026-06-15T19:34:10.257749Z",
+     "iopub.status.idle": "2026-06-15T19:34:12.888229Z",
+     "shell.execute_reply": "2026-06-15T19:34:12.887849Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "round 1: e9148c8625f6  rewards=[1.0, 1.0, 1.0, 1.0]  →  build level 2 on ep_orders-api_0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "round 2: c25fabbbdc2e  rewards=[1.0, 1.0, 1.0, 1.0]  →  build level 3 on ep_orders-api_0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "round 3: abc8470d00d3  rewards=[1.0, 1.0, 1.0, 1.0]  →  add broken_authz on ep_orders-db_0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "round 4: 41114faeae7a  rewards=[1.0, 1.0, 1.0, 1.0]  →  add command_injection on ep_orders-db_0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "round 5: 9eb0ac5a4341  rewards=[1.0, 1.0, 1.0, 1.0]  →  add config_disclosure on ep_orders-db_0\n"
+     ]
+    }
+   ],
+   "source": [
+    "def scripted_round(snap):\n",
+    "    # A reference policy that always solves — a stand-in for a trained model, so the\n",
+    "    # curriculum visibly climbs without a GPU.\n",
+    "    factory = make_environment_factory(\n",
+    "        pack, [snap], f\"or-runs/cyber/evolve-{snap.snapshot_id[-12:]}\", tools=WEB_TOOLS\n",
+    "    )\n",
+    "    reports = []\n",
+    "    for _ in range(num_generations):\n",
+    "        env = factory()\n",
+    "        env.reset(snapshot_id=snap.snapshot_id, task_id=pentest_task(snap).id)\n",
+    "        solve(env, snap)\n",
+    "        env._finalize()\n",
+    "        reports.append(env.report)\n",
+    "        env.service.close()\n",
+    "    return reports\n",
+    "\n",
+    "\n",
+    "def evolve_meta(snap):\n",
+    "    # The patch path nests _evolve under the re-admitted manifest; a builder-grow\n",
+    "    # writes it at the top level. Read whichever is present.\n",
+    "    return snap.lineage.get(\"_evolve\") or snap.lineage.get(\"manifest\", {}).get(\n",
+    "        \"_evolve\", {}\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def run_curriculum(snap, *, rounds, run_round):\n",
+    "    chain = [snap]\n",
+    "    for r in range(1, rounds + 1):\n",
+    "        reports = run_round(snap)\n",
+    "        rewards = [round(episode_reward(x).scalar, 3) for x in reports]\n",
+    "        evolved = auto_evolve(snap, *reports, pack=pack, policy=reward_variance_policy)\n",
+    "        meta = {} if evolved is None else evolve_meta(evolved)\n",
+    "        move = (\n",
+    "            \"converged\" if evolved is None else meta.get(\"note\", meta.get(\"kind\", \"\"))\n",
+    "        )\n",
+    "        print(f\"round {r}: {snap.snapshot_id[-12:]}  rewards={rewards}  →  {move}\")\n",
+    "        if evolved is None:\n",
+    "            break\n",
+    "        snap = evolved\n",
+    "        chain.append(snap)\n",
+    "    return chain\n",
+    "\n",
+    "\n",
+    "chain = run_curriculum(snapshot, rounds=5, run_round=scripted_round)"
    ]
   },
   {
@@ -480,24 +598,24 @@
    "id": "077d9b0e",
    "metadata": {},
    "source": [
-    "## 8. Inspect the learning signal\n",
+    "## 8. The curriculum is a lineage\n",
     "\n",
-    "The envs `GRPOTrainer` built hold the last batch's graded episodes. We read each\n",
-    "rollout's reward and whether it *resolved* the world, then export a\n",
-    "`snapshot_id`-tagged trajectory — the seam any downstream consumer (replay,\n",
-    "fine-tuning, analysis) reads."
+    "Every round's world is a fresh, **admission-checked** child snapshot — `auto_evolve`\n",
+    "mutates the graph, re-admits (so the harder world is still provably solvable), and\n",
+    "tags the child with its parent. Training doesn't grind one fixed task; it produces a\n",
+    "**chain of worlds**, each content-addressed and fully attributable."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "a374702f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T06:37:08.261882Z",
-     "iopub.status.busy": "2026-06-15T06:37:08.261766Z",
-     "iopub.status.idle": "2026-06-15T06:37:08.265294Z",
-     "shell.execute_reply": "2026-06-15T06:37:08.264949Z"
+     "iopub.execute_input": "2026-06-15T19:34:12.889365Z",
+     "iopub.status.busy": "2026-06-15T19:34:12.889289Z",
+     "iopub.status.idle": "2026-06-15T19:34:12.891528Z",
+     "shell.execute_reply": "2026-06-15T19:34:12.891174Z"
     }
    },
    "outputs": [
@@ -505,33 +623,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "rewards : [0.0, 0.333, 0.333, 0.333]\n",
-      "spread  : 0.333   (>0 => a real GRPO gradient)\n",
-      "resolved: 0/4\n",
-      "world   : sha256:0279d1d5a9df43477abdf88d277fd91e44db3f5dd8a01f66d82ee9148c8625f6\n",
-      "turns   : 1   success: False\n"
+      "e9148c8625f6  parent=        root  vulns=['sql_injection', 'sql_injection', 'sql_injection']\n",
+      "c25fabbbdc2e  parent=e9148c8625f6  vulns=['sql_injection', 'sql_injection', 'sql_injection']\n",
+      "abc8470d00d3  parent=c25fabbbdc2e  vulns=['sql_injection', 'sql_injection', 'sql_injection']\n",
+      "41114faeae7a  parent=abc8470d00d3  vulns=['broken_authz', 'sql_injection', 'sql_injection', 'sql_injection']\n",
+      "9eb0ac5a4341  parent=41114faeae7a  vulns=['broken_authz', 'command_injection', 'sql_injection', 'sql_injection', 'sql_injection']\n",
+      "40178f1a5bcb  parent=9eb0ac5a4341  vulns=['broken_authz', 'command_injection', 'config_disclosure', 'sql_injection', 'sql_injection', 'sql_injection']\n"
      ]
     }
    ],
    "source": [
-    "from openrange_trl import env_trajectory\n",
-    "\n",
-    "envs = list(trainer.environments or ())\n",
-    "rewards = [env.reward for env in envs]\n",
-    "resolved = sum(1 for env in envs if env.report is not None and env.report.passed)\n",
-    "spread = max(rewards) - min(rewards) if rewards else 0.0\n",
-    "\n",
-    "print(f\"rewards : {[round(r, 3) for r in rewards]}\")\n",
-    "print(f\"spread  : {spread:.3f}   (>0 => a real GRPO gradient)\")\n",
-    "print(f\"resolved: {resolved}/{len(envs)}\")\n",
-    "\n",
-    "# Export the best rollout's trajectory — the seam downstream consumers read.\n",
-    "trajectory = env_trajectory(max(envs, key=lambda e: e.reward))\n",
-    "print(f\"world   : {trajectory.snapshot_id}\")\n",
-    "print(f\"turns   : {len(trajectory.steps)}   success: {trajectory.success}\")\n",
-    "\n",
-    "for env in envs:\n",
-    "    env.service.close()"
+    "for snap in chain:\n",
+    "    kinds = sorted(\n",
+    "        str(n.attrs.get(\"kind\")) for n in snap.graph.by_kind(\"vulnerability\")\n",
+    "    )\n",
+    "    parent = (evolve_meta(snap).get(\"parent_snapshot_id\") or \"\")[-12:] or \"root\"\n",
+    "    print(f\"{snap.snapshot_id[-12:]}  parent={parent:>12}  vulns={kinds}\")"
    ]
   },
   {
@@ -541,27 +648,22 @@
    "source": [
     "## Where this goes\n",
     "\n",
-    "You saw the reward is real (§3) and the loop runs end-to-end (§7–8). Three seams\n",
-    "carry it further:\n",
+    "You watched the world **evolve with the agent** — that loop is the whole point: the\n",
+    "gym hardens toward wherever the policy is, instead of handing it the same fixed task\n",
+    "forever. Two things take it past a laptop:\n",
     "\n",
-    "- **Curriculum, in-place.** Unlike the SWE pack, the cyber pentest family ships\n",
-    "  graph mutations: when a round's reward spread collapses, `reward_variance_policy`\n",
-    "  fires `auto_evolve`, which mutates the world (harden / soften / diversify the\n",
-    "  planted vulnerabilities) and re-admits it — a new, harder snapshot to train on.\n",
-    "  The gym tracks the policy, live.\n",
-    "- **Provenance.** Every trajectory is tagged with the `snapshot_id`, so an evolved\n",
-    "  curriculum stays fully attributable.\n",
-    "- **Scale.** The batch above runs `num_generations` episodes at once on a laptop;\n",
-    "  TRL's `AsyncGRPOTrainer` pipelines hundreds against a vLLM server with the same\n",
-    "  `make_environment_factory`. The one OpenRange-side lever is world-boot cost — both\n",
-    "  trainers reset worlds serially, so a pooled / fast world realization keeps a big\n",
-    "  batch from stalling on boots (a gym-side follow-up).\n",
+    "- **A real climb.** Swap the reference `solve` for `grpo_round` + a larger instruct\n",
+    "  model on a GPU. Now the *policy's* own improvement collapses the reward spread and\n",
+    "  drives the evolution — the same loop, no stand-in.\n",
+    "- **Throughput.** Each round's `num_generations` rollouts boot at once; TRL's\n",
+    "  `AsyncGRPOTrainer` pipelines hundreds against a vLLM server with the same\n",
+    "  `make_environment_factory`. Both trainers reset worlds serially, so a pooled /\n",
+    "  fast world realization is the gym-side lever that keeps a big batch from stalling\n",
+    "  on boots (#294).\n",
     "\n",
-    "The deterministic, torch-free seam and its reward-dynamics tests live in\n",
-    "the `openrange-trl` package + `tests/test_trl_cyber.py`, and the gated live\n",
-    "mechanics test is `tests/test_trl_live.py`. Honest scope: a laptop-scale model\n",
-    "won't actually pop the SQLi — the gradient is real and proven (§3), but mastery\n",
-    "needs GPU-scale compute."
+    "The torch-free seam + reward/curriculum tests live in `openrange-trl` +\n",
+    "`tests/test_trl_cyber.py`; the gated test that runs a real `GRPOTrainer` across\n",
+    "evolving rounds is `tests/test_trl_live.py`."
    ]
   }
  ],

--- a/tests/test_trl_cyber.py
+++ b/tests/test_trl_cyber.py
@@ -312,3 +312,35 @@ class TestCurriculum:
         assert evolved is not None
         assert evolved.snapshot_id != snapshot.snapshot_id
         assert any(event.phase == "evolve" for event in evolved.history)
+
+    def test_curriculum_chains_distinct_worlds_across_rounds(
+        self, snapshot: Snapshot, tmp_path: Path
+    ) -> None:
+        # Solving every round collapses the spread -> harden -> a fresh admitted
+        # world; the lineage advances as a chain of distinct snapshots round over
+        # round, not one fixed task. This is the loop the cyber notebook teaches.
+        pack = WebappPack()
+        snap = snapshot
+        chain = [snap.snapshot_id]
+        for i in range(3):
+            task = _pentest_task(snap)
+            reports = []
+            for j in range(2):
+                svc = EpisodeService(pack, tmp_path / f"r{i}s{j}")
+                env = EpisodeEnv(
+                    service=svc, snapshots={snap.snapshot_id: snap}, tools=WEB_TOOLS
+                )
+                env.reset(snapshot_id=snap.snapshot_id, task_id=task.id)
+                env.http_get(_exploit_path(snap, task))
+                env.submit(json.dumps({"flag": _truth_flag(snap, task)}))
+                env._finalize()
+                assert env.report is not None and env.report.passed
+                reports.append(env.report)
+                svc.close()
+            evolved = auto_evolve(
+                snap, *reports, pack=pack, policy=reward_variance_policy
+            )
+            assert evolved is not None and evolved.snapshot_id not in chain
+            snap = evolved
+            chain.append(snap.snapshot_id)
+        assert len(set(chain)) == 4  # root + three evolved, all distinct

--- a/tests/test_trl_live.py
+++ b/tests/test_trl_live.py
@@ -20,10 +20,11 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
-from openrange_pack_sdk import Backing
+from openrange_pack_sdk import Backing, EpisodeReportLike
 from openrange_trl import (
     EpisodeEnv,
     build_grpo_dataset,
@@ -34,6 +35,7 @@ from openrange_trl import (
 
 from examples.tools import FILE_TOOLS, WEB_TOOLS
 from openrange.core.admit import AdmissionFailure, admit
+from openrange.core.curriculum import Direction, auto_evolve
 
 
 def _docker_available() -> bool:
@@ -411,3 +413,100 @@ def test_live_grpo_one_step_cyber_container_file_loot(tmp_path: Path) -> None:
     finally:
         for env in envs:
             env.service.close()
+
+
+def _always_harden(reports: Sequence[EpisodeReportLike]) -> Direction:
+    # A tiny laptop model won't drive a reward spread, so force the direction: this
+    # proves the *loop* (re-root + carry the model across rounds), not learning.
+    del reports
+    return "harden"
+
+
+def test_live_grpo_curriculum_evolves_between_rounds(tmp_path: Path) -> None:
+    """Two real GRPO rounds with the world evolving between them.
+
+    Each round trains a real ``GRPOTrainer`` on the current world, grades it, and
+    ``auto_evolve`` forks a child snapshot the next round re-roots onto — carrying
+    the LoRA model forward. This is the curriculum loop the notebook teaches, here
+    against a real trainer; *learning* the exploit is the GPU-scale step.
+    """
+    datasets = pytest.importorskip("datasets")
+    peft = pytest.importorskip("peft")
+    transformers = pytest.importorskip("transformers")
+    trl = pytest.importorskip("trl")
+
+    from cyber_webapp import WebappPack
+
+    pack = WebappPack()
+    snapshot = admit(
+        pack,
+        manifest={
+            "world": {"goal": "recover the hidden flag"},
+            "pack": {"id": "webapp"},
+            "runtime": {"tick": {"mode": "off"}},
+            "npc": [],
+            "seed": 0,
+            "loot_shapes": {"db": 1, "file": 0},
+            "vuln_kinds": {"sql_injection": 1},
+        },
+    )
+    assert not isinstance(snapshot, AdmissionFailure)
+
+    model = transformers.AutoModelForCausalLM.from_pretrained(_MODEL)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(_MODEL)
+    lora = peft.LoraConfig(
+        r=8,
+        lora_alpha=16,
+        lora_dropout=0.0,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+        task_type="CAUSAL_LM",
+    )
+    config = trl.GRPOConfig(
+        output_dir=str(tmp_path / "trainer"),
+        per_device_train_batch_size=2,
+        num_generations=2,
+        steps_per_generation=1,
+        max_steps=1,
+        beta=0.0,
+        max_completion_length=128,
+        max_tool_calling_iterations=3,
+        use_vllm=False,
+        report_to="none",
+        save_strategy="no",
+        bf16=False,
+        fp16=False,
+    )
+
+    # The curriculum loop, inline: train a round -> grade -> evolve -> re-root, with
+    # the first round wrapping the model in LoRA and later rounds carrying it.
+    lineage = [snapshot]
+    snap, wrapped = snapshot, False
+    for _ in range(2):
+        rows = [
+            r for r in build_grpo_dataset(snap, repeat=2) if "pentest" in r["task_id"]
+        ]
+        factory = make_environment_factory(
+            pack, [snap], tmp_path / snap.snapshot_id[-12:], tools=WEB_TOOLS
+        )
+        trainer = trl.GRPOTrainer(
+            model=model,
+            reward_funcs=[make_reward_func()],
+            args=config,
+            train_dataset=datasets.Dataset.from_list(rows),
+            processing_class=tokenizer,
+            environment_factory=factory,
+            peft_config=None if wrapped else lora,
+        )
+        trainer.train()
+        model, wrapped = trainer.model, True
+        reports = [
+            e.report for e in (trainer.environments or ()) if e.report is not None
+        ]
+        assert reports, "a real GRPO round produced no graded rollout"
+        evolved = auto_evolve(snap, *reports, pack=pack, policy=_always_harden)
+        assert evolved is not None and evolved.snapshot_id != snap.snapshot_id
+        snap = evolved
+        lineage.append(snap)
+
+    # Three distinct worlds: the curriculum advanced as a chain across the rounds.
+    assert len({s.snapshot_id for s in lineage}) == 3


### PR DESCRIPTION
## What

Reworked per review: the curriculum loop is now **integrated into the cyber tutorial** as what training *is*, not a standalone example script.

The cyber GRPO notebook (`examples/trl_grpo_cyber.ipynb`) trained one static GRPO step — which made the gym look like every other gym. But training here is a **loop**: each round runs GRPO, then `auto_evolve` moves the world toward the policy's frontier (harden when solving, soften when stuck), re-admits it, and the next round trains on that. So **§7 "Train" is now that loop**, and **§8 is the lineage it produces**.

- **§7** runs one real `GRPOTrainer.train()` (honest floored rewards on a laptop), then runs the loop. A 0.5B can't drive the reward-spread collapse, so the loop is driven by the §3 reference solver — a stand-in for a trained policy — and the world visibly hardens round over round (build complexity, then new vuln kinds). Swap the GRPO round back in on a GPU for the real climb.
- **§8** prints the lineage: a chain of distinct admission-checked snapshots, each tagged with its parent, the vuln set growing 3→6.
- §3's exploit is refactored into a reusable `solve(env, snap)` the curriculum reuses.

The committed output now shows:
```
one real GRPO round → rewards [0.0, 0.333, 0.333, 0.333]
round 1: e9148c8625f6  rewards=[1.0,...]  →  build level 2 on ep_orders-api_0
round 3: abc8470d00d3  rewards=[1.0,...]  →  add broken_authz on ep_orders-db_0
round 5: 9eb0ac5a4341  rewards=[1.0,...]  →  add config_disclosure on ep_orders-db_0
...
40178f1a5bcb  parent=9eb0ac5a4341  vulns=[broken_authz, command_injection, config_disclosure, sql_injection×3]
```

## Why no standalone script

The earlier version added `examples/trl_grpo_curriculum.py`. Per review, the curriculum is the *tutorial's payoff*, and TRL training is taught in notebooks — so the loop lives **inline in the notebook** (like `codex_eval.py` keeps its loop inline), and the standalone script is gone.

## Tests

- `tests/test_trl_cyber.py` — new torch-free **multi-round chaining test** (reuses the file's exploit helpers): solving every round hardens the world into a fresh admitted snapshot; asserts 3 distinct snapshots across the lineage. Runs in CI.
- `tests/test_trl_live.py` — the gated test now **inlines a real two-round `GRPOTrainer` loop** (re-root + LoRA model-carry), asserting the world evolves between rounds. No dependency on a deleted module.
- The reward surface stays pinned by `tests/test_trl_cyber.py`'s existing rung tests.

## Verification

- Re-executed the notebook **live on this Mac**; committed outputs are from that run.
- `ruff check .`, boundary, `mypy`, and the impacted tests all pass; the gated live curriculum test passes (1 passed, ~20s).
- Ran through an **adversarial multi-agent review** (narrative coherence, honesty, `.rules`, executability, dangling refs). Confirmed findings applied: a latent lineage-key fix (read `_evolve` from both the patch- and grow-path locations) and honesty tweaks to the intro/§7 prose. Most flagged items were adversarially cleared as false positives.

Honest scope unchanged: this teaches the *loop* and shows the world evolving via a reference policy. The policy actually *learning* to exploit needs a larger model + GPU (the swap is a one-liner). Throughput past a laptop is the gym-side world pool, #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
