### PR TITLE
Dashboard world-evolution view + fix the curriculum's "harden" mislabel

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -476,7 +476,7 @@ class BuildEvent:
 | `feasibility`  | every admission attempt | "attempt K: N infeasible task(s)". `refs` carries the task ids that failed. |
 | `repair`       | between failed attempts | "builder regenerated after attempt K". |
 | `freeze`       | exactly once, on success | "world admitted and frozen". |
-| `evolve`       | curriculum (`auto_evolve`) | reserved — `auto_evolve` does not currently emit this on success; the evolved snapshot's `lineage` carries the `_evolve` block instead. |
+| `evolve`       | curriculum (`auto_evolve`) | "evolved from `<parent>` via `<family>/<direction>`". Appended once to the evolved snapshot's history; `refs` carries the parent `snapshot_id`. The evolved snapshot's `lineage` also carries the structured `_evolve` block (parent id, direction, family, note). |
 
 `history` is the build **story**, not part of the graph's identity.
 Two builds that produce the same graph but took different repair

--- a/examples/_verify.py
+++ b/examples/_verify.py
@@ -1,0 +1,75 @@
+"""A consequence gate for ``auto_evolve`` (cyber webapp).
+
+Rejects a "harden" add whose exploit actually leaks the flag — that's a second
+solution (easier), not a hardening. Lives here, not in the pack or core,
+because it composes pack pieces (reference exploit + verifier) with host
+realization (``EpisodeService``).
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from cyber_webapp.consequence import detect_leak
+from cyber_webapp.reference_solver import exploit_and_benign
+from openrange_pack_sdk import Mutation, Pack, Snapshot
+
+from openrange.core.curriculum import EvolutionGate
+from openrange.core.episode import EpisodeService
+
+
+def _fetch(url: str) -> str:
+    try:
+        with urllib.request.urlopen(url, timeout=15) as resp:
+            return str(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return str(exc.read().decode())
+    except Exception:  # noqa: BLE001 — an unreachable surface just can't leak
+        return ""
+
+
+def consequence_gate(pack: Pack, workdir: str | Path) -> EvolutionGate:
+    """Build a gate for ``auto_evolve(..., gate=…)``.
+
+    Vets a ``harden`` add: realizes the candidate, runs the added vuln's
+    reference exploit, and returns ``False`` if it leaks the flag (so the
+    leaking add is skipped and a genuine non-leaking decoy is picked instead).
+    Anything it can't assess (non-harden, no added vuln, no reference exploit)
+    passes through unchanged.
+    """
+    root = Path(workdir)
+
+    def gate(evolved: Snapshot, mutation: Mutation) -> bool:
+        if mutation.direction != "harden":
+            return True
+        added_kinds = [
+            str(n.attrs.get("kind"))
+            for n in mutation.patch.nodes_added
+            if n.kind == "vulnerability"
+        ]
+        if not added_kinds:
+            return True
+        task = next(
+            (t for t in evolved.tasks if t.meta.get("family") == "webapp.pentest"),
+            None,
+        )
+        if task is None:
+            return True
+        svc = EpisodeService(pack, root)
+        try:
+            handle = svc.start_episode(evolved, task.id)
+            base = str(svc.surface(handle)["base_url"])
+            for kind in added_kinds:
+                try:
+                    exploit_path, _benign = exploit_and_benign(evolved.graph, kind)
+                except Exception:  # noqa: BLE001 — no reference exploit → can't leak-check
+                    continue
+                if detect_leak(evolved.graph, [_fetch(base + exploit_path)]).occurred:
+                    return False  # a "harden" add that leaks the flag → reject
+            return True
+        finally:
+            svc.close()
+
+    return gate

--- a/examples/codex_eval.py
+++ b/examples/codex_eval.py
@@ -25,6 +25,7 @@ from openrange_pack_sdk import (
 )
 
 from examples._briefing import agent_briefing
+from examples._verify import consequence_gate
 from openrange.agent_backend import CodexAgentBackend
 from openrange.core import PACKS, auto_evolve
 from openrange.core.episode import AgentTurn, EpisodeReport
@@ -149,7 +150,14 @@ def main() -> None:
                 "report": report.as_dict(),
             }
         )
-        evolved = auto_evolve(snapshot, report, pack=pack, llm=curriculum_llm)
+        # Gate so a "harden" add that actually leaks the flag (easier) is skipped.
+        evolved = auto_evolve(
+            snapshot,
+            report,
+            pack=pack,
+            llm=curriculum_llm,
+            gate=consequence_gate(pack, run.root / "_gate"),
+        )
         if evolved is None:
             break
         snapshot = evolved

--- a/packs/cyber_webapp/cyber_webapp/mutation.py
+++ b/packs/cyber_webapp/cyber_webapp/mutation.py
@@ -81,14 +81,17 @@ def _harden_add_absent_mutations(
     services = list(graph.by_kind("service"))
     if not endpoints and not services:
         return []
+    # Prefer off-oracle surfaces for the decoy: a record-reading vuln on the
+    # flag's own surface can become a second path to it (easier). Only a
+    # preference — auto_evolve's consequence gate is the actual safeguard.
     oracle_endpoints, oracle_services = _oracle_path_targets(graph)
-    endpoints_oracle_first = sorted(
+    endpoints_decoy_first = sorted(
         endpoints,
-        key=lambda n: (0 if n.id in oracle_endpoints else 1, n.id),
+        key=lambda n: (1 if n.id in oracle_endpoints else 0, n.id),
     )
-    services_oracle_first = sorted(
+    services_decoy_first = sorted(
         services,
-        key=lambda n: (0 if n.id in oracle_services else 1, n.id),
+        key=lambda n: (1 if n.id in oracle_services else 0, n.id),
     )
 
     existing_kinds_by_target = _existing_kinds_by_target(graph)
@@ -102,9 +105,9 @@ def _harden_add_absent_mutations(
         target_kinds = catalog_entry.target_kinds
         candidates: Sequence[Node]
         if "endpoint" in target_kinds:
-            candidates = endpoints_oracle_first
+            candidates = endpoints_decoy_first
         elif "service" in target_kinds:
-            candidates = services_oracle_first
+            candidates = services_decoy_first
         else:
             continue
         target = next(

--- a/src/openrange/core/curriculum.py
+++ b/src/openrange/core/curriculum.py
@@ -62,6 +62,14 @@ def _report_passed(report: EpisodeReportLike) -> bool:
         return False
 
 
+# Returns True iff the candidate genuinely matches its claimed ``direction``.
+# The caller supplies one (typically realizing the world and checking a
+# verifier) to drop a mutation whose static label is wrong — e.g. one tagged
+# "harden" that actually makes the task easier. Without a gate, the family's
+# label is trusted.
+EvolutionGate = Callable[["Snapshot", Mutation], bool]
+
+
 def auto_evolve(
     snapshot: Snapshot,
     *reports: EpisodeReportLike,
@@ -69,6 +77,7 @@ def auto_evolve(
     policy: CurriculumPolicy = direction_from_reports,
     llm: LLMBackend | None = None,
     max_repairs: int = 2,
+    gate: EvolutionGate | None = None,
 ) -> Snapshot | None:
     """Pick an evolution for ``direction`` and re-admit it.
 
@@ -76,6 +85,10 @@ def auto_evolve(
     world, falls back to a builder *grow* (re-running the builder with a
     difficulty-stepped prior). Returns the next Snapshot, or ``None`` if nothing
     admits.
+
+    ``gate``, when given, vets each admitted candidate against its claimed
+    ``direction`` (see :data:`EvolutionGate`); a rejected candidate is skipped
+    so a mislabelled mutation never lands.
     """
     if not reports:
         return None
@@ -89,8 +102,15 @@ def auto_evolve(
             evolved = _evolve_snapshot(snapshot, pack, chosen, max_repairs=max_repairs)
         except Exception:  # noqa: BLE001 — pack-supplied code is untrusted
             continue
-        if evolved is not None and evolved.snapshot_id != snapshot.snapshot_id:
-            return evolved
+        if evolved is None or evolved.snapshot_id == snapshot.snapshot_id:
+            continue
+        if gate is not None:
+            try:
+                if not gate(evolved, chosen):
+                    continue
+            except Exception:  # noqa: BLE001 — caller-supplied gate is untrusted
+                continue
+        return evolved
 
     try:
         return _grow_snapshot(snapshot, pack, direction, max_repairs=max_repairs)

--- a/src/openrange/dashboard/static/dashboard.css
+++ b/src/openrange/dashboard/static/dashboard.css
@@ -970,3 +970,80 @@ button { font: inherit; cursor: pointer; }
   .topbar { flex-wrap: wrap; }
   .topbar-spacer { flex-basis: 100%; height: 0; }
 }
+
+.view-toggle {
+  display: inline-flex; gap: 2px; background: var(--bg-2);
+  border: 1px solid var(--line); border-radius: 9px; padding: 2px;
+}
+.view-toggle-btn {
+  font: 500 12px var(--f-ui); color: var(--ink-2); background: transparent;
+  border: 0; border-radius: 7px; padding: 5px 12px; cursor: pointer;
+}
+.view-toggle-btn.is-active {
+  background: var(--bg-1-solid); color: var(--ink-0); box-shadow: var(--shadow-1);
+}
+
+.evo-stage {
+  position: absolute; inset: 0; z-index: 4;
+  background: radial-gradient(circle at 50% 36%, #f3eedf 0%, #e6dec8 72%);
+}
+.evo-graph { width: 100%; height: 100%; display: block; cursor: grab; touch-action: none; }
+.evo-graph.grabbing { cursor: grabbing; }
+.evo-graph .evo-edge { stroke: var(--line); stroke-width: 1.2; transition: opacity .35s ease; }
+.evo-graph .evo-edge.affects { stroke: #8d3f3a; stroke-opacity: .55; stroke-dasharray: 4 3; }
+.evo-graph .evo-edge.gone { opacity: 0; }
+.evo-graph .evo-edge.added { stroke: #9e7232; stroke-width: 2.6; stroke-opacity: 1; stroke-dasharray: none; }
+.evo-graph .evo-node { transition: opacity .35s ease; cursor: pointer; }
+.evo-graph .evo-node.gone { opacity: 0; pointer-events: none; }
+.evo-graph .evo-node.removed { opacity: .5; }
+.evo-graph .evo-node.removed .main { fill-opacity: .25; stroke: #8d3f3a; stroke-width: 2; stroke-dasharray: 3 2; }
+.evo-graph .evo-edge.removed { stroke: #8d3f3a; stroke-opacity: .55; stroke-dasharray: 3 2; }
+.evo-graph .evo-node .halo,
+.evo-graph .evo-node .mod { opacity: 0; transition: opacity .3s ease; }
+.evo-graph .evo-node.added .halo { opacity: 1; }
+.evo-graph .evo-node.modified .mod { opacity: 1; }
+.evo-graph .nlab { font: 500 11px var(--f-mono); fill: var(--ink-1); pointer-events: none; }
+.evo-graph .nlab.strong { fill: var(--ink-0); }
+.evo-graph .nsub { font: 400 9px var(--f-mono); fill: var(--ink-3); pointer-events: none; }
+.evo-graph .npill { font: 500 9px var(--f-ui); fill: #7a571f; opacity: 0; transition: opacity .3s ease; pointer-events: none; }
+.evo-graph .evo-node.added .npill { opacity: 1; }
+
+.evo-legend {
+  position: absolute; top: 72px; right: 18px; display: flex; flex-direction: column;
+  gap: 5px; background: var(--bg-1); border: 1px solid var(--line);
+  border-radius: 11px; padding: 10px 12px; box-shadow: var(--shadow-1);
+}
+.evo-legend .row { display: flex; align-items: center; gap: 7px; font: 500 11px var(--f-ui); color: var(--ink-2); }
+.evo-legend .sw { width: 11px; height: 11px; border-radius: 50%; flex: 0 0 auto; }
+.evo-legend .sw.ring { background: transparent; border: 2.5px solid #9e7232; }
+.evo-legend .sw.ring.amber { border-color: #b88521; }
+
+.evo-emptymsg {
+  position: absolute; inset: 0; display: flex; align-items: center;
+  justify-content: center; font: 500 15px var(--f-ui); color: var(--ink-3);
+}
+
+.evo-scrubber {
+  position: absolute; left: 50%; transform: translateX(-50%); bottom: 60px; z-index: 9;
+  display: flex; align-items: stretch; gap: 10px; width: min(640px, calc(100% - 48px));
+  background: var(--bg-1); border: 1px solid var(--line); border-radius: 15px;
+  padding: 12px 14px; box-shadow: var(--shadow-2);
+}
+.evo-nav {
+  flex: 0 0 auto; width: 46px; border: 1px solid var(--line); background: var(--bg-1-solid);
+  border-radius: 10px; font-size: 22px; line-height: 1; color: var(--ink-1); cursor: pointer;
+}
+.evo-nav:disabled { opacity: .32; cursor: default; }
+.evo-scrubber-mid { flex: 1; min-width: 0; }
+.evo-scrubber-head { display: flex; align-items: baseline; gap: 8px; }
+.evo-step-label { font: 600 14px var(--f-ui); color: var(--ink-0); }
+.evo-step-snap { font: 400 11px var(--f-mono); color: var(--ink-3); }
+.evo-step-summary { font: 400 12.5px var(--f-ui); color: var(--ink-2); margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.evo-step-changes { font: 500 12px var(--f-ui); margin-top: 3px; }
+.evo-step-changes .add { color: #5e7c3d; }
+.evo-step-changes .rm { color: #8d3f3a; }
+.evo-step-changes .mod { color: #b88521; }
+.evo-step-changes .neutral { color: var(--ink-3); }
+.evo-dots { display: flex; gap: 6px; margin-top: 8px; flex-wrap: wrap; }
+.evo-dot { width: 11px; height: 11px; border-radius: 50%; border: 1px solid var(--line); background: var(--bg-1-solid); cursor: pointer; padding: 0; }
+.evo-dot.on { background: var(--accent); border-color: var(--accent); }

--- a/src/openrange/dashboard/static/dashboard.js
+++ b/src/openrange/dashboard/static/dashboard.js
@@ -1547,9 +1547,10 @@ function showBuildBanner(node) {
   const title = node.builder_summary
     || (isFirst ? `Built world ${(node.id || "").slice(-10)}` : `Mutated → ${(node.id || "").slice(-10)}`);
   document.getElementById("build-banner-title").textContent = shortText(title, 90);
+  const direction = evoDirectionWord(node.evolve?.direction);
   const sub = node.parent_id
-    ? `from ${(node.parent_id || "").slice(-10)} · ${plural((node.touched_files || []).length, "file")}`
-    : `${plural((node.touched_files || []).length, "file")} touched`;
+    ? `${direction ? `${direction} · ` : ""}from …${(node.parent_id || "").slice(-10)}`
+    : "starting world";
   document.getElementById("build-banner-sub").textContent = sub;
   bannerEl.hidden = false;
   // Mark the build tab so the user notices it.
@@ -2019,13 +2020,13 @@ function renderLineagePanel() {
     nodes.map((node, idx) => {
       const isActive = node.id === rail.selectedLineageId
         || (rail.selectedLineageId == null && idx === nodes.length - 1);
-      const ops = (node.curriculum?.ops || node.curriculum?.mutation_ops || []).join(", ");
-      const summary = node.builder_summary || node.prompt || "";
+      const summary = evoSummaryText(node) || node.prompt || "";
+      const stepLabel = idx === 0 ? "Initial world" : `Evolution ${idx}`;
+      const direction = evoDirectionWord(node.evolve?.direction);
       return `<li class="lineage-node ${isActive ? "is-active" : ""}" data-node-id="${escapeHtml(node.id)}">
-        <h4>${escapeHtml(node.id)}</h4>
+        <h4>${escapeHtml(stepLabel)} · …${escapeHtml((node.id || "").slice(-10))}</h4>
         ${summary ? `<p class="summary">${escapeHtml(shortText(summary, 200))}</p>` : ""}
-        ${ops ? `<p class="meta">ops: ${escapeHtml(ops)}</p>` : ""}
-        <p class="meta">${plural((node.touched_files || []).length, "file")}${node.parent_id ? ` · from ${(node.parent_id || "").slice(-10)}` : ""}</p>
+        <p class="meta">${direction ? `<span class="zone-pill">${escapeHtml(direction)}</span> ` : ""}${node.parent_id ? `from …${escapeHtml((node.parent_id || "").slice(-10))}` : "root"}</p>
       </li>`;
     }).join("")
   }</ul>`;
@@ -2129,6 +2130,423 @@ function emptyCard(message) {
   return `<div class="empty-card">${escapeHtml(message)}</div>`;
 }
 
+// One layout over the union of all worlds, so a node added by an evolution
+// pops in at a fixed spot instead of reshuffling the whole graph.
+
+const SVGNS = "http://www.w3.org/2000/svg";
+
+const EVO_FILL = {
+  network: "#6e5e44", host: "#9e8e72",
+  service: "#3d6a8a", endpoint: "#6f9bb5",
+  data_store: "#5e7c3d", record: "#7c9456",
+  secret: "#b88521", account: "#6e5a85", credential: "#8a7aa0",
+  vulnerability: "#8d3f3a",
+};
+const EVO_R = {
+  network: 12, host: 9, service: 12, endpoint: 6.5, data_store: 10,
+  record: 6, secret: 10, account: 8, credential: 6.5, vulnerability: 7.5,
+};
+const EVO_BAND = {
+  network: 0, host: 0, service: 1, endpoint: 2,
+  vulnerability: 3, data_store: 4, record: 4, secret: 4, account: 4, credential: 4,
+};
+const EVO_LABELED = new Set([
+  "network", "host", "service", "endpoint", "data_store", "secret",
+  "account", "credential", "vulnerability",
+]);
+const EVO_LEGEND = [
+  ["infrastructure", "#9e8e72"], ["service", "#3d6a8a"], ["endpoint", "#6f9bb5"],
+  ["data / records", "#5e7c3d"], ["secret", "#b88521"], ["account / cred", "#6e5a85"],
+  ["vulnerability", "#8d3f3a"], ["added this step", "ring"], ["changed this step", "ring-amber"],
+];
+
+const evo = {
+  active: false,
+  step: 0,
+  chainKey: "",
+  mounted: false,
+  W: 1280, H: 760,
+  nodes: [], edges: [], steps: [],
+  stepNodeSets: [], stepEdgeSets: [], stepAttrs: [],
+  nodeEls: new Map(), edgeEls: new Map(),
+  view: { x: 0, y: 0, k: 1 },
+};
+
+function evoNodeLabel(n) {
+  const L = (n.label || "").trim();
+  if (L) return L;
+  const id = n.id || "";
+  if (n.kind === "network") return "network";
+  if (n.kind === "host") return "host";
+  if (n.kind === "secret") return "flag";
+  if (n.kind === "service") return id.replace(/^svc_/, "");
+  if (n.kind === "vulnerability") return id.replace(/^vuln_/, "").replace(/_\d+$/, "");
+  if (n.kind === "data_store") return id.replace(/^ds_/, "");
+  if (n.kind === "account") return "account";
+  if (n.kind === "credential") return "cred";
+  return "";
+}
+
+function setEvoView(mode) {
+  evo.active = (mode === "evolution");
+  document.querySelectorAll(".view-toggle-btn").forEach((b) =>
+    b.classList.toggle("is-active", b.dataset.view === mode));
+  const stage = document.getElementById("evo-stage");
+  const scrub = document.getElementById("evo-scrubber");
+  if (stage) stage.hidden = !evo.active;
+  const canvas = document.getElementById("sim-canvas");
+  const labels = document.getElementById("sim-label-layer");
+  if (canvas) canvas.style.visibility = evo.active ? "hidden" : "visible";
+  if (labels) labels.style.visibility = evo.active ? "hidden" : "visible";
+  if (evo.active) {
+    evo.chainKey = "";        // force a rebuild from current model
+    renderEvoView();
+    if (scrub) scrub.hidden = (evo.steps.length === 0);
+  } else if (scrub) {
+    scrub.hidden = true;
+  }
+}
+
+function buildEvo() {
+  const steps = ((model.lineage || {}).nodes || []).filter((n) => n && n.graph);
+  const key = steps.map((s) => s.id).join("|");
+  if (key === evo.chainKey) return false;
+  evo.chainKey = key;
+  evo.steps = steps;
+  const unodes = new Map(), uedges = new Map();
+  steps.forEach((s) => {
+    (s.graph.nodes || []).forEach((n) => { if (!unodes.has(n.id)) unodes.set(n.id, { ...n }); });
+    (s.graph.edges || []).forEach((e) => { if (!uedges.has(e.id)) uedges.set(e.id, { ...e }); });
+  });
+  evo.nodes = [...unodes.values()];
+  evo.edges = [...uedges.values()];
+  evo.stepNodeSets = steps.map((s) => new Set((s.graph.nodes || []).map((n) => n.id)));
+  evo.stepEdgeSets = steps.map((s) => new Set((s.graph.edges || []).map((e) => e.id)));
+  evo.stepAttrs = steps.map((s) => {
+    const m = new Map();
+    (s.graph.nodes || []).forEach((n) => m.set(n.id, n.attrs || {}));
+    return m;
+  });
+  if (evo.step > steps.length - 1) evo.step = Math.max(0, steps.length - 1);
+  layoutEvo();
+  evo.mounted = false;
+  return true;
+}
+
+function layoutEvo() {
+  const padX = 110, padY = 60, W = evo.W, H = evo.H;
+  const bands = 5;
+  const colX = (b) => padX + b * ((W - 2 * padX) / (bands - 1));
+  const byId = new Map(evo.nodes.map((n) => [n.id, n]));
+  const nbrs = new Map(evo.nodes.map((n) => [n.id, []]));
+  evo.edges.forEach((e) => {
+    if (byId.has(e.src) && byId.has(e.dst)) {
+      nbrs.get(e.src).push(e.dst);
+      nbrs.get(e.dst).push(e.src);
+    }
+  });
+  const cols = Array.from({ length: bands }, () => []);
+  evo.nodes.slice().sort((a, b) => (a.id < b.id ? -1 : 1)).forEach((n) => {
+    n.band = EVO_BAND[n.kind] ?? 4;
+    cols[n.band].push(n);
+  });
+  const assignY = () => cols.forEach((arr, b) => {
+    const n = arr.length;
+    arr.forEach((node, i) => {
+      node.x = colX(b);
+      node.y = n <= 1 ? H / 2 : padY + i * ((H - 2 * padY) / (n - 1));
+    });
+  });
+  assignY();
+  for (let it = 0; it < 12; it++) {
+    cols.forEach((arr) => {
+      arr.forEach((node) => {
+        const ns = nbrs.get(node.id).map((id) => byId.get(id)).filter(Boolean);
+        node._k = ns.length ? ns.reduce((s, m) => s + m.y, 0) / ns.length : node.y;
+      });
+      arr.sort((a, b) => a._k - b._k);
+    });
+    assignY();
+  }
+}
+
+function mountEvoGraph() {
+  const svg = document.getElementById("evo-graph");
+  if (!svg) return;
+  svg.setAttribute("viewBox", `0 0 ${evo.W} ${evo.H}`);
+  svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
+  svg.innerHTML = "";
+  evo.nodeEls.clear();
+  evo.edgeEls.clear();
+
+  const vp = document.createElementNS(SVGNS, "g");
+  vp.setAttribute("id", "evo-viewport");
+  svg.appendChild(vp);
+  const gEdges = document.createElementNS(SVGNS, "g");
+  const gNodes = document.createElementNS(SVGNS, "g");
+  vp.appendChild(gEdges); vp.appendChild(gNodes);
+  evo._vp = vp;
+
+  const byId = new Map(evo.nodes.map((n) => [n.id, n]));
+  evo.edges.forEach((e) => {
+    const s = byId.get(e.src), t = byId.get(e.dst);
+    if (!s || !t) return;
+    const ln = document.createElementNS(SVGNS, "line");
+    ln.setAttribute("x1", s.x); ln.setAttribute("y1", s.y);
+    ln.setAttribute("x2", t.x); ln.setAttribute("y2", t.y);
+    ln.setAttribute("class", "evo-edge" + (e.kind === "affects" ? " affects" : ""));
+    gEdges.appendChild(ln);
+    evo.edgeEls.set(e.id, ln);
+  });
+
+  evo.nodes.forEach((n) => {
+    const g = document.createElementNS(SVGNS, "g");
+    g.setAttribute("class", "evo-node");
+    g.setAttribute("transform", `translate(${n.x},${n.y})`);
+    const r = EVO_R[n.kind] || 7;
+    const halo = document.createElementNS(SVGNS, "circle");
+    halo.setAttribute("r", r + 5); halo.setAttribute("class", "halo");
+    halo.setAttribute("fill", "none"); halo.setAttribute("stroke", "#9e7232");
+    halo.setAttribute("stroke-width", "2.6");
+    g.appendChild(halo);
+    const mod = document.createElementNS(SVGNS, "circle");
+    mod.setAttribute("r", r + 5); mod.setAttribute("class", "mod");
+    mod.setAttribute("fill", "none"); mod.setAttribute("stroke", "#b88521");
+    mod.setAttribute("stroke-width", "2.6");
+    g.appendChild(mod);
+    const c = document.createElementNS(SVGNS, "circle");
+    c.setAttribute("r", r); c.setAttribute("class", "main");
+    c.setAttribute("fill", EVO_FILL[n.kind] || "#9e8e72");
+    c.setAttribute("stroke", n.public ? "#4f3a1f" : "#faf7ee");
+    c.setAttribute("stroke-width", n.public ? "2.6" : "1.4");
+    g.appendChild(c);
+    const title = document.createElementNS(SVGNS, "title");
+    title.textContent = `${n.id}  ·  ${n.kind}${n.zone ? "  ·  " + n.zone : ""}${n.public ? "  ·  public" : ""}`;
+    g.appendChild(title);
+    const lab = evoNodeLabel(n);
+    if (lab && (EVO_LABELED.has(n.kind) || n.public)) {
+      const side = (n.kind === "endpoint" || n.kind === "host");
+      const t = document.createElementNS(SVGNS, "text");
+      if (side) {
+        t.setAttribute("x", r + 5); t.setAttribute("y", 3.2); t.setAttribute("text-anchor", "start");
+        t.setAttribute("class", "nsub");
+      } else {
+        t.setAttribute("x", 0); t.setAttribute("y", r + 12); t.setAttribute("text-anchor", "middle");
+        t.setAttribute("class", "nlab" + (n.kind === "service" || n.kind === "secret" || n.kind === "vulnerability" ? " strong" : ""));
+      }
+      t.textContent = lab;
+      g.appendChild(t);
+      let sub = "";
+      if (n.kind === "service" && n.zone) sub = n.public ? n.zone + " · public" : n.zone;
+      else if (n.kind === "network") sub = "network";
+      if (sub) {
+        const z = document.createElementNS(SVGNS, "text");
+        z.setAttribute("x", 0); z.setAttribute("y", r + 23); z.setAttribute("text-anchor", "middle");
+        z.setAttribute("class", "nsub");
+        z.textContent = sub;
+        g.appendChild(z);
+      }
+    }
+    const pill = document.createElementNS(SVGNS, "text");
+    pill.setAttribute("x", r + 4); pill.setAttribute("y", -r - 2);
+    pill.setAttribute("class", "npill"); pill.textContent = "new";
+    g.appendChild(pill);
+    gNodes.appendChild(g);
+    evo.nodeEls.set(n.id, g);
+  });
+
+  mountEvoLegend();
+  mountEvoDots();
+  wireEvoPanZoom(svg);
+  fitEvoView();
+  evo.mounted = true;
+}
+
+function mountEvoLegend() {
+  const el = document.getElementById("evo-legend");
+  if (!el) return;
+  el.innerHTML = EVO_LEGEND.map(([name, color]) => {
+    const isRing = color === "ring" || color === "ring-amber";
+    const cls = color === "ring-amber" ? " ring amber" : color === "ring" ? " ring" : "";
+    const style = isRing ? "" : ` style="background:${color}"`;
+    return `<div class="row"><span class="sw${cls}"${style}></span>${escapeHtml(name)}</div>`;
+  }).join("");
+}
+
+function mountEvoDots() {
+  const wrap = document.getElementById("evo-dots");
+  if (!wrap) return;
+  wrap.innerHTML = "";
+  evo.steps.forEach((s, i) => {
+    const b = document.createElement("button");
+    b.className = "evo-dot";
+    b.setAttribute("aria-label", i === 0 ? "Initial world" : "Evolution " + i);
+    b.addEventListener("click", () => { evo.step = i; renderEvoStep(); });
+    wrap.appendChild(b);
+  });
+}
+
+// Fit into the band between the top bar and scrubber (both float over the SVG).
+function fitEvoView() {
+  const svg = document.getElementById("evo-graph");
+  if (!svg || !evo.nodes.length) return;
+  const xs = evo.nodes.map((n) => n.x), ys = evo.nodes.map((n) => n.y);
+  const minX = Math.min(...xs), maxX = Math.max(...xs);
+  const minY = Math.min(...ys), maxY = Math.max(...ys);
+  const tx0 = 70, ty0 = 86, tx1 = evo.W - 70, ty1 = evo.H - 152;
+  const bw = Math.max(1, maxX - minX), bh = Math.max(1, maxY - minY);
+  const k = Math.min((tx1 - tx0) / bw, (ty1 - ty0) / bh, 1.5);
+  evo.view.k = k;
+  evo.view.x = tx0 + ((tx1 - tx0) - k * bw) / 2 - k * minX;
+  evo.view.y = ty0 + ((ty1 - ty0) - k * bh) / 2 - k * minY;
+  applyEvoTransform();
+}
+
+function applyEvoTransform() {
+  if (evo._vp) {
+    evo._vp.setAttribute("transform",
+      `translate(${evo.view.x},${evo.view.y}) scale(${evo.view.k})`);
+  }
+}
+
+function wireEvoPanZoom(svg) {
+  let dragging = false, lx = 0, ly = 0;
+  svg.onpointerdown = (e) => { dragging = true; lx = e.clientX; ly = e.clientY; svg.classList.add("grabbing"); svg.setPointerCapture(e.pointerId); };
+  svg.onpointermove = (e) => {
+    if (!dragging) return;
+    evo.view.x += e.clientX - lx; evo.view.y += e.clientY - ly;
+    lx = e.clientX; ly = e.clientY; applyEvoTransform();
+  };
+  svg.onpointerup = (e) => { dragging = false; svg.classList.remove("grabbing"); try { svg.releasePointerCapture(e.pointerId); } catch (_) {} };
+  svg.onwheel = (e) => {
+    e.preventDefault();
+    const rect = svg.getBoundingClientRect();
+    const scale = evo.W / rect.width;                  // client px → viewBox units
+    const mx = (e.clientX - rect.left) * scale, my = (e.clientY - rect.top) * scale;
+    const factor = e.deltaY < 0 ? 1.12 : 1 / 1.12;
+    const nk = Math.max(0.4, Math.min(4, evo.view.k * factor));
+    evo.view.x = mx - (mx - evo.view.x) * (nk / evo.view.k);
+    evo.view.y = my - (my - evo.view.y) * (nk / evo.view.k);
+    evo.view.k = nk; applyEvoTransform();
+  };
+}
+
+function evoShortName(vid) {
+  return (vid || "").replace(/^vuln_/, "").replace(/_\d+$/, "");
+}
+
+// "harden"/"soften" collide with security-hardening (the opposite); show the
+// agent-difficulty sense instead.
+const EVO_DIRECTION_WORD = { harden: "harder", soften: "easier", diversify: "varied" };
+function evoDirectionWord(d) { return EVO_DIRECTION_WORD[d] || d || ""; }
+
+function evoSummaryText(node) {
+  const ev = node.evolve;
+  if (!ev) return node.builder_summary || "";   // initial world
+  const word = evoDirectionWord(ev.direction);
+  const fam = ev.family ? ` · ${ev.family}` : "";
+  const note = ev.note ? ` — ${ev.note}` : "";
+  return `${word}${fam}${note}`;
+}
+
+function renderEvoStep() {
+  if (!evo.steps.length) return;
+  const i = Math.max(0, Math.min(evo.step, evo.steps.length - 1));
+  evo.step = i;
+  const ns = evo.stepNodeSets[i], es = evo.stepEdgeSets[i];
+  const prevN = i > 0 ? evo.stepNodeSets[i - 1] : null;
+  const prevE = i > 0 ? evo.stepEdgeSets[i - 1] : null;
+
+  const attrsNow = evo.stepAttrs[i], attrsPrev = i > 0 ? evo.stepAttrs[i - 1] : null;
+  const modified = [];
+  if (attrsPrev) {
+    ns.forEach((id) => {
+      if (!prevN || !prevN.has(id)) return;
+      const a = attrsNow.get(id) || {}, b = attrsPrev.get(id) || {};
+      for (const k of new Set([...Object.keys(a), ...Object.keys(b)])) {
+        if (JSON.stringify(a[k]) !== JSON.stringify(b[k])) {
+          modified.push({ id, key: k, from: b[k], to: a[k] });
+          break;
+        }
+      }
+    });
+  }
+  const modIds = new Set(modified.map((m) => m.id));
+
+  evo.nodeEls.forEach((el, id) => {
+    const on = ns.has(id);
+    // Linger one step as a ghost before going fully hidden.
+    const justRemoved = !on && prevN != null && prevN.has(id);
+    el.classList.toggle("removed", justRemoved);
+    el.classList.toggle("gone", !on && !justRemoved);
+    el.classList.toggle("added", on && prevN != null && !prevN.has(id));
+    el.classList.toggle("modified", on && modIds.has(id));
+  });
+  evo.edgeEls.forEach((el, id) => {
+    const on = es.has(id);
+    const justRemoved = !on && prevE != null && prevE.has(id);
+    el.classList.toggle("removed", justRemoved);
+    el.classList.toggle("gone", !on && !justRemoved);
+    el.classList.toggle("added", on && prevE != null && !prevE.has(id));
+  });
+
+  const step = evo.steps[i];
+  document.getElementById("evo-step-label").textContent = i === 0 ? "Initial world" : "Evolution " + i;
+  document.getElementById("evo-step-snap").textContent = "…" + (step.id || "").slice(-8);
+  document.getElementById("evo-step-summary").textContent = evoSummaryText(step);
+
+  const addedN = prevN ? [...ns].filter((x) => !prevN.has(x)) : [];
+  const addedE = prevE ? [...es].filter((x) => !prevE.has(x)) : [];
+  const removedN = prevN ? [...prevN].filter((x) => !ns.has(x)) : [];
+  const ch = document.getElementById("evo-step-changes");
+  const tally = `<span class="neutral"> · ${ns.size} nodes / ${es.size} edges</span>`;
+  const byId = new Map(evo.nodes.map((n) => [n.id, n]));
+  const vulnNamesOf = (ids) => ids.map((x) => byId.get(x)).filter((n) => n && n.kind === "vulnerability").map((n) => evoShortName(n.id));
+  if (addedN.length || addedE.length || removedN.length) {
+    const addV = vulnNamesOf(addedN), remV = vulnNamesOf(removedN);
+    const parts = [];
+    if (addedN.length) parts.push(`<span class="add">+${addedN.length} node${addedN.length > 1 ? "s" : ""}${addV.length ? ` (${addV.join(", ")})` : ""}</span>`);
+    if (addedE.length) parts.push(`<span class="add">+${addedE.length} edge${addedE.length > 1 ? "s" : ""}</span>`);
+    if (removedN.length) parts.push(`<span class="rm">−${removedN.length} node${removedN.length > 1 ? "s" : ""}${remV.length ? ` (${remV.join(", ")})` : ""}</span>`);
+    ch.innerHTML = parts.join(" ") + tally;
+  } else if (modified.length) {
+    const m = modified[0];
+    const nm = evoNodeLabel(byId.get(m.id)) || m.id;
+    const delta = (m.from === undefined || m.from === null)
+      ? `${escapeHtml(m.key)} → ${escapeHtml(String(m.to))}`
+      : `${escapeHtml(m.key)} ${escapeHtml(String(m.from))}→${escapeHtml(String(m.to))}`;
+    ch.innerHTML = `<span class="mod">${delta}</span> <span class="neutral">on ${escapeHtml(nm)}${tally}</span>`;
+  } else if (i === 0) {
+    ch.innerHTML = `<span class="neutral">starting world · ${ns.size} nodes / ${es.size} edges</span>`;
+  } else {
+    ch.innerHTML = `<span class="neutral">no change · ${ns.size} nodes / ${es.size} edges</span>`;
+  }
+
+  document.getElementById("evo-prev").disabled = (i === 0);
+  document.getElementById("evo-next").disabled = (i === evo.steps.length - 1);
+  const dots = document.getElementById("evo-dots").children;
+  for (let d = 0; d < dots.length; d++) dots[d].classList.toggle("on", d === i);
+}
+
+function renderEvoView() {
+  if (!evo.active) return;
+  buildEvo();
+  const empty = document.getElementById("evo-emptymsg");
+  const scrub = document.getElementById("evo-scrubber");
+  if (!evo.steps.length) {
+    if (empty) empty.hidden = false;
+    if (scrub) scrub.hidden = true;
+    const svg = document.getElementById("evo-graph");
+    if (svg) svg.innerHTML = "";
+    evo.mounted = false;
+    return;
+  }
+  if (empty) empty.hidden = true;
+  if (scrub) scrub.hidden = false;
+  if (!evo.mounted) mountEvoGraph();
+  renderEvoStep();
+}
+
 // =============================================================
 // Top-level render coordinator
 // =============================================================
@@ -2144,6 +2562,7 @@ function render() {
   }
   // Re-render the active rail panel so it reflects fresh data.
   if (rail.open) renderRailPanel(rail.active);
+  renderEvoView();
   // Surface a build banner when a new lineage node lands.
   checkForNewLineage();
 }
@@ -2325,6 +2744,21 @@ function wireUI() {
       if (rail.open) closeRail();
     }
   });
+  document.querySelectorAll(".view-toggle-btn").forEach((btn) => {
+    btn.addEventListener("click", () => setEvoView(btn.dataset.view));
+  });
+  document.getElementById("evo-prev")?.addEventListener("click", () => {
+    if (evo.step > 0) { evo.step--; renderEvoStep(); }
+  });
+  document.getElementById("evo-next")?.addEventListener("click", () => {
+    if (evo.step < evo.steps.length - 1) { evo.step++; renderEvoStep(); }
+  });
+  document.addEventListener("keydown", (e) => {
+    if (!evo.active) return;
+    if (e.key === "ArrowLeft" && evo.step > 0) { evo.step--; renderEvoStep(); }
+    if (e.key === "ArrowRight" && evo.step < evo.steps.length - 1) { evo.step++; renderEvoStep(); }
+  });
+
   // Build banner.
   document.getElementById("build-banner-cta")?.addEventListener("click", () => {
     if (banner.current) rail.selectedLineageId = banner.current.id;

--- a/src/openrange/dashboard/static/index.html
+++ b/src/openrange/dashboard/static/index.html
@@ -21,11 +21,23 @@
   <canvas id="sim-canvas" aria-label="OpenRange episode simulation"></canvas>
   <div class="label-layer" id="sim-label-layer" aria-hidden="true"></div>
 
+  <!-- Evolution graph stage: the whole world as a node-link graph, scrubbed
+       across evolution steps. Hidden until the Evolution view is selected. -->
+  <div class="evo-stage" id="evo-stage" hidden>
+    <svg class="evo-graph" id="evo-graph" aria-label="World evolution graph"></svg>
+    <div class="evo-legend" id="evo-legend" aria-hidden="true"></div>
+    <div class="evo-emptymsg" id="evo-emptymsg" hidden>No evolution recorded yet.</div>
+  </div>
+
   <!-- Top bar: minimal. Brand · run picker · status · live-clock · play/pause. -->
   <header class="topbar" id="topbar">
     <div class="topbar-brand">
       <span class="topbar-mark"></span>
       <span class="topbar-name">OpenRange</span>
+    </div>
+    <div class="view-toggle" id="view-toggle" role="tablist" aria-label="View">
+      <button class="view-toggle-btn is-active" data-view="office" role="tab">Office</button>
+      <button class="view-toggle-btn" data-view="evolution" role="tab">Evolution</button>
     </div>
     <button
       class="topbar-pill"
@@ -158,6 +170,21 @@
     </div>
     <button class="build-banner-cta" id="build-banner-cta">Open</button>
     <button class="build-banner-dismiss" id="build-banner-dismiss" title="Dismiss">×</button>
+  </div>
+
+  <!-- Evolution scrubber: step back/forth through the lineage chain. -->
+  <div class="evo-scrubber" id="evo-scrubber" hidden>
+    <button class="evo-nav" id="evo-prev" aria-label="Previous evolution">&#8249;</button>
+    <div class="evo-scrubber-mid">
+      <div class="evo-scrubber-head">
+        <span class="evo-step-label" id="evo-step-label">Initial world</span>
+        <span class="evo-step-snap" id="evo-step-snap"></span>
+      </div>
+      <div class="evo-step-summary" id="evo-step-summary"></div>
+      <div class="evo-step-changes" id="evo-step-changes"></div>
+      <div class="evo-dots" id="evo-dots"></div>
+    </div>
+    <button class="evo-nav" id="evo-next" aria-label="Next evolution">&#8250;</button>
   </div>
 
   <!-- Toasts: short-lived persona speech / agent action highlights. -->

--- a/src/openrange/dashboard/topology.py
+++ b/src/openrange/dashboard/topology.py
@@ -224,6 +224,67 @@ def _services_from_graph(graph: WorldGraph) -> list[dict[str, object]]:
     return services
 
 
+def graph_projection(graph: WorldGraph) -> dict[str, object]:
+    """Every node and edge of the world, with display hints only — never a
+    secret's value — so the evolution view can draw and diff the full graph.
+    """
+    host_zone = {
+        n.id: str(n.attrs.get("zone", ""))
+        for n in graph.nodes.values()
+        if n.kind == "host"
+    }
+    service_host: dict[str, str] = {}
+    endpoint_service: dict[str, str] = {}
+    for edge in graph.edges.values():
+        if edge.kind == "runs_on":
+            service_host[edge.src] = edge.dst
+        elif edge.kind == "exposes":
+            endpoint_service[edge.dst] = edge.src
+
+    def zone_for(node: object) -> str:
+        kind = node.kind  # type: ignore[attr-defined]
+        node_id = node.id  # type: ignore[attr-defined]
+        if kind == "host":
+            return host_zone.get(node_id, "")
+        if kind == "service":
+            return host_zone.get(service_host.get(node_id, ""), "")
+        if kind == "endpoint":
+            svc = endpoint_service.get(node_id, "")
+            return host_zone.get(service_host.get(svc, ""), "")
+        return ""
+
+    def tuning_attrs(node: object) -> dict[str, object]:
+        # Numeric knobs only (e.g. build_level): strings are skipped so a secret
+        # value can't ride along. bool is an int subclass, so int|float covers it.
+        out: dict[str, object] = {}
+        for key, value in node.attrs.items():  # type: ignore[attr-defined]
+            if isinstance(value, int | float) and not sensitive_world_key(str(key)):
+                out[str(key)] = value
+        return out
+
+    nodes = [
+        {
+            "id": n.id,
+            "kind": n.kind,
+            "zone": zone_for(n),
+            "label": str(
+                n.attrs.get("name") or n.attrs.get("path") or n.attrs.get("kind") or ""
+            ),
+            "public": bool(n.kind == "service" and n.attrs.get("exposure") == "public"),
+            "attrs": tuning_attrs(n),
+        }
+        for n in graph.nodes.values()
+    ]
+    edges = [
+        {"id": e.id, "kind": e.kind, "src": e.src, "dst": e.dst}
+        for e in graph.edges.values()
+    ]
+    return {
+        "nodes": sorted(nodes, key=lambda row: str(row["id"])),
+        "edges": sorted(edges, key=lambda row: str(row["id"])),
+    }
+
+
 def _edges_from_graph(graph: WorldGraph) -> list[dict[str, object]]:
     service_name = {
         n.id: str(n.attrs.get("name", n.id))

--- a/src/openrange/dashboard/view.py
+++ b/src/openrange/dashboard/view.py
@@ -29,6 +29,7 @@ from openrange.dashboard.summaries import (
 )
 from openrange.dashboard.topology import (
     empty_runtime_topology,
+    graph_projection,
     normalized_runtime_topology,
     public_world,
     stored_entrypoints,
@@ -114,6 +115,9 @@ class DashboardView:
         self.bridge = bridge or EventBridge()
         self._running = False
         self._lock = threading.Lock()
+        self._lineage_nodes: list[dict[str, object]] = (
+            [] if snapshot is None else [_lineage_node(snapshot)]
+        )
         self._event_log_path = None if event_log_path is None else Path(event_log_path)
         self._state_path = None if state_path is None else Path(state_path)
         self._stored_dashboard = (
@@ -177,6 +181,19 @@ class DashboardView:
             **runtime_topology,
         }
 
+    def register_snapshot(self, snapshot: Snapshot) -> None:
+        """Re-bind to ``snapshot`` and append it to the lineage chain.
+
+        Re-binding keeps topology reflecting the current world, not the one the
+        view was created with; the appended node is what makes the evolution
+        history viewable. A repeated id is a no-op.
+        """
+        self.snapshot = snapshot
+        last = self._lineage_nodes[-1]["id"] if self._lineage_nodes else None
+        if last != snapshot.snapshot_id:
+            self._lineage_nodes.append(_lineage_node(snapshot))
+        self._write_configured_state()
+
     def lineage(self) -> Mapping[str, object]:
         if self.snapshot is None:
             stored = self._stored_section("lineage")
@@ -184,16 +201,17 @@ class DashboardView:
                 return stored
             return {
                 "snapshot_id": None,
+                "nodes": [],
                 "lineage": {},
                 "history": [],
                 "parent_snapshot_id": None,
             }
-        parent_id = self.snapshot.lineage.get("parent_snapshot_id")
         return {
             "snapshot_id": self.snapshot.snapshot_id,
+            "nodes": [dict(node) for node in self._lineage_nodes],
             "lineage": dict(self.snapshot.lineage),
             "history": [event.to_dict() for event in self.snapshot.history],
-            "parent_snapshot_id": parent_id if isinstance(parent_id, str) else None,
+            "parent_snapshot_id": _parent_snapshot_id(self.snapshot.lineage),
         }
 
     def state(self) -> Mapping[str, object]:
@@ -406,6 +424,60 @@ def _manifest_from_lineage(lineage: Mapping[str, object]) -> Mapping[str, object
     if isinstance(manifest, Mapping):
         return cast(Mapping[str, object], manifest)
     return {}
+
+
+def _evolve_block(lineage: Mapping[str, object]) -> Mapping[str, object]:
+    # A grow step records ``_evolve`` at the top level; a patch step nests it
+    # under the manifest.
+    top = lineage.get("_evolve")
+    if isinstance(top, Mapping):
+        return cast(Mapping[str, object], top)
+    manifest = _manifest_from_lineage(lineage)
+    nested = manifest.get("_evolve")
+    if isinstance(nested, Mapping):
+        return cast(Mapping[str, object], nested)
+    return {}
+
+
+def _parent_snapshot_id(lineage: Mapping[str, object]) -> str | None:
+    parent = _evolve_block(lineage).get("parent_snapshot_id")
+    return parent if isinstance(parent, str) else None
+
+
+# "harden"/"soften" collide with security-hardening (the opposite); the UI
+# shows the agent-difficulty sense instead.
+_DIRECTION_LABEL = {"harden": "harder", "soften": "easier", "diversify": "varied"}
+
+
+def _evolve_summary(evolve: Mapping[str, object]) -> str:
+    if not evolve:
+        return "Initial build"
+    direction = str(evolve.get("direction") or "evolved")
+    word = _DIRECTION_LABEL.get(direction, direction)
+    family = evolve.get("family")
+    note = evolve.get("note")
+    head = f"{word} · {family}" if family else word
+    return f"{head} — {note}" if note else head
+
+
+def _lineage_node(snapshot: Snapshot) -> dict[str, object]:
+    lineage = snapshot.lineage
+    evolve = _evolve_block(lineage)
+    manifest = dict(_manifest_from_lineage(lineage))
+    # Drop _evolve so the Build tab's manifest delta shows authoring changes.
+    manifest.pop("_evolve", None)
+    difficulty = lineage.get("curriculum_difficulty")
+    curriculum = dict(difficulty) if isinstance(difficulty, Mapping) else {}
+    return {
+        "id": snapshot.snapshot_id,
+        "parent_id": _parent_snapshot_id(lineage),
+        "builder_summary": _evolve_summary(evolve),
+        "manifest": manifest,
+        "pack": {"id": lineage.get("pack"), "version": lineage.get("pack_version")},
+        "curriculum": curriculum,
+        "evolve": dict(evolve) if evolve else None,
+        "graph": graph_projection(snapshot.graph),
+    }
 
 
 def _task_to_dict(task: TaskSpec) -> dict[str, object]:

--- a/src/openrange/runtime.py
+++ b/src/openrange/runtime.py
@@ -163,6 +163,12 @@ class OpenRangeRun:
                 state_path=self.root / "dashboard.json",
                 reset_artifacts=False,
             )
+        else:
+            # A later ``auto_evolve`` hands us a fresh world: re-bind the view
+            # so topology reflects the current world and the evolution chain
+            # grows a node. (Re-binding also fixes the view freezing on the
+            # first snapshot for the whole run.)
+            self._dashboard_view.register_snapshot(snapshot)
         return self._dashboard_view
 
     def episode_service(self, snapshot: Snapshot) -> EpisodeService:

--- a/tests/test_curriculum.py
+++ b/tests/test_curriculum.py
@@ -431,6 +431,73 @@ def test_auto_evolve_picks_highest_relevance_in_direction() -> None:
     assert evolve_meta["note"] == "high"
 
 
+def test_auto_evolve_gate_skips_rejected_candidate() -> None:
+    """A gate vetoing the top candidate (e.g. a 'harden' add that actually
+    leaks the flag → easier) makes auto_evolve fall through to the next."""
+    low_patch = GraphPatch(
+        nodes_added=[Node("ep.low", "endpoint", attrs={"path": "/low"})],
+        edges_added=[Edge("e.low", "exposes", "repo.a", "ep.low")],
+    )
+    high_patch = GraphPatch(
+        nodes_added=[Node("ep.high", "endpoint", attrs={"path": "/high"})],
+        edges_added=[Edge("e.high", "exposes", "repo.a", "ep.high")],
+    )
+    family = _StubFamily(
+        mutations=(
+            Mutation(
+                patch=low_patch,
+                direction="harden",
+                relevance=0.2,
+                family="stub.family",
+                note="low",
+            ),
+            Mutation(
+                patch=high_patch,
+                direction="harden",
+                relevance=0.9,
+                family="stub.family",
+                note="high",
+            ),
+        ),
+    )
+    snap, pack = _build_stub_snapshot(family)
+
+    seen: list[str] = []
+
+    def gate(evolved: Snapshot, mutation: Mutation) -> bool:
+        seen.append(mutation.note)
+        return mutation.note != "high"  # reject the leaking top pick
+
+    out = auto_evolve(snap, _Report(True), pack=pack, gate=gate)
+    assert isinstance(out, Snapshot), out
+    # The vetoed high-relevance add was skipped; the legitimate one landed.
+    assert "ep.high" not in out.graph.nodes
+    assert "ep.low" in out.graph.nodes
+    assert seen == ["high", "low"]  # tried highest-relevance first, then fell through
+
+
+def test_auto_evolve_gate_rejecting_all_returns_none() -> None:
+    """If the gate vetoes every candidate and no grow is possible, evolution
+    legitimately stalls (None) rather than landing a mislabelled world."""
+    patch = GraphPatch(
+        nodes_added=[Node("ep.x", "endpoint", attrs={"path": "/x"})],
+        edges_added=[Edge("e.x", "exposes", "repo.a", "ep.x")],
+    )
+    family = _StubFamily(
+        mutations=(
+            Mutation(
+                patch=patch,
+                direction="harden",
+                relevance=0.9,
+                family="stub.family",
+                note="x",
+            ),
+        ),
+    )
+    snap, pack = _build_stub_snapshot(family)
+    assert auto_evolve(snap, _Report(True), pack=pack, gate=lambda *_: False) is None
+
+
 def test_auto_evolve_custom_policy() -> None:
     """Trainer can override the direction policy."""
     diversify_patch = GraphPatch(

--- a/tests/test_cyber_auto_curriculum.py
+++ b/tests/test_cyber_auto_curriculum.py
@@ -14,7 +14,7 @@ from types import MappingProxyType
 from typing import Any
 
 from cyber_webapp import WebappPack, WebappPentest
-from cyber_webapp.mutation import available_mutations
+from cyber_webapp.mutation import _oracle_path_targets, available_mutations
 from cyber_webapp.vulnerabilities import CATALOG as VULN_CATALOG
 from graphschema import GraphPatch, WorldGraph, apply_patch
 from openrange_pack_sdk import EpisodeReportLike, Mutation, Snapshot
@@ -163,6 +163,29 @@ def test_directions_produce_different_patch_shapes() -> None:
         assert opt.patch.nodes_updated, "diversify must update a vuln in place"
         assert not opt.patch.nodes_added
         assert not opt.patch.nodes_removed
+
+
+def test_harden_adds_decoys_off_the_oracle_path() -> None:
+    """A 'harden' add is a decoy — it must NOT land on the flag's path. A
+    record-reading vuln on the oracle endpoint would open a second leak (an
+    *easier* world), so every harden add targets an off-oracle surface."""
+    snap = _build_snapshot()
+    oracle_endpoints, oracle_services = _oracle_path_targets(snap.graph)
+    on_oracle = oracle_endpoints | oracle_services
+    assert on_oracle, "the seed world must have a flag path to test against"
+
+    harden = [
+        o
+        for o in available_mutations(snap.graph, "webapp.pentest", ())
+        if o.direction == "harden"
+    ]
+    assert harden, "the seed world should admit at least one harden add"
+    for opt in harden:
+        targets = {e.dst for e in opt.patch.edges_added}
+        assert targets, f"harden add {opt.note!r} has no affects edge"
+        assert not (targets & on_oracle), (
+            f"harden decoy {opt.note!r} landed on the oracle path → would leak"
+        )
 
 
 def test_soften_relevance_is_floor_without_reports() -> None:

--- a/tests/test_dashboard_runs.py
+++ b/tests/test_dashboard_runs.py
@@ -22,6 +22,7 @@ import json
 import time
 from collections.abc import Callable, Mapping
 from pathlib import Path
+from typing import cast
 
 from cyber_webapp import WebappPack
 from openrange_pack_sdk import Snapshot
@@ -319,21 +320,40 @@ def test_topology_carries_new_snapshot_id_and_no_artifact_paths() -> None:
 
 
 def test_lineage_uses_history_and_lineage_mapping() -> None:
-    """``lineage()`` ships ``history`` and the ``lineage`` mapping.
+    """``lineage()`` ships the evolution ``nodes`` chain plus the current
+    world's ``history`` and flat ``lineage`` mapping.
 
     Published fields:
       - ``snapshot_id``: the content-addressed id
+      - ``nodes``: the evolution chain (one entry per admitted world); a
+        fresh single snapshot is a one-node chain rooted at itself
       - ``history``: phases ``admit()`` recorded (build / validate /
         feasibility / freeze + any repair attempts)
       - ``lineage``: the flat provenance mapping (manifest, pack
         id+version, attempt count)
-      - ``parent_snapshot_id``: forward-compat hook.
+      - ``parent_snapshot_id``: the parent this world evolved from
+        (``None`` for an initial build).
     """
     snap = _admit_seed_snapshot()
     view = DashboardView(snap)
     try:
         payload = view.lineage()
         assert payload["snapshot_id"] == snap.snapshot_id
+        nodes = payload["nodes"]
+        assert isinstance(nodes, list) and len(nodes) == 1
+        node = nodes[0]
+        assert node["id"] == snap.snapshot_id
+        assert node["parent_id"] is None
+        assert node["builder_summary"] == "Initial build"
+        assert node["pack"] == {"id": "webapp", "version": "v2"}
+        # The full node-link graph rides along so the evolution view can draw
+        # and diff it. Counts must match the admitted graph exactly.
+        graph = node["graph"]
+        assert isinstance(graph, Mapping)
+        assert len(graph["nodes"]) == len(snap.graph.nodes)
+        assert len(graph["edges"]) == len(snap.graph.edges)
+        first = graph["nodes"][0]
+        assert set(first.keys()) == {"id", "kind", "zone", "label", "public", "attrs"}
         lineage = payload["lineage"]
         assert isinstance(lineage, Mapping)
         assert lineage["pack"] == "webapp"
@@ -345,6 +365,43 @@ def test_lineage_uses_history_and_lineage_mapping() -> None:
         assert phases[0] == "build"
         assert phases[-1] == "freeze"
         assert payload["parent_snapshot_id"] is None
+    finally:
+        view.close()
+
+
+def test_lineage_chain_grows_across_evolution() -> None:
+    """``register_snapshot`` extends the chain so the dashboard can show how
+    a world changed per evolution: each evolved world is a node whose
+    ``parent_id`` points at the world it came from."""
+    from openrange.core import auto_evolve
+
+    class _Report:
+        passed = True
+        final_state: dict[str, list[str]] = {"requests_made": []}
+
+    pack = WebappPack()
+    snap = _admit_seed_snapshot()
+    view = DashboardView(snap)
+    try:
+        produced = [snap.snapshot_id]
+        prev = snap
+        for _ in range(3):
+            evolved = auto_evolve(prev, _Report(), pack=pack)
+            if evolved is None:
+                break
+            view.register_snapshot(evolved)
+            produced.append(evolved.snapshot_id)
+            prev = evolved
+
+        nodes = cast(list[dict[str, object]], view.lineage()["nodes"])
+        assert [n["id"] for n in nodes] == produced
+        # First node is the root; every later node links to the one before it.
+        assert nodes[0]["parent_id"] is None
+        for child, parent in zip(nodes[1:], nodes[:-1], strict=True):
+            assert child["parent_id"] == parent["id"]
+            assert child["evolve"] is not None
+        # The view now reflects the latest world, not the first.
+        assert view.lineage()["snapshot_id"] == produced[-1]
     finally:
         view.close()
 

--- a/tests/test_llm_and_dashboard.py
+++ b/tests/test_llm_and_dashboard.py
@@ -462,6 +462,7 @@ def test_dashboard_http_server_can_start_without_snapshot() -> None:
     }
     empty_lineage: dict[str, object] = {
         "snapshot_id": None,
+        "nodes": [],
         "lineage": {},
         "history": [],
         "parent_snapshot_id": None,


### PR DESCRIPTION
## Why

Two things, found by pulling the thread on "is the world-evolution view actually updated in the dashboard?"

1. **The evolution view was dead.** The SPA renders from a per-world `nodes` chain that the backend stopped producing after the typed-graph refactor (#223). The Lineage/Build tabs showed "0 nodes" even across a real multi-world run.
2. **A real curriculum bug the view surfaced.** `auto_evolve` labelled "add an absent vuln" as `harden`, but it dropped the decoy on the **flag's own endpoint**, so a record-reading vuln (e.g. `broken_authz`) leaked the flag — a *second* solution, i.e. **easier**, mislabelled as harder. Verified empirically (the added `broken_authz` exploit leaks; `path_traversal` decoy does not).

## What

**Dashboard**
- `view.py`: accumulate the evolution chain (`register_snapshot`); `/api/lineage` serves `nodes` again; fix parent-id extraction (read `_evolve`, not a never-set top-level key).
- `runtime.py`: rebind the dashboard view to each newly-admitted world (also fixes the view freezing on the first world for a whole run).
- `topology.py`: `graph_projection` — the full node/edge graph (+ numeric tuning attrs like `build_level`; never secret values) per lineage node.
- New full-canvas **Evolution** view toggled from the office scene: node-link graph (one stable layout over the union of worlds), a scrubber over the lineage, and **add / change / remove** diff highlighting. Endpoints/hosts/networks/services labelled; networks no longer read as services.
- `CONTRACTS.md`: §5.4 — the `evolve` phase *is* emitted now; documented.

**Curriculum**
- `mutation.py`: place harden decoys **off** the oracle path (non-flag surfaces), so an add is a genuine distractor (harder), not a second leak.
- `curriculum.py`: `auto_evolve(..., gate=…)` — a consequence gate that vets each candidate against its claimed direction. `examples/_verify.py` realizes the candidate and rejects a "harden" add that actually leaks the flag. Wired into `examples/codex_eval.py`.

## Tests
- Lineage chain grows across evolution + graph projection shape (`test_dashboard_runs.py`).
- Gate hook: skips a vetoed candidate / returns `None` when all rejected (`test_curriculum.py`).
- Harden decoys land off the oracle path (`test_cyber_auto_curriculum.py`).
- Full suite green.

## Validation
Driven end-to-end with a real Claude agent loop (codegen episodes graded by the held-out contract → `auto_evolve`), watched live in the dashboard's evolution view. Before the mutation fix, a harden-add leaked the flag (easier); after, it lands a non-leaking decoy (genuinely harder), with the gate as a backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)