### PR TITLE
perf(cyber): reuse the container image across episodes instead of rebuilding it

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/realize.py
+++ b/packs/cyber_webapp/cyber_webapp/realize.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import atexit
+import hashlib
 import json
 import shutil
 import subprocess
@@ -237,6 +239,51 @@ class WebappRuntime(SubprocessRuntime):
             return False
 
 
+# Container images are content-addressed by their build files, so episodes of the same
+# world reuse one image instead of each rebuilding + deleting an identical one. Built
+# images are swept at exit — a running container pins its image, so docker skips those.
+_IMAGE_LABEL = "openrange.cyber.image=1"
+_built_tags: set[str] = set()
+_sweep_registered = False
+
+
+def _content_tag(
+    build_files: Mapping[str, str], *, prefix: str = "openrange-cyber"
+) -> str:
+    digest = hashlib.sha256(
+        json.dumps(build_files, sort_keys=True).encode()
+    ).hexdigest()
+    return f"{prefix}:{digest[:16]}"
+
+
+def _image_present(tag: str) -> bool:
+    probe = subprocess.run(["docker", "image", "inspect", tag], capture_output=True)
+    return probe.returncode == 0
+
+
+def _ensure_image(tag: str, context: str) -> None:
+    # Check docker each time, not a "built" memo: the image can be swept or pruned
+    # between episodes, and a stale memo would `docker run` a missing one.
+    if _image_present(tag):
+        return
+    subprocess.run(
+        ["docker", "build", "-q", "--label", _IMAGE_LABEL, "-t", tag, context],
+        check=True,
+        capture_output=True,
+        timeout=600,
+    )
+    _built_tags.add(tag)
+    global _sweep_registered
+    if not _sweep_registered:
+        atexit.register(_sweep_built_images)
+        _sweep_registered = True
+
+
+def _sweep_built_images() -> None:
+    for tag in _built_tags:
+        subprocess.run(["docker", "rmi", "-f", tag], capture_output=True)
+
+
 class ContainerWebappRuntime(WebappRuntime):
     """WebappRuntime that runs the world as a real Docker container.
 
@@ -259,9 +306,8 @@ class ContainerWebappRuntime(WebappRuntime):
         self._base_url: str | None = None
         self._log_offset = 0
         self._build_files = image_files(graph)
-        self._tag = f"openrange-cyber-{uuid.uuid4().hex[:12]}"
+        self._tag = _content_tag(self._build_files)
         self._cname: str | None = None
-        self._image_built = False
 
     def prepare_env_files(self, graph: WorldGraph) -> Mapping[str, str]:
         del graph
@@ -270,15 +316,8 @@ class ContainerWebappRuntime(WebappRuntime):
 
     def subprocess_command(self, env_root: Path, solver_root: Path) -> list[str]:
         del solver_root
-        if not self._image_built:
-            subprocess.run(
-                ["docker", "build", "-q", "-t", self._tag, str(env_root / "pack")],
-                check=True,
-                capture_output=True,
-                timeout=600,
-            )
-            self._image_built = True
-        self._cname = f"{self._tag}-{uuid.uuid4().hex[:8]}"
+        _ensure_image(self._tag, str(env_root / "pack"))
+        self._cname = f"openrange-cyber-{uuid.uuid4().hex[:12]}"
         return [
             "docker",
             "run",
@@ -334,8 +373,7 @@ class ContainerWebappRuntime(WebappRuntime):
         super().stop()  # kills the docker-run child; --rm removes the container
         if self._cname is not None:
             subprocess.run(["docker", "rm", "-f", self._cname], capture_output=True)
-        if self._image_built:
-            subprocess.run(["docker", "rmi", "-f", self._tag], capture_output=True)
+        # The image is content-addressed and reused across episodes — not deleted here.
 
 
 class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
@@ -355,6 +393,7 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
         self._internals = [s for s in self._services if s is not self._public]
         # The foreground child is the public service, not the whole-world image.
         self._build_files = self._public.build_files
+        self._tag = _content_tag(self._build_files)
         self._network = f"openrange-net-{uuid.uuid4().hex[:12]}"
         self._network_created = False
         self._internal_runs: list[tuple[str, str]] = []  # (container name, image tag)
@@ -396,7 +435,9 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
         if self._internal_runs:  # pragma: no cover - idempotent across resets
             return
         for service in self._internals:
-            tag = f"openrange-cyber-{service.name}-{uuid.uuid4().hex[:8]}"
+            tag = _content_tag(
+                service.build_files, prefix=f"openrange-cyber-{service.name}"
+            )
             cname = f"{self._network}-{service.name}"
             self._build_service_image(tag, service.build_files)
             subprocess.run(
@@ -427,12 +468,7 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
         try:
             for name, content in build_files.items():
                 (context / name).write_text(content, encoding="utf-8")
-            subprocess.run(
-                ["docker", "build", "-q", "-t", tag, str(context)],
-                check=True,
-                capture_output=True,
-                timeout=600,
-            )
+            _ensure_image(tag, str(context))
         finally:
             shutil.rmtree(context, ignore_errors=True)
 
@@ -484,10 +520,9 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
         return ()  # verdict comes from collect()'s full aggregated read, not offsets
 
     def stop(self) -> None:
-        super().stop()  # tears down the public child + its image
-        for cname, tag in self._internal_runs:
+        super().stop()  # tears down the public child (its image is kept for reuse)
+        for cname, _tag in self._internal_runs:
             subprocess.run(["docker", "rm", "-f", cname], capture_output=True)
-            subprocess.run(["docker", "rmi", "-f", tag], capture_output=True)
         self._internal_runs.clear()
         if self._network_created:
             subprocess.run(

--- a/tests/test_cyber_container.py
+++ b/tests/test_cyber_container.py
@@ -32,6 +32,7 @@ from cyber_webapp.container import (
     image_files,
     required_apt_packages,
 )
+from cyber_webapp.realize import _content_tag, _image_present
 from cyber_webapp.realize_admit import cmdi_exploit_and_benign
 from graphschema import Node, WorldGraph
 from openrange_pack_sdk import Backing, EpisodeResult, Snapshot
@@ -453,6 +454,30 @@ def test_container_runtime_reuses_the_image_across_resets() -> None:
 
 
 @pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
+def test_container_image_is_shared_across_episodes() -> None:
+    # Training gives each episode a NEW runtime, so the image is shared by content
+    # across runtimes — not rebuilt + deleted per episode.
+    graph = _admit_cmdi().graph
+    first = ContainerWebappRuntime(graph, Backing.CONTAINER)
+    second = ContainerWebappRuntime(graph, Backing.CONTAINER)
+    assert first._tag == second._tag == _content_tag(image_files(graph))
+    other = ContainerWebappRuntime(_admit_sqli().graph, Backing.CONTAINER)
+    assert other._tag != first._tag  # a different world → a different image
+    try:
+        first.reset()
+        assert str(first.surface()["base_url"]).startswith("http://127.0.0.1:")
+        first.stop()  # the episode ends — the image must NOT be deleted
+        assert _image_present(first._tag)
+        second.reset()  # a fresh runtime finds the image present → skips the build
+        assert str(second.surface()["base_url"]).startswith("http://127.0.0.1:")
+    finally:
+        # Stop the containers but keep the (shared, content-addressed) image — other
+        # episodes reuse it; the process-exit sweep removes it.
+        first.stop()
+        second.stop()
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
 def test_container_and_process_backings_grade_identically(tmp_path: Path) -> None:
     # The load-bearing parity check: the SAME snapshot + SAME exploit grades identically
     # on PROCESS (in-memory emulation) and CONTAINER (a real shell in a container).
@@ -562,3 +587,16 @@ def test_path_traversal_reads_a_real_file_in_a_container(
         miss = _http_get(base + _pt_url(graph, wrong))
     assert flag in hit, hit[:200]  # real open() recovers the real file via this escape
     assert flag not in miss  # a wrong-technique payload this confinement neutralizes
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
+def test_built_images_are_swept() -> None:
+    # The shutdown safety net: images reused across a run are force-removed at exit.
+    from cyber_webapp import realize as realize_mod
+
+    runtime = ContainerWebappRuntime(_admit_cmdi().graph, Backing.CONTAINER)
+    runtime.reset()
+    runtime.stop()  # the container is gone; the image stays for reuse
+    assert _image_present(runtime._tag)
+    realize_mod._sweep_built_images()  # the atexit cleanup, exercised directly
+    assert not _image_present(runtime._tag)


### PR DESCRIPTION
## What

First slice of #294. The cyber CONTAINER realizer rebuilt and deleted a byte-identical docker image **every episode**: it tagged each episode's image with a fresh `uuid`, ran `docker build`, and `docker rmi`'d it on teardown. The world graph is frozen and content-addressed, so the image is identical across every episode of a snapshot — yet it was rebuilt and destroyed each time. (The existing "reuse across resets" only helped a *single* runtime; training gives each episode a fresh runtime, so it rebuilt every time.)

This content-addresses the image by its build files: episodes of the same world share one image. The first episode builds it; the rest find it present and just `docker run`.

## Measured

Same per-episode CONTAINER boot, this Mac:

```
before:  ~2.8–3.2 s  every episode   (build + run + rmi)
after:   #1 3.24 s   (builds once)
         #2 0.17 s   (reuses → run only)
         #3 0.17 s
         #4 0.15 s
```

~18× faster after the first episode.

## How

- `_content_tag(build_files)` — `sha256` of the rendered build files → a stable tag per world.
- `_ensure_image(tag, ctx)` — builds only if absent (in-process memo + `docker image inspect`), labels the image `openrange.cyber.image=1`.
- `stop()` no longer `rmi`s — the image is reused across episodes and **swept at process exit** (`atexit`); a running container pins its image so docker skips those. Mirrors the `AgentSandbox` cleanup pattern.
- Applies to both the single-service `ContainerWebappRuntime` and the networked per-internal-service path.

## Tested

- `tests/test_cyber_container.py::test_container_image_is_shared_across_episodes` (new, docker-gated): two runtimes for the same world share a tag; a different world gets a different tag; the image **survives an episode's teardown** and is reused by the next — the training path, not just resets of one runtime.
- Full docker-gated suite green locally: `test_cyber_container.py` (24), `test_cyber_networked/lateral/company.py` (22), `test_trl_sandbox_episode.py` (4) — the last confirms the agent-sandbox-on-network path still resolves the world container after the `_cname` change. ruff + mypy + boundary clean.

## Scope

This is the cheap lever (stop the per-episode build+delete churn). The bigger one — keeping a booted world **warm** to also skip the ~2 s `docker run` + app startup — is the rest of #294, still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
