### PR TITLE
Make credential-reuse a first-class, verified graph path

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/__init__.py
@@ -17,6 +17,7 @@ from cyber_webapp.builder import WebappBuilder
 from cyber_webapp.container import minimum_backing
 from cyber_webapp.families import WebappBuild, WebappPentest
 from cyber_webapp.invariants import (
+    credential_reuse_binding,
     no_orphan_nodes,
     oracle_path_exists,
     secret_must_be_held,
@@ -49,6 +50,7 @@ class WebappPack(Pack):
             secret_must_be_held,
             oracle_path_exists,
             sqli_targets_db_backed_service,
+            credential_reuse_binding,
         ]
 
     def make_builder(self, prior: PackPrior | None) -> Builder:
@@ -100,6 +102,7 @@ __all__ = [
     "WebappPentest",
     "WebappRuntimeError",
     "WebappRuntime",
+    "credential_reuse_binding",
     "minimum_backing",
     "no_orphan_nodes",
     "oracle_path_exists",

--- a/packs/cyber_webapp/cyber_webapp/invariants.py
+++ b/packs/cyber_webapp/cyber_webapp/invariants.py
@@ -134,6 +134,114 @@ def oracle_path_exists(graph: WorldGraph) -> list[Issue]:
     return issues
 
 
+_CHAIN_PRODUCER_KINDS: frozenset[str] = frozenset(
+    {"credential_leak", "credential_gated_relay"}
+)
+_CHAIN_GATE_KINDS: frozenset[str] = frozenset(
+    {"credential_gated_relay", "credential_gated_flag"}
+)
+
+
+def credential_reuse_binding(graph: WorldGraph) -> list[Issue]:
+    """Every `requires_credential` gate must obtain its credential from exactly
+    one strictly-earlier hop on the `enables` chain, and the producing and
+    gating vulns must keep their credential-chain kinds.
+
+    Binds by credential-node identity + enable ordering; it does not read
+    `value_ref` or detect cycles (the chain is a DAG by construction), and the
+    handler param-name / response-shape contract stays the verifier's job. The
+    kind check is what stops a mutation that rewrites a chain vuln in place from
+    leaving the binding structurally intact but the world unsolvable. Endpoints
+    without a `requires_credential` edge are untouched.
+    """
+    producers: dict[str, list[str]] = {}
+    affects: dict[str, list[str]] = {}
+    enables: dict[str, set[str]] = {}
+    for edge in graph.edges.values():
+        if edge.kind == "produces":
+            producers.setdefault(edge.dst, []).append(edge.src)
+        elif edge.kind == "affects":
+            affects.setdefault(edge.dst, []).append(edge.src)
+        elif edge.kind == "enables":
+            enables.setdefault(edge.src, set()).add(edge.dst)
+    vuln_kind = {
+        n.id: str(n.attrs.get("kind", "")) for n in graph.by_kind("vulnerability")
+    }
+
+    def reaches(src: str, dst: str) -> bool:
+        seen: set[str] = set()
+        stack = list(enables.get(src, ()))
+        while stack:
+            cur = stack.pop()
+            if cur == dst:
+                return True
+            if cur in seen:
+                continue
+            seen.add(cur)
+            stack.extend(enables.get(cur, ()))
+        return False
+
+    issues: list[Issue] = []
+    for edge in graph.edges.values():
+        if edge.kind != "produces":
+            continue
+        if vuln_kind.get(edge.src) not in _CHAIN_PRODUCER_KINDS:
+            issues.append(
+                Issue(
+                    "error",
+                    "credential_binding",
+                    f"credential {edge.dst!r} is produced by {edge.src!r} of kind "
+                    f"{vuln_kind.get(edge.src)!r}, not a credential-chain hop",
+                    edge.src,
+                )
+            )
+    for edge in graph.edges.values():
+        if edge.kind != "requires_credential":
+            continue
+        endpoint_id, cred_id = edge.src, edge.dst
+        produced_by = producers.get(cred_id, [])
+        if len(produced_by) != 1:
+            issues.append(
+                Issue(
+                    "error",
+                    "credential_binding",
+                    f"credential {cred_id!r} required by {endpoint_id!r} is "
+                    f"produced by {len(produced_by)} hop(s), expected exactly 1",
+                    endpoint_id,
+                )
+            )
+            continue
+        producer = produced_by[0]
+        gates = [
+            v
+            for v in affects.get(endpoint_id, [])
+            if vuln_kind.get(v) in _CHAIN_GATE_KINDS
+        ]
+        if not gates:
+            issues.append(
+                Issue(
+                    "error",
+                    "credential_binding",
+                    f"endpoint {endpoint_id!r} requires a credential but no "
+                    f"credential-gate vuln affects it",
+                    endpoint_id,
+                )
+            )
+            continue
+        for gate in gates:
+            if producer == gate or not reaches(producer, gate):
+                issues.append(
+                    Issue(
+                        "error",
+                        "credential_binding",
+                        f"credential {cred_id!r}: producer {producer!r} is not a "
+                        f"strictly-earlier hop than gate {gate!r}",
+                        endpoint_id,
+                    )
+                )
+    return issues
+
+
 def sqli_targets_db_backed_service(graph: WorldGraph) -> list[Issue]:
     """SQL-injection vulns must target endpoints of services with a
     `backed_by` data_store edge (else the handler queries nothing)."""

--- a/packs/cyber_webapp/cyber_webapp/ontology.py
+++ b/packs/cyber_webapp/cyber_webapp/ontology.py
@@ -288,5 +288,17 @@ def webapp_ontology() -> Ontology:
                 endpoints=[("credential", "secret")],
                 description="a credential whose value comes from this secret",
             ),
+            "produces": EdgeKind(
+                "produces",
+                endpoints=[("vulnerability", "credential")],
+                description="exploiting this weakness yields this credential",
+            ),
+            "requires_credential": EdgeKind(
+                "requires_credential",
+                endpoints=[("endpoint", "credential")],
+                description=(
+                    "this endpoint grants access only when this credential is presented"
+                ),
+            ),
         },
     )

--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -1298,6 +1298,19 @@ def _lateralize(graph: WorldGraph, rng: random.Random) -> None:
     tparams = [rng.choice(_TOKEN_PARAMS) for _ in range(depth)]
     gate_path = "/internal/vault"
 
+    # Credential nodes stay PUBLIC, never HIDDEN: a HIDDEN value_ref would be
+    # swept into the guarded set, and the leak handler serving it would trip the
+    # consequence verifier on a benign probe.
+    cred_ids = [f"cred_chain_{j}" for j in range(depth)]
+    for token, cred_id in zip(creds, cred_ids, strict=True):
+        graph.add_node(
+            Node(
+                id=cred_id,
+                kind="credential",
+                attrs={"kind": "token", "value_ref": token},
+            )
+        )
+
     def _name(node: Node) -> str:
         return str(node.attrs.get("name", node.id))
 
@@ -1338,6 +1351,7 @@ def _lateralize(graph: WorldGraph, rng: random.Random) -> None:
     )
     _add_edge(graph, "affects", leak_vuln_id, leak_ep_id)
     _add_edge(graph, "enables", ssrf.id, leak_vuln_id)
+    _add_edge(graph, "produces", leak_vuln_id, cred_ids[0])
 
     # 4. The flag record's value goes decoy so the db's default endpoints can't leak it;
     #    the real flag stays in the secret the gated handler serves.
@@ -1398,6 +1412,9 @@ def _lateralize(graph: WorldGraph, rng: random.Random) -> None:
         )
         _add_edge(graph, "affects", vuln_id, ep_id)
         _add_edge(graph, "enables", prev_vuln, vuln_id)
+        _add_edge(graph, "requires_credential", ep_id, cred_ids[j])
+        if j < depth - 1:
+            _add_edge(graph, "produces", vuln_id, cred_ids[j + 1])
         prev_vuln = vuln_id
 
 

--- a/tests/test_cyber_lateral.py
+++ b/tests/test_cyber_lateral.py
@@ -16,8 +16,9 @@ from pathlib import Path
 
 import pytest
 from cyber_webapp import NetworkedContainerWebappRuntime, WebappPack, _is_networked
+from cyber_webapp.consequence import guarded_values
 from cyber_webapp.reference_solver import solve_chain
-from graphschema import WorldGraph
+from graphschema import Visibility, WorldGraph
 from openrange_pack_sdk import Backing, Snapshot
 
 from openrange.core.admit import admit
@@ -46,6 +47,55 @@ def _chain_depth(graph: WorldGraph) -> int:
         for n in graph.by_kind("vulnerability")
         if n.attrs.get("kind") in ("credential_gated_relay", "credential_gated_flag")
     )
+
+
+def test_chain_credentials_are_public_wired_graph_nodes() -> None:
+    graph = _admit().graph
+    # Scope to the chain's tokens — the NPC `password` credentials are a
+    # separate credential system that this binding does not own.
+    creds = [n for n in graph.by_kind("credential") if n.attrs.get("kind") == "token"]
+    assert creds, "a lateral world mints a credential node per hop"
+    referenced = {e.src for e in graph.edges.values()} | {
+        e.dst for e in graph.edges.values()
+    }
+    for cred in creds:
+        assert cred.visibility == Visibility.PUBLIC
+        assert cred.attrs.get("kind") == "token"
+        produced = [
+            e for e in graph.edges.values() if e.kind == "produces" and e.dst == cred.id
+        ]
+        required = [
+            e
+            for e in graph.edges.values()
+            if e.kind == "requires_credential" and e.dst == cred.id
+        ]
+        assert len(produced) == 1, cred.id
+        assert len(required) == 1, cred.id
+        assert cred.id in referenced
+
+
+def test_admission_rejects_a_broken_credential_binding() -> None:
+    # Runs the full validate() pipeline (ontology + invariants), not the
+    # invariant alone — proves the gate fires at admission.
+    from graphschema import validate
+
+    pack = WebappPack()
+    graph = _admit().graph
+    produces = [e for e in graph.edges.values() if e.kind == "produces"]
+    assert produces
+    del graph.edges[produces[0].id]
+    issues = validate(graph, pack.ontology(), pack.invariants())
+    assert any(i.code == "credential_binding" and i.severity == "error" for i in issues)
+
+
+def test_chain_credentials_are_not_guarded() -> None:
+    # PUBLIC credential nodes must NOT join the guarded set — a HIDDEN token would
+    # be swept in, and the leak handler serving it would trip the verifier on a
+    # benign probe (every lateral world would then be rejected as trivial).
+    graph = _admit().graph
+    guarded = set(guarded_values(graph))
+    assert guarded, "the flag must be guarded"
+    assert not (guarded & {n.id for n in graph.by_kind("credential")})
 
 
 def _get(base: str, path: str) -> str:

--- a/tests/test_cyber_webapp_v2.py
+++ b/tests/test_cyber_webapp_v2.py
@@ -22,6 +22,7 @@ from typing import Any
 from cyber_webapp.families.build import WebappBuild
 from cyber_webapp.families.pentest import WebappPentest
 from cyber_webapp.invariants import (
+    credential_reuse_binding,
     no_orphan_nodes,
     oracle_path_exists,
     secret_must_be_held,
@@ -263,9 +264,7 @@ class _StubWebappPack(Pack):
 
 
 def test_cyber_ontology_is_valid() -> None:
-    """The new cyber ontology declares 10 node kinds + 11 edge kinds
-    (the two old `affects` rows collapse into one EdgeKind with 2
-    endpoint pairs)."""
+    """The cyber ontology declares the expected node and edge kinds."""
     o = webapp_ontology()
     assert o.id == "cyber.webapp@v2"
     assert set(o.node_kinds) == {
@@ -376,6 +375,109 @@ def test_oracle_path_exists_fails_when_vuln_removed() -> None:
     g.edges.pop("e.wk-ep", None)
     issues = oracle_path_exists(g)
     assert any(i.code == "no_oracle_chain" for i in issues)
+
+
+def _binding_chain(*, producer: str | None = "v_leak") -> WorldGraph:
+    # leak -enables-> gate; the gate's endpoint requires a credential. `producer`
+    # is the vuln that `produces` that credential (None = nobody produces it).
+    g = WorldGraph(ontology=ONTOLOGY_ID)
+    g.add_node(
+        Node(
+            "v_leak",
+            "vulnerability",
+            attrs={"kind": "credential_leak"},
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    g.add_node(
+        Node(
+            "v_gate",
+            "vulnerability",
+            attrs={"kind": "credential_gated_flag"},
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    g.add_node(Node("ep_gate", "endpoint", attrs={"path": "/internal/vault"}))
+    g.add_node(Node("cred", "credential", attrs={"kind": "token", "value_ref": "tok0"}))
+    g.add_edge(Edge("e_aff", "affects", "v_gate", "ep_gate"))
+    g.add_edge(Edge("e_en", "enables", "v_leak", "v_gate"))
+    g.add_edge(Edge("e_req", "requires_credential", "ep_gate", "cred"))
+    if producer is not None:
+        g.add_edge(Edge("e_prod", "produces", producer, "cred"))
+    return g
+
+
+def test_credential_binding_accepts_a_valid_chain() -> None:
+    assert credential_reuse_binding(_binding_chain()) == []
+
+
+def test_credential_binding_rejects_an_unproduced_credential() -> None:
+    issues = credential_reuse_binding(_binding_chain(producer=None))
+    assert any(i.code == "credential_binding" for i in issues)
+
+
+def test_credential_binding_rejects_a_producer_not_strictly_earlier() -> None:
+    # The consuming gate produces its own required credential — not obtainable
+    # before the gate, so the binding is unsatisfiable.
+    issues = credential_reuse_binding(_binding_chain(producer="v_gate"))
+    assert any(i.code == "credential_binding" for i in issues)
+
+
+def test_credential_binding_rejects_a_swapped_chain_kind() -> None:
+    # A diversify swap that rewrites a chain hop's kind in place (keeping its
+    # produces edge) must be caught, or an unsolvable world admits clean.
+    g = _binding_chain()
+    g.nodes["v_leak"].attrs["kind"] = "idor"
+    assert any(i.code == "credential_binding" for i in credential_reuse_binding(g))
+
+
+def test_credential_binding_rejects_two_producers() -> None:
+    g = _binding_chain()
+    g.add_node(
+        Node(
+            "v_leak2",
+            "vulnerability",
+            attrs={"kind": "credential_leak"},
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    g.add_edge(Edge("e_prod2", "produces", "v_leak2", "cred"))
+    assert any(i.code == "credential_binding" for i in credential_reuse_binding(g))
+
+
+def test_credential_binding_rejects_when_no_gate_vuln() -> None:
+    # The required endpoint's only vuln is no longer a gate kind (a swap rewrote
+    # it), so nothing actually consumes the credential it gates on.
+    g = _binding_chain()
+    g.nodes["v_gate"].attrs["kind"] = "idor"
+    assert any(i.code == "credential_binding" for i in credential_reuse_binding(g))
+
+
+def test_credential_binding_rejects_when_producer_cannot_reach_gate() -> None:
+    # Producer is a valid hop but no enables path reaches the gate (an enables
+    # cycle that never arrives), so the gate's credential is unobtainable.
+    g = WorldGraph(ontology=ONTOLOGY_ID)
+    for vid, kind in (
+        ("v_leak", "credential_leak"),
+        ("v_relay", "credential_gated_relay"),
+        ("v_gate", "credential_gated_flag"),
+    ):
+        g.add_node(
+            Node(
+                vid,
+                "vulnerability",
+                attrs={"kind": kind},
+                visibility=Visibility.HIDDEN,
+            )
+        )
+    g.add_node(Node("ep_gate", "endpoint", attrs={"path": "/internal/vault"}))
+    g.add_node(Node("cred", "credential", attrs={"kind": "token", "value_ref": "t"}))
+    g.add_edge(Edge("e_prod", "produces", "v_leak", "cred"))
+    g.add_edge(Edge("e_aff", "affects", "v_gate", "ep_gate"))
+    g.add_edge(Edge("e_req", "requires_credential", "ep_gate", "cred"))
+    g.add_edge(Edge("e_en1", "enables", "v_leak", "v_relay"))
+    g.add_edge(Edge("e_en2", "enables", "v_relay", "v_leak"))
+    assert any(i.code == "credential_binding" for i in credential_reuse_binding(g))
 
 
 def test_real_webapp_pack_identity() -> None:


### PR DESCRIPTION
## Why

OpenRange is a synthesized gym: the **world graph is the single source of truth** — the dashboard, curriculum, feasibility, and search all read it. Credential-reuse / lateral movement already *worked* at runtime (an SSRF pivot chain `credential_leak → credential_gated_relay* → credential_gated_flag`, with the reused token threaded through vuln params and the reference solver walking hop→hop), but the credential **binding lived only as opaque strings + a hand-coded solver** — invisible to the graph. So the gym's machinery couldn't see, verify, or evolve it (it's why the dashboard showed the cred path as nothing).

## What

Make the binding **graph-native and verified at admission** (additive — no handler/realizer changes):

- **ontology**: new edge kinds `produces` (vulnerability→credential) and `requires_credential` (endpoint→credential).
- **sampling** (`_lateralize`): mint one **PUBLIC** `credential` node per hop (`kind=token`, `value_ref` = the chain token) and wire `produces`/`requires_credential` from the same tokens it already threads. Handler params are unchanged, so PROCESS and CONTAINER realization stay **byte-identical**.
- **invariant** `credential_reuse_binding` (runs at admission, every family): each `requires_credential` gate gets its credential from exactly one **strictly-earlier** hop on the `enables` chain, and the producing/gating vulns must keep their chain kinds — so a `diversify` swap that rewrites a chain vuln in place is **rejected**, not admitted as an unsolvable world.
- the **evolution dashboard** renders the new edges for free.

### A trap worth calling out
Credential nodes are **PUBLIC, not HIDDEN**: a HIDDEN token (≥8 chars) gets swept into the consequence verifier's guarded set, so the leak handler serving it would trip the verifier on a *benign* probe — and every lateral world would be rejected as trivial. There's a regression test pinning "chain creds absent from the guarded set."

## Honest scope
The graph binding **mirrors** the existing param contract by *value identity + ordering*; the param-name / response-shape contract stays the verifier's job. This is the spine, not the full "single source of truth."

## Deferred (tracked)
- **#298** — retire the dead account/credential NPC system (the orphan `account → password` component). Split out because removing `_sample_accounts` shifts the rng stream (broad world perturbation); deserves its own PR + test pass.
- Single-source-of-truth (handlers/solver read the token from the graph) and mutation-excludes-chain-kinds — noted in #298.

## Validation
- Boundary clean (pack-only, no `core/*`), ruff + format + mypy clean.
- Impacted suite green: lateral + webapp_v2 (38), solver/company/auto-curriculum/procedural-builder/codegen/curriculum (97).
- Plan and implementation both adversarially audited by multi-agent workflows; the impl audit caught the diversify-masking bug above (fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
