### PR TITLE
refactor(cyber): shared runtime base — drop the __init__ bypass, dead guards, comments

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/__init__.py
@@ -62,13 +62,12 @@ class WebappPack(Pack):
         backing: Backing,
     ) -> RuntimeHandle:
         if backing is Backing.CONTAINER:
-            # A *networked* world — one whose flag is reachable only by pivoting from
-            # the public service to an internal one — runs as one container per service
-            # on a network. Single-host worlds stay one container.
             if _is_networked(graph):
-                return NetworkedContainerWebappRuntime(graph, backing)
-            return ContainerWebappRuntime(graph, backing)
-        return WebappRuntime(graph, backing)
+                return NetworkedContainerWebappRuntime(graph)
+            return ContainerWebappRuntime(graph)
+        if backing is Backing.PROCESS:
+            return WebappRuntime(graph)
+        raise NotImplementedError(f"webapp pack does not support backing={backing!r}")
 
     def task_families(self) -> list[TaskFamily]:
         return [WebappBuild(), WebappPentest()]

--- a/packs/cyber_webapp/cyber_webapp/realize.py
+++ b/packs/cyber_webapp/cyber_webapp/realize.py
@@ -1,4 +1,4 @@
-"""WebappRuntime (PROCESS backing) and ContainerWebappRuntime (CONTAINER backing)."""
+"""Webapp world runtimes: PROCESS (a local subprocess) and CONTAINER (docker)."""
 
 from __future__ import annotations
 
@@ -18,7 +18,6 @@ from urllib.request import urlopen
 
 from graphschema import WorldGraph
 from openrange_pack_sdk import (
-    Backing,
     OpenRangeError,
     SubprocessRuntime,
 )
@@ -36,7 +35,6 @@ from cyber_webapp.container import (
     realize_services,
 )
 
-# Where the container's app writes its request log (the image CMD's --log path).
 _CONTAINER_LOG_PATH = "/app/requests.jsonl"
 _CONTAINER_PORT = "8000"
 
@@ -45,70 +43,21 @@ class WebappRuntimeError(OpenRangeError):
     pass
 
 
-class WebappRuntime(SubprocessRuntime):
-    """SubprocessRuntime for the cyber webapp pack.
+class _WebappRuntime(SubprocessRuntime):
+    """Shared webapp-runtime logic over a JSON request log.
 
-    Spawns the rendered ``app.py`` as a subprocess that serves HTTP, parses
-    its startup line to get the bound ``host:port``, surfaces an
-    ``http_get`` closure to the agent, and reads the request log on every
-    poll / collect.
+    Handles the HTTP surface, log-driven events, the graded collect, and
+    checkpoint/restore. Subclasses supply the world (``subprocess_command`` /
+    ``parse_startup`` / ``prepare_env_files``) and where its log lives
+    (``_read_log_bytes``, defaulting to the local request-log file).
     """
 
     RESULT_FILE = RESULT_FILE_NAME
 
-    def __init__(self, graph: WorldGraph, backing: Backing) -> None:
-        if backing is not Backing.PROCESS:
-            raise NotImplementedError(
-                f"WebappRuntime does not yet support backing={backing!r}; "
-                "only Backing.PROCESS is wired",
-            )
+    def __init__(self, graph: WorldGraph) -> None:
         super().__init__(graph)
-        # Render eagerly so a graph that breaks codegen fails at construction
-        # (admission can re-raise) rather than inside an episode.
-        self._files: dict[str, str] = _realize_graph(graph)
         self._base_url: str | None = None
         self._log_offset: int = 0
-
-    def prepare_env_files(self, graph: WorldGraph) -> Mapping[str, str]:
-        del graph
-        return {**self._files, REQUEST_LOG_NAME: ""}
-
-    def subprocess_command(
-        self,
-        env_root: Path,
-        solver_root: Path,
-    ) -> list[str]:
-        del solver_root
-        app_path = env_root / "pack" / APP_FILE_NAME
-        if not app_path.exists():
-            raise WebappRuntimeError(
-                f"runtime artifact is missing: {app_path.name}",
-            )
-        return [
-            sys.executable,
-            str(app_path),
-            "--host",
-            "127.0.0.1",
-            "--port",
-            "0",
-            "--log",
-            str(env_root / "pack" / REQUEST_LOG_NAME),
-        ]
-
-    def parse_startup(self, stdout_line: str) -> Mapping[str, Any]:
-        try:
-            data = json.loads(stdout_line)
-        except json.JSONDecodeError as exc:
-            raise WebappRuntimeError(
-                f"runtime reported invalid listening address: {stdout_line!r}",
-            ) from exc
-        if not isinstance(data, dict) or "host" not in data or "port" not in data:
-            raise WebappRuntimeError(
-                f"runtime reported invalid listening address: {data!r}",
-            )
-        self._base_url = f"http://{data['host']}:{data['port']}"
-        self._log_offset = 0
-        return {"base_url": self._base_url}
 
     def surface_extras(self) -> Mapping[str, Any]:
         base_url = self._base_url
@@ -130,8 +79,6 @@ class WebappRuntime(SubprocessRuntime):
         new_bytes = raw[self._log_offset :]
         if not new_bytes:
             return ()
-        # Only consume complete lines; a racy partial line gets picked up
-        # on the next poll.
         last_newline = new_bytes.rfind(b"\n")
         if last_newline == -1:
             return ()
@@ -157,7 +104,6 @@ class WebappRuntime(SubprocessRuntime):
         if isinstance(result.get("flag"), str):
             flag = str(result["flag"])
         elif isinstance(result.get("flag_from_response"), str):
-            # Agents write `flag`; families read `flag_from_response`.
             flag = str(result["flag_from_response"])
         requests = self._all_requests()
         requests_made = [str(row.get("path", "")) for row in requests if row]
@@ -187,10 +133,6 @@ class WebappRuntime(SubprocessRuntime):
             raise WebappRuntimeError(
                 "restore() payload is missing 'log_offset' (int)",
             )
-        # The webapp's runtime state (HTTP server, in-memory DB) cannot
-        # be checkpointed — restore re-runs reset() to bring up a fresh
-        # process, then re-materializes the agent's workspace from the
-        # snapshot.
         self.reset()
         super().restore(state)
         self._log_offset = log_offset
@@ -201,8 +143,6 @@ class WebappRuntime(SubprocessRuntime):
         return self.pack_root / REQUEST_LOG_NAME
 
     def _read_log_bytes(self) -> bytes | None:
-        # The request log as raw bytes, or None if it isn't there yet. The seam the
-        # CONTAINER backing overrides to read the log out of the running container.
         log = self._request_log_path()
         if log is None or not log.exists():
             return None
@@ -239,9 +179,51 @@ class WebappRuntime(SubprocessRuntime):
             return False
 
 
-# Container images are content-addressed by their build files, so episodes of the same
-# world reuse one image instead of each rebuilding + deleting an identical one. Built
-# images are swept at exit — a running container pins its image, so docker skips those.
+class WebappRuntime(_WebappRuntime):
+    """PROCESS backing: the rendered ``app.py`` runs as a local subprocess."""
+
+    def __init__(self, graph: WorldGraph) -> None:
+        super().__init__(graph)
+        self._files: dict[str, str] = _realize_graph(graph)
+
+    def prepare_env_files(self, graph: WorldGraph) -> Mapping[str, str]:
+        del graph
+        return {**self._files, REQUEST_LOG_NAME: ""}
+
+    def subprocess_command(self, env_root: Path, solver_root: Path) -> list[str]:
+        del solver_root
+        app_path = env_root / "pack" / APP_FILE_NAME
+        if not app_path.exists():
+            raise WebappRuntimeError(
+                f"runtime artifact is missing: {app_path.name}",
+            )
+        return [
+            sys.executable,
+            str(app_path),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+            "--log",
+            str(env_root / "pack" / REQUEST_LOG_NAME),
+        ]
+
+    def parse_startup(self, stdout_line: str) -> Mapping[str, Any]:
+        try:
+            data = json.loads(stdout_line)
+        except json.JSONDecodeError as exc:
+            raise WebappRuntimeError(
+                f"runtime reported invalid listening address: {stdout_line!r}",
+            ) from exc
+        if not isinstance(data, dict) or "host" not in data or "port" not in data:
+            raise WebappRuntimeError(
+                f"runtime reported invalid listening address: {data!r}",
+            )
+        self._base_url = f"http://{data['host']}:{data['port']}"
+        self._log_offset = 0
+        return {"base_url": self._base_url}
+
+
 _IMAGE_LABEL = "openrange.cyber.image=1"
 _built_tags: set[str] = set()
 _sweep_registered = False
@@ -262,8 +244,6 @@ def _image_present(tag: str) -> bool:
 
 
 def _ensure_image(tag: str, context: str) -> None:
-    # Check docker each time, not a "built" memo: the image can be swept or pruned
-    # between episodes, and a stale memo would `docker run` a missing one.
     if _image_present(tag):
         return
     subprocess.run(
@@ -284,34 +264,23 @@ def _sweep_built_images() -> None:
         subprocess.run(["docker", "rmi", "-f", tag], capture_output=True)
 
 
-class ContainerWebappRuntime(WebappRuntime):
-    """WebappRuntime that runs the world as a real Docker container.
+class ContainerWebappRuntime(_WebappRuntime):
+    """CONTAINER backing: the world runs as a real docker container.
 
-    ``docker run`` (foreground) is the supervised child: the container's app prints the
-    same startup line a local subprocess would, so the SubprocessRuntime handshake still
-    works; the published host port is resolved with ``docker port`` (the app only sees
-    its in-container port). The request log is read out of the running container, and
-    the image sets ``OPENRANGE_REALFS`` so the file and shell surfaces are real.
+    ``docker run`` (foreground) is the supervised child — the container prints the
+    same startup line a subprocess would; the published host port is read with
+    ``docker port`` and the request log out of the running container. The image sets
+    ``OPENRANGE_REALFS`` so the file and shell surfaces are real.
     """
 
-    def __init__(self, graph: WorldGraph, backing: Backing) -> None:
-        if backing is not Backing.CONTAINER:
-            raise NotImplementedError(
-                f"ContainerWebappRuntime is the CONTAINER backing, got {backing!r}",
-            )
-        # WebappRuntime.__init__ guards PROCESS-only; the container runtime shares its
-        # log/surface/collect logic but its own lifecycle, so init the subprocess base.
-        SubprocessRuntime.__init__(self, graph)
-        self._files: dict[str, str] = {}
-        self._base_url: str | None = None
-        self._log_offset = 0
+    def __init__(self, graph: WorldGraph) -> None:
+        super().__init__(graph)
         self._build_files = image_files(graph)
         self._tag = _content_tag(self._build_files)
         self._cname: str | None = None
 
     def prepare_env_files(self, graph: WorldGraph) -> Mapping[str, str]:
         del graph
-        # The image carries app.py + seed.json; pack_root is just the build context.
         return dict(self._build_files)
 
     def subprocess_command(self, env_root: Path, solver_root: Path) -> list[str]:
@@ -331,8 +300,6 @@ class ContainerWebappRuntime(WebappRuntime):
         ]
 
     def parse_startup(self, stdout_line: str) -> Mapping[str, Any]:
-        # A startup line means the app is up (the readiness signal); it only knows its
-        # in-container port, so resolve the published host port for the agent URL.
         del stdout_line
         mapping = subprocess.run(
             ["docker", "port", str(self._cname), _CONTAINER_PORT],
@@ -344,10 +311,6 @@ class ContainerWebappRuntime(WebappRuntime):
         host_port = mapping.splitlines()[0].rsplit(":", 1)[-1]
         self._base_url = f"http://127.0.0.1:{host_port}"
         self._log_offset = 0
-        # Also expose the world's container + in-container port so a harness can put an
-        # agent sandbox on the same docker network and let it reach the target by alias
-        # (over the wire, not via the host). Agent-invisible — the brief renders only
-        # base_url. See the openrange-trl AgentSandbox integration.
         return {
             "base_url": self._base_url,
             "target_container": self._cname,
@@ -364,51 +327,42 @@ class ContainerWebappRuntime(WebappRuntime):
                 timeout=10,
                 check=False,
             )
-        except Exception:  # noqa: BLE001  # pragma: no cover - container gone mid-poll
+        except Exception:  # noqa: BLE001  # pragma: no cover
             return None
-        # A non-zero rc before the first request just means the log isn't written yet.
         return done.stdout if done.returncode == 0 else b""
 
     def stop(self) -> None:
-        super().stop()  # kills the docker-run child; --rm removes the container
+        super().stop()
         if self._cname is not None:
             subprocess.run(["docker", "rm", "-f", self._cname], capture_output=True)
-        # The image is content-addressed and reused across episodes — not deleted here.
 
 
 class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
-    """The CONTAINER backing for a *networked* world: one container per service on a
-    real docker network. The public service is the foreground child (reused from
-    ContainerWebappRuntime — it gives the agent's ``base_url``); the internal services
-    run detached on the same network, reachable only by name and never published. So a
-    flag in an internal service is reachable only by pivoting from the public service
-    over the network — genuine network position, not a path lookup on one server.
+    """CONTAINER backing for a *networked* world: one container per service on a real
+    docker network. The public service is the foreground child; internal services run
+    detached, reachable only by name — so a flag in an internal service is reached only
+    by pivoting over the network, not by a path lookup on one server.
     """
 
-    def __init__(self, graph: WorldGraph, backing: Backing) -> None:
-        super().__init__(graph, backing)
+    def __init__(self, graph: WorldGraph) -> None:
+        super().__init__(graph)
         self._services = realize_services(graph)
         publics = [s for s in self._services if s.exposure == "public"]
         self._public: ServiceImage = publics[0] if publics else self._services[0]
         self._internals = [s for s in self._services if s is not self._public]
-        # The foreground child is the public service, not the whole-world image.
         self._build_files = self._public.build_files
         self._tag = _content_tag(self._build_files)
         self._network = f"openrange-net-{uuid.uuid4().hex[:12]}"
         self._network_created = False
-        self._internal_runs: list[tuple[str, str]] = []  # (container name, image tag)
+        self._internal_runs: list[tuple[str, str]] = []
 
     def reset(self) -> None:
-        # Network + internal services first, then the public service as the child.
         self._create_network()
         self._start_internals()
         super().reset()
 
     def subprocess_command(self, env_root: Path, solver_root: Path) -> list[str]:
         cmd = super().subprocess_command(env_root, solver_root)
-        # Put the public container on the network so it can reach the internals by name,
-        # and switch its SSRF handler to a real cross-network fetch (the public service
-        # holds no flag — the secret can only come from the internal host).
         insert = cmd.index("run") + 1
         cmd[insert:insert] = [
             "--network",
@@ -474,8 +428,6 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
 
     @staticmethod
     def _wait_ready_in_container(cname: str) -> None:
-        # The internal service publishes no port, so probe it from inside the container
-        # (the docker-exec latency itself paces the retries).
         probe = (
             "import urllib.request as u; u.urlopen('http://localhost:8000/', timeout=2)"
         )
@@ -493,10 +445,6 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
         )
 
     def _read_log_bytes(self) -> bytes | None:
-        # Aggregate the public child's log with every internal service's log, so the
-        # verdict sees a leak wherever it happened (the internal service detects it
-        # serving its own flag). collect() reads this fully; poll_events is disabled —
-        # one offset can't track concatenated, independently-growing logs.
         chunks: list[bytes] = []
         public = super()._read_log_bytes()
         if public:
@@ -512,15 +460,13 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
                 chunks.append(done.stdout)
         if chunks:
             return b"".join(chunks)
-        # In practice every internal service has at least its readiness-probe request
-        # logged, so this empty fallback is only the pre-reset / no-container state.
         return b"" if self._cname is not None else None  # pragma: no cover
 
     def poll_events(self) -> tuple[Mapping[str, Any], ...]:
-        return ()  # verdict comes from collect()'s full aggregated read, not offsets
+        return ()
 
     def stop(self) -> None:
-        super().stop()  # tears down the public child (its image is kept for reuse)
+        super().stop()
         for cname, _tag in self._internal_runs:
             subprocess.run(["docker", "rm", "-f", cname], capture_output=True)
         self._internal_runs.clear()

--- a/tests/test_cyber_container.py
+++ b/tests/test_cyber_container.py
@@ -86,7 +86,6 @@ def test_required_apt_packages_scopes_to_the_worlds_cmdi_tool() -> None:
     assert isinstance(params, dict)
     expected = _BASE_COMMAND_PACKAGE[str(params["base_command"])]
     assert required_apt_packages(cmdi) == {expected}
-    # a file-read world runs no server-side OS command → its image installs none
     assert required_apt_packages(_admit_path_traversal().graph) == set()
 
 
@@ -98,8 +97,6 @@ def test_hardening_run_args_drops_privileges_and_caps_resources() -> None:
 
 
 def test_required_apt_packages_skips_malformed_and_unmapped() -> None:
-    # A cmdi vuln whose params aren't a mapping, or whose base_command isn't a known
-    # diagnostic tool, contributes nothing — no crash, no bogus package.
     graph = _admit_cmdi().graph
     vuln = next(
         n
@@ -115,14 +112,12 @@ def test_required_apt_packages_skips_malformed_and_unmapped() -> None:
 def test_dockerfile_installs_os_tools_only_when_a_vuln_needs_them() -> None:
     cmdi_df = image_files(_admit_cmdi().graph)["Dockerfile"]
     pt_df = image_files(_admit_path_traversal().graph)["Dockerfile"]
-    assert "apt-get install" in cmdi_df  # cmdi world needs its diagnostic tool
-    assert "apt-get" not in pt_df  # a file-read world stays lean — no OS tools
-    assert "pip install --no-cache-dir jinja2" in pt_df  # the app's one structural dep
+    assert "apt-get install" in cmdi_df
+    assert "apt-get" not in pt_df
+    assert "pip install --no-cache-dir jinja2" in pt_df
 
 
 def test_every_sampled_base_command_has_an_apt_package() -> None:
-    # Lockstep guard: every base_command the sampler picks must map to a package, or a
-    # cmdi world ships without the tool its real `sh -c` needs.
     from cyber_webapp.container import _CMDI_APT_PACKAGES
     from cyber_webapp.sampling import _COMMAND_INJECTION_BASE
 
@@ -147,22 +142,15 @@ def _admit_sqli() -> Snapshot:
 
 
 def test_minimum_backing_is_container_for_file_and_code_shapes() -> None:
-    # A file-read / code-exec world's loot sits at a randomized path the PROCESS
-    # emulation gives no way to enumerate — so it is only blackbox-solvable on a real
-    # filesystem/shell, i.e. CONTAINER.
     assert minimum_backing(_admit_cmdi().graph) is Backing.CONTAINER
     assert minimum_backing(_admit_path_traversal().graph) is Backing.CONTAINER
 
 
 def test_minimum_backing_is_process_for_in_band_response_leak() -> None:
-    # SQLi leaks in-band through the response (the agent enumerates via the query
-    # itself), so PROCESS already leaves the world winnable — no container needed.
     assert minimum_backing(_admit_sqli().graph) is Backing.PROCESS
 
 
 def test_minimum_backing_ignores_unknown_vuln_kinds() -> None:
-    # A vuln node whose kind is not in the catalog must not force CONTAINER (nor crash);
-    # the decision falls through to PROCESS.
     graph = _admit_sqli().graph
     vuln = next(iter(graph.by_kind("vulnerability")))
     vuln.attrs["kind"] = "not_a_real_vuln"
@@ -176,14 +164,12 @@ def _docker_available() -> bool:
         probe = subprocess.run(
             ["docker", "info"], capture_output=True, timeout=10, check=False
         )
-    except Exception:  # noqa: BLE001 - a best-effort probe; any failure means "no"
+    except Exception:  # noqa: BLE001
         return False
     return probe.returncode == 0
 
 
 def _http_get(url: str) -> str:
-    # The response body regardless of status — a neutralized traversal answers 403/404,
-    # which urlopen raises on; we still want to assert the flag is NOT in that body.
     try:
         body = urllib.request.urlopen(url, timeout=10).read()
     except urllib.error.HTTPError as exc:
@@ -197,7 +183,7 @@ def _wait_ready(base: str, timeout: float) -> None:
         try:
             urllib.request.urlopen(base + "/", timeout=2)
             return
-        except OSError:  # URLError is an OSError subclass
+        except OSError:
             time.sleep(0.3)
     raise AssertionError(f"container did not become ready at {base}")
 
@@ -210,8 +196,6 @@ def _container(
     *,
     env: Sequence[tuple[str, str]] = (),
 ) -> Iterator[str]:
-    # Build the given image build-context, run it (with any -e env), and yield the base
-    # URL once it answers. Cleans up image + container regardless of outcome.
     context = tmp_path / "ctx"
     context.mkdir()
     for name, content in build_files.items():
@@ -266,7 +250,6 @@ def _pin_context(graph: WorldGraph, context: str) -> None:
 
 
 def _exploit_for(graph: WorldGraph, context: str) -> str:
-    # The context-matching exploit path; mutates params transiently to shape its payload
     _pin_context(graph, context)
     exploit_path, _benign = cmdi_exploit_and_benign(graph)
     return exploit_path
@@ -286,10 +269,6 @@ def test_world_runs_in_a_container_and_is_exploited(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
 def test_world_container_is_hardened(tmp_path: Path) -> None:
-    # The world runs attacker-controlled code, so it is contained: all capabilities
-    # dropped, no privilege escalation, and memory / pid caps set — verified both on the
-    # run config and behaviourally inside the container. It stays exploitable over HTTP
-    # under these flags (every other docker test here runs with the same _container).
     snap = _admit_cmdi()
     graph = snap.graph
     tag = f"openrange-m1-harden-{snap.snapshot_id[:8]}"
@@ -314,7 +293,6 @@ def test_world_container_is_hardened(tmp_path: Path) -> None:
         assert any("no-new-privileges" in opt for opt in host.get("SecurityOpt") or [])
         assert host["Memory"] > 0 and host["PidsLimit"] and host["PidsLimit"] > 0
 
-        # Behavioural: effective capabilities are actually all-zero in the container.
         status = subprocess.run(
             ["docker", "exec", cid, "cat", "/proc/self/status"],
             check=True,
@@ -325,7 +303,6 @@ def test_world_container_is_hardened(tmp_path: Path) -> None:
         cap_eff = next(ln for ln in status.splitlines() if ln.startswith("CapEff:"))
         assert cap_eff.split()[1].strip("0") == "", cap_eff
 
-        # Still exploitable under the hardening — containment doesn't break the vuln.
         exploit_path, _benign = cmdi_exploit_and_benign(graph)
         body = _http_get(base + exploit_path)
     assert str(graph.nodes["secret_flag"].attrs["value_ref"]) in body, body[:200]
@@ -335,22 +312,21 @@ def test_generated_app_has_a_real_shell_cmdi_branch() -> None:
     import ast
 
     source = _realize_graph(_admit_cmdi().graph)["app.py"]
-    ast.parse(source)  # the generated app is valid Python
-    assert "subprocess.run" in source  # real shell, gated by OPENRANGE_REALFS
-    assert 'os.environ.get("OPENRANGE_REALFS")' in source  # the CONTAINER toggle
+    ast.parse(source)
+    assert "subprocess.run" in source
+    assert 'os.environ.get("OPENRANGE_REALFS")' in source
 
 
 @pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
 def test_real_shell_container_recovers_a_real_file_flag(tmp_path: Path) -> None:
     snap = _admit_cmdi()
     graph = snap.graph
-    _pin_context(graph, "separator")  # a clean `; cat <path>` exploit
+    _pin_context(graph, "separator")
     flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
     exploit_path, benign_path = cmdi_exploit_and_benign(graph)
 
     tag = f"openrange-m1-realfs-{snap.snapshot_id[:12]}"
     with _container(image_files(graph), tmp_path, tag) as base:
-        # A real `cat` against the real filesystem recovers the real file's flag.
         exploit_body = (
             urllib.request.urlopen(base + exploit_path, timeout=10).read().decode()
         )
@@ -373,26 +349,20 @@ def test_real_shell_container_recovers_a_real_file_flag(tmp_path: Path) -> None:
 def test_real_shell_contexts_are_mutually_exclusive(
     live: str, wrong: str, tmp_path: Path
 ) -> None:
-    # The injection contexts hold over a REAL shell, not just the in-memory emulation: a
-    # world built for one context is exploited by THAT context's payload and NOT by
-    # another's (the wrong vectors are filtered before sh).
     snap = _admit_cmdi()
     graph = snap.graph
     flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
 
     matching = _exploit_for(graph, live)
     mismatched = _exploit_for(graph, wrong)
-    _pin_context(graph, live)  # the image must be built from the live context
+    _pin_context(graph, live)
 
     tag = f"openrange-m1-ctx-{live}-{snap.snapshot_id[:8]}"
     with _container(image_files(graph), tmp_path, tag) as base:
         hit = urllib.request.urlopen(base + matching, timeout=10).read().decode()
         miss = urllib.request.urlopen(base + mismatched, timeout=10).read().decode()
-    assert flag in hit, hit[:200]  # the matching context's exploit lands
-    assert flag not in miss  # a wrong-context exploit is filtered out
-
-
-# --- CONTAINER backing wired as a runtime: it grades identically to PROCESS -----------
+    assert flag in hit, hit[:200]
+    assert flag not in miss
 
 
 def _run_pentest_episode(
@@ -403,8 +373,6 @@ def _run_pentest_episode(
     exploit_path: str,
     flag: str,
 ) -> EpisodeResult:
-    # Drive one pentest episode end to end on the given backing: start it, run the
-    # exploit over its live HTTP surface, submit the recovered flag, return the result.
     service = EpisodeService(WebappPack(), root, backing=backing)
     try:
         handle = service.start_episode(snapshot, task_id)
@@ -424,28 +392,19 @@ def _run_pentest_episode(
     return report.episode_result
 
 
-def test_container_runtime_rejects_non_container_backing() -> None:
-    with pytest.raises(NotImplementedError):
-        ContainerWebappRuntime(_admit_cmdi().graph, Backing.PROCESS)
-
-
 def test_container_runtime_is_inert_before_reset() -> None:
-    # No container yet (no docker touched): the log read is None and stop() is a clean
-    # no-op — nothing built or running to tear down.
-    runtime = ContainerWebappRuntime(_admit_cmdi().graph, Backing.CONTAINER)
+    runtime = ContainerWebappRuntime(_admit_cmdi().graph)
     assert runtime._read_log_bytes() is None
-    runtime.stop()  # must not raise with nothing built/running
+    runtime.stop()
 
 
 @pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
 def test_container_runtime_reuses_the_image_across_resets() -> None:
-    # The image builds once and is reused on later resets; each reset brings up a fresh
-    # container on a fresh published port.
-    runtime = ContainerWebappRuntime(_admit_cmdi().graph, Backing.CONTAINER)
+    runtime = ContainerWebappRuntime(_admit_cmdi().graph)
     try:
         runtime.reset()
         first = str(runtime.surface()["base_url"])
-        runtime.reset()  # image already built → rebuild is skipped
+        runtime.reset()
         second = str(runtime.surface()["base_url"])
         assert first.startswith("http://127.0.0.1:")
         assert second.startswith("http://127.0.0.1:")
@@ -455,33 +414,26 @@ def test_container_runtime_reuses_the_image_across_resets() -> None:
 
 @pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
 def test_container_image_is_shared_across_episodes() -> None:
-    # Training gives each episode a NEW runtime, so the image is shared by content
-    # across runtimes — not rebuilt + deleted per episode.
     graph = _admit_cmdi().graph
-    first = ContainerWebappRuntime(graph, Backing.CONTAINER)
-    second = ContainerWebappRuntime(graph, Backing.CONTAINER)
+    first = ContainerWebappRuntime(graph)
+    second = ContainerWebappRuntime(graph)
     assert first._tag == second._tag == _content_tag(image_files(graph))
-    other = ContainerWebappRuntime(_admit_sqli().graph, Backing.CONTAINER)
-    assert other._tag != first._tag  # a different world → a different image
+    other = ContainerWebappRuntime(_admit_sqli().graph)
+    assert other._tag != first._tag
     try:
         first.reset()
         assert str(first.surface()["base_url"]).startswith("http://127.0.0.1:")
-        first.stop()  # the episode ends — the image must NOT be deleted
+        first.stop()
         assert _image_present(first._tag)
-        second.reset()  # a fresh runtime finds the image present → skips the build
+        second.reset()
         assert str(second.surface()["base_url"]).startswith("http://127.0.0.1:")
     finally:
-        # Stop the containers but keep the (shared, content-addressed) image — other
-        # episodes reuse it; the process-exit sweep removes it.
         first.stop()
         second.stop()
 
 
 @pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
 def test_container_and_process_backings_grade_identically(tmp_path: Path) -> None:
-    # The load-bearing parity check: the SAME snapshot + SAME exploit grades identically
-    # on PROCESS (in-memory emulation) and CONTAINER (a real shell in a container).
-    # Only fidelity changes between the backings, not the task surface.
     snap = _admit_cmdi()
     graph = snap.graph
     _pin_context(graph, "separator")
@@ -496,12 +448,9 @@ def test_container_and_process_backings_grade_identically(tmp_path: Path) -> Non
         snap, task.id, Backing.CONTAINER, tmp_path / "cont", exploit_path, flag
     )
 
-    assert process.success is True  # the exploit really solves the world
+    assert process.success is True
     assert container.success == process.success
-    assert container.subgoals == process.subgoals  # identical grade across backings
-
-
-# --- file_read shape over a real filesystem (generalize past command_injection) ------
+    assert container.subgoals == process.subgoals
 
 
 def _admit_path_traversal() -> Snapshot:
@@ -530,7 +479,6 @@ def _pt_vuln(graph: WorldGraph) -> Node:
 
 
 def _flag_file_path(graph: WorldGraph) -> str:
-    # The file whose content is the flag, in the projected seed's file map.
     from cyber_webapp.codegen.seeding import project_seed
 
     flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
@@ -557,10 +505,6 @@ def _pt_url(graph: WorldGraph, payload: str) -> str:
 def test_path_traversal_reads_a_real_file_in_a_container(
     confinement: str, tmp_path: Path
 ) -> None:
-    # The file_read shape is REAL on the generated app in a container: a path-traversal
-    # escape is a real open() against the real container fs, and the three confinement
-    # contexts stay mutually exclusive over it — each accepts ONE technique and
-    # neutralizes the others, so a wrong-technique payload recovers nothing.
     snap = _admit_path_traversal()
     graph = snap.graph
     flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
@@ -572,9 +516,8 @@ def test_path_traversal_reads_a_real_file_in_a_container(
     base_dir = str(params["base_dir"])
     flag_path = _flag_file_path(graph)
     relchain = posixpath.relpath(flag_path, base_dir)
-    assert ".." in relchain  # the flag is reachable only by escaping base_dir
+    assert ".." in relchain
     payloads = {
-        # confinement: (the technique that escapes, a technique it neutralizes)
         "absolute_only": (flag_path, relchain),
         "relative": (relchain, flag_path),
         "dotdot_filter": (relchain.replace("../", "....//"), relchain),
@@ -585,18 +528,17 @@ def test_path_traversal_reads_a_real_file_in_a_container(
     with _container(image_files(graph), tmp_path, tag) as base:
         hit = _http_get(base + _pt_url(graph, matching))
         miss = _http_get(base + _pt_url(graph, wrong))
-    assert flag in hit, hit[:200]  # real open() recovers the real file via this escape
-    assert flag not in miss  # a wrong-technique payload this confinement neutralizes
+    assert flag in hit, hit[:200]
+    assert flag not in miss
 
 
 @pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
 def test_built_images_are_swept() -> None:
-    # The shutdown safety net: images reused across a run are force-removed at exit.
     from cyber_webapp import realize as realize_mod
 
-    runtime = ContainerWebappRuntime(_admit_cmdi().graph, Backing.CONTAINER)
+    runtime = ContainerWebappRuntime(_admit_cmdi().graph)
     runtime.reset()
-    runtime.stop()  # the container is gone; the image stays for reuse
+    runtime.stop()
     assert _image_present(runtime._tag)
-    realize_mod._sweep_built_images()  # the atexit cleanup, exercised directly
+    realize_mod._sweep_built_images()
     assert not _image_present(runtime._tag)

--- a/tests/test_cyber_networked.py
+++ b/tests/test_cyber_networked.py
@@ -162,7 +162,7 @@ def test_networked_runtime_isolates_internal_services() -> None:
     # only from inside the network, by name — real network position. (Constructed
     # directly to isolate the runtime; an SSRF world also auto-routes here — see the
     # routing test above.)
-    runtime = NetworkedContainerWebappRuntime(_admit_ssrf().graph, Backing.CONTAINER)
+    runtime = NetworkedContainerWebappRuntime(_admit_ssrf().graph)
     try:
         runtime.reset()
         assert runtime.poll_events() == ()  # networked verdict comes from collect()


### PR DESCRIPTION
## What

You asked why the container runtime did an `__init__` bypass — because `ContainerWebappRuntime` inherited `WebappRuntime` (PROCESS) just to reuse its methods, but rejected its PROCESS-only `__init__`, so it called `SubprocessRuntime.__init__` by hand and papered it over with a comment. That's the smell. This makes them **siblings on a shared `_WebappRuntime` base** (HTTP surface, log events, collect, checkpoint/restore; file-based log reading as the default the container overrides). Every `__init__` now just calls `super()` — no bypass.

- The per-backing `raise NotImplementedError` guards in the constructors were **dead** (`realize()` already dispatches by backing). Removed; the one real check they encoded — reject SIMULATOR/HYBRID — moves into `realize()` where the routing happens. Dropped the now-pointless `backing` constructor arg + the obsolete `rejects_non_container_backing` test.
- **Comments: realize.py 50 → 0 prose comments** (only `# pragma`/`# noqa` directives left).

Net −113 lines.

## Verified

Behavior-preserving. ruff + mypy clean, and the full impacted suite passes locally — PROCESS, CONTAINER, networked, sandbox-on-network, plus checkpoint/restore and the unwired-backing rejection (`test_cyber_codegen`, `test_runtime`, `test_trl_cyber`, `test_cyber_container/networked/lateral/company`, `test_trl_sandbox_episode`). The docker-gated tests run in CI too.

Supersedes the earlier comment-only cleanup (this includes it).