### PR TITLE
feat(trl): make the cyber example a real multi-service company on Docker

### DIFF
--- a/examples/trl_grpo_cyber.ipynb
+++ b/examples/trl_grpo_cyber.ipynb
@@ -2,27 +2,23 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "80d85d85",
+   "id": "2b1b9810",
    "metadata": {},
    "source": [
-    "# Train a model to exploit a live web service with TRL GRPO + LoRA\n",
+    "# Train a model to compromise a multi-service company with TRL GRPO + LoRA\n",
     "\n",
-    "OpenRange admits **content-addressed** agent-training worlds. This notebook trains\n",
-    "a small model on the *cyber* pack: every rollout boots a **real HTTP server** with\n",
-    "a planted vulnerability, and the policy must **exploit it over the wire** and\n",
-    "exfiltrate a hidden flag — graded by the world itself, no static dataset of\n",
-    "\"correct\" attacks.\n",
+    "OpenRange admits **content-addressed, evolving** agent-training worlds. This notebook\n",
+    "trains a small model on the *cyber* pack's flagship: a **believable company** — a public\n",
+    "storefront in a dmz, plus internal APIs and databases on a segmented network. The flag is\n",
+    "a production-style credential **confined to an internal service**, with no front door. To\n",
+    "get it, the agent must **recon the estate, find a foothold (an SSRF on the storefront),\n",
+    "and pivot dmz→internal** over the network — graded by the world itself, no static dataset\n",
+    "of \"correct\" attacks.\n",
     "\n",
-    "It is the same torch-free TRL seam that also trains file-editing agents, with a cyber **action surface**:\n",
-    "the policy gets the `http_get` and `submit` tools you pass in. The adapter is\n",
-    "unchanged — the generic `EpisodeEnv` reflects whatever tools you bring (these are\n",
-    "OpenRange's reference `WEB_TOOLS`; bring your own to change the surface).\n",
-    "\n",
-    "Runs on a laptop (MPS or CUDA). The point is that **training is a loop that evolves\n",
-    "the world**: §3 maps the reward surface, then §7 runs the loop — and you watch the\n",
-    "gym **harden the world** as it gets solved (driven by a reference policy on a\n",
-    "laptop, by the model's own climb on a GPU). The opposite of grinding one fixed\n",
-    "benchmark.\n",
+    "It runs on **real Docker**: each rollout boots **one container per service** on a real\n",
+    "segmented network (and falls back to an in-process emulation when Docker isn't there).\n",
+    "Same torch-free TRL seam, same `http_get` / `submit` tools you bring — only the world\n",
+    "got real, and it **hardens as the agent improves**.\n",
     "\n",
     "For the simplest file-editing surface (a one-line bug fix), see\n",
     "`trl_grpo_lora.ipynb`."
@@ -30,7 +26,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "182aca87",
+   "id": "2fc783a2",
    "metadata": {},
    "source": [
     "## 1. Install\n",
@@ -39,98 +35,32 @@
     "uv pip install \"openrange-trl[train]\"   # torch, transformers, trl, datasets, accelerate, peft\n",
     "```\n",
     "\n",
-    "`import openrange` never needs this extra — only the live training path below does."
+    "`import openrange` never needs this extra — only the live training path below does. The\n",
+    "**CONTAINER** path needs a running Docker engine; the in-process fallback needs nothing."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1e1681f7",
+   "id": "2d6753bf",
    "metadata": {},
    "source": [
-    "## 2. Admit a cyber world\n",
+    "## 2. Admit the company world\n",
     "\n",
-    "`admit` freezes a procedural cyber world into a **content-addressed snapshot**. We\n",
-    "pin a **SQL-injection** world (`vuln_kinds`, `seed=0`): a deterministic target whose\n",
-    "pentest entrypoint is an injectable `GET` over a `db`-backed endpoint. Each world\n",
-    "yields two tasks (`webapp.build`, `webapp.pentest`); we train on the offensive one."
+    "`company: True` flips the procedural builder onto a segmented 6–8-service estate —\n",
+    "deterministic and LLM-free, so this snapshot is byte-identical on every machine. We also\n",
+    "pick the backing: real Docker if it's running, else the in-process emulation."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "873c9d13",
+   "id": "3900e6b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T19:33:44.308723Z",
-     "iopub.status.busy": "2026-06-15T19:33:44.308586Z",
-     "iopub.status.idle": "2026-06-15T19:33:44.605965Z",
-     "shell.execute_reply": "2026-06-15T19:33:44.605507Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'sha256:0279d1d5a9df43477abdf88d277fd91e44db3f5dd8a01f66d82ee9148c8625f6'"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from cyber_webapp import WebappPack\n",
-    "\n",
-    "from openrange.core.admit import AdmissionFailure, admit\n",
-    "\n",
-    "pack = WebappPack()\n",
-    "snapshot = admit(\n",
-    "    pack,\n",
-    "    manifest={\n",
-    "        \"world\": {\"goal\": \"recover the hidden flag\"},\n",
-    "        \"pack\": {\"id\": \"webapp\"},\n",
-    "        \"runtime\": {\"tick\": {\"mode\": \"off\"}},\n",
-    "        \"npc\": [],\n",
-    "        \"seed\": 0,\n",
-    "        # Pin the shape so the world is reproducibly a SQL-injection-over-the-response\n",
-    "        # target (a `db` response-leak + the `sql_injection` oracle), independent of the\n",
-    "        # pack's default vuln mix.\n",
-    "        \"loot_shapes\": {\"db\": 1, \"file\": 0},\n",
-    "        \"vuln_kinds\": {\"sql_injection\": 1},\n",
-    "    },\n",
-    ")\n",
-    "assert not isinstance(snapshot, AdmissionFailure), snapshot\n",
-    "snapshot.snapshot_id"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "452b67a0",
-   "metadata": {},
-   "source": [
-    "## 3. See the reward before you train\n",
-    "\n",
-    "The reward is the world's held-out verdict over the **HTTP path**. The pentest\n",
-    "family scores three subgoals — reach the endpoint, extract *something*, submit the\n",
-    "*right* flag — so `episode_reward` yields a four-rung surface. Driving the env's\n",
-    "tools by hand maps it: no model, no GPU, one fresh booted server per call.\n",
-    "\n",
-    "We read the injection's coordinates (endpoint, parameter, table/column, quote\n",
-    "context) from the world graph, run a **real SQL injection** that leaks the hidden\n",
-    "column, and exfiltrate the flag from the response — the top rung."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "a812c6ef",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-15T19:33:44.607155Z",
-     "iopub.status.busy": "2026-06-15T19:33:44.607048Z",
-     "iopub.status.idle": "2026-06-15T19:33:44.844546Z",
-     "shell.execute_reply": "2026-06-15T19:33:44.844169Z"
+     "iopub.execute_input": "2026-06-16T13:34:09.159276Z",
+     "iopub.status.busy": "2026-06-16T13:34:09.159204Z",
+     "iopub.status.idle": "2026-06-16T13:34:09.550700Z",
+     "shell.execute_reply": "2026-06-16T13:34:09.550055Z"
     }
    },
    "outputs": [
@@ -138,21 +68,183 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "no-op (no request)     reward=0.000  resolved=False\n",
-      "reach endpoint         reward=0.333  resolved=False\n",
-      "reach + wrong flag     reward=0.667  resolved=False\n",
-      "exploit + submit       reward=1.000  resolved=True\n"
+      "world ce3e3fcec648   backing=CONTAINER\n"
+     ]
+    }
+   ],
+   "source": [
+    "import shutil\n",
+    "import subprocess\n",
+    "\n",
+    "from cyber_webapp import WebappPack\n",
+    "from openrange_pack_sdk import Backing, Snapshot\n",
+    "\n",
+    "from openrange.core.admit import admit\n",
+    "\n",
+    "pack = WebappPack()\n",
+    "snapshot = admit(\n",
+    "    pack,\n",
+    "    manifest={\n",
+    "        \"world\": {\"goal\": \"recover the hidden flag from the internal estate\"},\n",
+    "        \"pack\": {\"id\": \"webapp\"},\n",
+    "        \"runtime\": {\"tick\": {\"mode\": \"off\"}},\n",
+    "        \"npc\": [],\n",
+    "        \"seed\": 3,\n",
+    "        \"company\": True,\n",
+    "    },\n",
+    "    max_repairs=3,\n",
+    ")\n",
+    "assert isinstance(snapshot, Snapshot), snapshot\n",
+    "\n",
+    "\n",
+    "def docker_ok():\n",
+    "    if shutil.which(\"docker\") is None:\n",
+    "        return False\n",
+    "    try:\n",
+    "        probe = subprocess.run(\n",
+    "            [\"docker\", \"info\"], capture_output=True, timeout=10, check=False\n",
+    "        )\n",
+    "    except Exception:\n",
+    "        return False\n",
+    "    return probe.returncode == 0\n",
+    "\n",
+    "\n",
+    "BACKING = Backing.CONTAINER if docker_ok() else Backing.PROCESS\n",
+    "print(f\"world {snapshot.snapshot_id[-12:]}   backing={BACKING.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c21d1c6",
+   "metadata": {},
+   "source": [
+    "## 3. The estate\n",
+    "\n",
+    "A read-only walk of the world graph — no runtime. A public **storefront** in the `dmz`;\n",
+    "the rest internal on an **isolated** network. The flag is a hidden credential confined to\n",
+    "an internal database service — the storefront is the only way in, so the pivot is\n",
+    "mandatory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0bf8859e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-16T13:34:09.552477Z",
+     "iopub.status.busy": "2026-06-16T13:34:09.552148Z",
+     "iopub.status.idle": "2026-06-16T13:34:09.557857Z",
+     "shell.execute_reply": "2026-06-16T13:34:09.557386Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8 services across networks ['dmz', 'internal']\n",
+      "\n",
+      "  orders-db        internal  internal   <- holds the flag\n",
+      "  orders-api       internal  internal \n",
+      "  users-db         internal  internal \n",
+      "  billing-db       internal  internal \n",
+      "  catalog-api      internal  internal \n",
+      "  payments-api     internal  internal \n",
+      "  ledger-db        internal  internal \n",
+      "  storefront       public    dmz        <- public entry (the only way in)\n",
+      "\n",
+      "flag: a hidden credential on 'orders-db' (internal) — reachable only by\n",
+      "pivoting from 'storefront' via the SSRF on its endpoint.\n"
+     ]
+    }
+   ],
+   "source": [
+    "g = snapshot.graph\n",
+    "services = list(g.by_kind(\"service\"))\n",
+    "public = next(s for s in services if s.attrs.get(\"exposure\") == \"public\")\n",
+    "ssrf = next(v for v in g.by_kind(\"vulnerability\") if v.attrs.get(\"kind\") == \"ssrf\")\n",
+    "flag_host = ssrf.attrs[\"params\"][\"internal_host\"]\n",
+    "\n",
+    "\n",
+    "def network_of(svc):\n",
+    "    edge = next(e for e in g.out_edges(svc.id, \"connected_to\"))\n",
+    "    return g.nodes[edge.dst].attrs[\"name\"]\n",
+    "\n",
+    "\n",
+    "nets = sorted({network_of(s) for s in services})\n",
+    "print(f\"{len(services)} services across networks {nets}\\n\")\n",
+    "for s in sorted(services, key=lambda s: s.attrs.get(\"exposure\")):\n",
+    "    tag = \"\"\n",
+    "    if s.attrs.get(\"exposure\") == \"public\":\n",
+    "        tag = \"  <- public entry (the only way in)\"\n",
+    "    elif s.attrs[\"name\"] == flag_host:\n",
+    "        tag = \"  <- holds the flag\"\n",
+    "    print(\n",
+    "        f\"  {s.attrs['name']:<16} {s.attrs.get('exposure'):<9} {network_of(s):<9}{tag}\"\n",
+    "    )\n",
+    "print(f\"\\nflag: a hidden credential on '{flag_host}' (internal) — reachable only by\")\n",
+    "print(f\"pivoting from '{public.attrs['name']}' via the SSRF on its endpoint.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03aa8f63",
+   "metadata": {},
+   "source": [
+    "## 4. See the reward before you train\n",
+    "\n",
+    "The reward is the world's held-out verdict over the **HTTP path** — three subgoals: reach\n",
+    "the entry, extract *something*, submit the *right* flag. Driving the env's tools by hand\n",
+    "maps three behaviors onto it (no model, no GPU). The richest is the **full breach**: reach\n",
+    "the storefront, **SSRF-pivot into the internal service, and exfiltrate the credential** —\n",
+    "every coordinate read from the world graph (no hardcoded secrets) via the pack's reference\n",
+    "solver."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "93f9fe0f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-16T13:34:09.559418Z",
+     "iopub.status.busy": "2026-06-16T13:34:09.559341Z",
+     "iopub.status.idle": "2026-06-16T13:34:26.565058Z",
+     "shell.execute_reply": "2026-06-16T13:34:26.563941Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reach the storefront       reward=0.333  resolved=False\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reach + wrong flag         reward=0.667  resolved=False\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recon + pivot + breach     reward=1.000  resolved=True\n"
      ]
     }
    ],
    "source": [
     "import json\n",
     "import re\n",
-    "from urllib.parse import urlencode\n",
     "\n",
+    "from cyber_webapp.reference_solver import solve_chain\n",
     "from openrange_trl import EpisodeEnv\n",
     "\n",
-    "from examples.tools import WEB_TOOLS  # the reference http_get + submit tools\n",
+    "from examples.tools import WEB_TOOLS\n",
     "from openrange.core.episode import EpisodeService\n",
     "\n",
     "\n",
@@ -160,157 +252,145 @@
     "    return next(t for t in snap.tasks if t.meta.get(\"family\") == \"webapp.pentest\")\n",
     "\n",
     "\n",
-    "def exploit_path(snap):\n",
-    "    # Read the injection's coordinates from *this* world's graph and match its\n",
-    "    # quote context — a constant payload breaks as the world evolves. The hidden\n",
-    "    # flag sits in a column the base query never selects, so a UNION pulls it.\n",
-    "    task = pentest_task(snap)\n",
-    "    entry = snap.graph.nodes[task.entrypoints[0]].attrs[\"public_url\"]\n",
-    "    p = next(\n",
-    "        v.attrs[\"params\"]\n",
-    "        for v in snap.graph.by_kind(\"vulnerability\")\n",
-    "        if v.attrs.get(\"kind\") == \"sql_injection\"\n",
+    "def entry_url(snap):\n",
+    "    return snap.graph.nodes[pentest_task(snap).entrypoints[0]].attrs[\"public_url\"]\n",
+    "\n",
+    "\n",
+    "def flag_from(body):\n",
+    "    try:\n",
+    "        obj = json.loads(body)\n",
+    "    except json.JSONDecodeError:\n",
+    "        obj = None\n",
+    "    if isinstance(obj, dict):\n",
+    "        for key in (\"credential\", \"data\", \"flag\", \"secret\"):\n",
+    "            if isinstance(obj.get(key), str):\n",
+    "                return obj[key]\n",
+    "    found = re.search(\n",
+    "        r\"(?:ghp_|gho_|sk_live_|AKIA)[A-Za-z0-9_]+|[0-9a-f-]{32,36}\", body\n",
     "    )\n",
-    "    union = f\"UNION SELECT key, {p['leak_column']} FROM {p['table']} -- \"\n",
-    "    prefix = {\"numeric\": \"0 \", \"double\": '\" '}.get(p.get(\"context\"), \"' \")\n",
-    "    return f\"{entry}?{urlencode({p['target_param']: prefix + union})}\"\n",
+    "    return found.group(0) if found else \"\"\n",
     "\n",
     "\n",
-    "def exfiltrate(response):\n",
-    "    body = response.split(chr(10), 1)[-1]\n",
-    "    uuid = r\"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\"\n",
-    "    for row in json.loads(body).get(\"rows\", []):\n",
-    "        for value in row.values():\n",
-    "            if re.fullmatch(uuid, str(value)):\n",
-    "                return str(value)\n",
-    "    return \"\"\n",
-    "\n",
-    "\n",
-    "def solve(env, snap):\n",
-    "    env.submit(json.dumps({\"flag\": exfiltrate(env.http_get(exploit_path(snap)))}))\n",
+    "def breach(env, snap):\n",
+    "    env.http_get(entry_url(snap))\n",
+    "    trace = solve_chain(snap.graph, lambda p: env.http_get(p).split(chr(10), 1)[-1])\n",
+    "    env.submit(json.dumps({\"flag\": flag_from(trace.terminal)}))\n",
     "\n",
     "\n",
     "def grade(name, act):\n",
-    "    svc = EpisodeService(pack, f\"or-runs/cyber/{name}\")\n",
+    "    svc = EpisodeService(pack, f\"or-runs/cyber/{name}\", backing=BACKING)\n",
     "    env = EpisodeEnv(\n",
     "        service=svc, snapshots={snapshot.snapshot_id: snapshot}, tools=WEB_TOOLS\n",
     "    )\n",
     "    env.reset(snapshot_id=snapshot.snapshot_id, task_id=pentest_task(snapshot).id)\n",
     "    act(env)\n",
     "    env._finalize()\n",
-    "    print(f\"{name:<22} reward={env.reward:.3f}  resolved={env.report.passed}\")\n",
+    "    print(f\"{name:<26} reward={env.reward:.3f}  resolved={env.report.passed}\")\n",
     "    svc.close()\n",
     "\n",
     "\n",
-    "entry = snapshot.graph.nodes[pentest_task(snapshot).entrypoints[0]].attrs[\"public_url\"]\n",
-    "\n",
-    "\n",
-    "def reach(e):\n",
-    "    e.http_get(entry)\n",
-    "\n",
-    "\n",
-    "def wrong(e):\n",
-    "    e.http_get(entry)\n",
-    "    e.submit(json.dumps({\"flag\": \"guess\"}))\n",
-    "\n",
-    "\n",
-    "grade(\"no-op (no request)\", lambda e: None)\n",
-    "grade(\"reach endpoint\", reach)\n",
-    "grade(\"reach + wrong flag\", wrong)\n",
-    "grade(\"exploit + submit\", lambda e: solve(e, snapshot))"
+    "entry = entry_url(snapshot)\n",
+    "grade(\"reach the storefront\", lambda e: e.http_get(entry))\n",
+    "grade(\n",
+    "    \"reach + wrong flag\",\n",
+    "    lambda e: (e.http_get(entry), e.submit(json.dumps({\"flag\": \"guess\"}))),\n",
+    ")\n",
+    "grade(\"recon + pivot + breach\", lambda e: breach(e, snapshot))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4f7d5433",
+   "id": "947b3d16",
    "metadata": {},
    "source": [
-    "Four behaviors, four distinct grades:\n",
+    "Three behaviors, three grades:\n",
     "\n",
     "| behavior | reward | why |\n",
     "|------|--------|-----|\n",
-    "| no-op | **0.0** | no subgoal touched |\n",
-    "| reach endpoint | **0.333** | `reached_endpoint` only |\n",
+    "| reach the storefront | **0.333** | `reached_endpoint` only |\n",
     "| reach + wrong flag | **0.667** | `+ extracted_anything`, but wrong |\n",
-    "| exploit + submit | **1.0** | SQLi exfiltrates the real flag → success |\n",
+    "| recon + pivot + breach | **1.0** | breached: pivoted dmz→internal, exfiltrated the credential |\n",
     "\n",
-    "That `0.0 → 1.0` ladder is the **spread GRPO turns into a gradient**. Training is\n",
-    "teaching the policy to find the *targeted* injection on its own. (This surface is\n",
-    "asserted live in `tests/test_trl_cyber.py`, so it can't silently drift.)"
+    "That `0.333 → 1.0` spread is what GRPO turns into a gradient. `matched_flag == success` — the\n",
+    "agent has to actually **submit the right credential**, which it can only get by pivoting,\n",
+    "not by poking the storefront. (This surface is asserted in `tests/test_cyber_company.py`.)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7ee84019",
+   "id": "cde726a1",
    "metadata": {},
    "source": [
-    "## 4. Wrap the world as a TRL environment\n",
+    "## 5. Wrap the company world as a TRL environment\n",
     "\n",
-    "The torch-free adapter exposes the three seams TRL needs, with the web action\n",
-    "surface — the tools you bring (here OpenRange's reference `WEB_TOOLS`):\n",
+    "The torch-free adapter exposes the three seams TRL needs — `build_grpo_dataset` (the\n",
+    "pentest prompt rows), `make_environment_factory` (one `EpisodeEnv` per rollout), and\n",
+    "`make_reward_func` (the held-out grader). We build them once here to show the wiring; §8\n",
+    "rebuilds the rows and factory per evolved world and reuses this `reward_func`.\n",
     "\n",
-    "- **`build_grpo_dataset`** — the prompt rows (we keep the pentest task), tagged\n",
-    "  with `snapshot_id`. The policy sees the tools via TRL's tool schemas, so a row\n",
-    "  is just the task instruction.\n",
-    "- **`make_environment_factory(..., tools=WEB_TOOLS)`** — one `EpisodeEnv` per\n",
-    "  rollout: a fresh booted server, with the tools you pass (`http_get`, `submit`)\n",
-    "  bound to it.\n",
-    "- **`make_reward_func`** — grades the final interaction with the held-out verdict."
+    "With `backing=CONTAINER`, each rollout boots the world's **per-service containers on a\n",
+    "docker network**, with the storefront published on a host port the policy's `http_get`\n",
+    "reaches. `sandbox=False` — the in-process policy talks to the world over the wire with the\n",
+    "tools you bring (`http_get`, `submit`)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "5f042eb0",
+   "execution_count": 4,
+   "id": "972058b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T19:33:44.845781Z",
-     "iopub.status.busy": "2026-06-15T19:33:44.845708Z",
-     "iopub.status.idle": "2026-06-15T19:33:45.910116Z",
-     "shell.execute_reply": "2026-06-15T19:33:45.909749Z"
+     "iopub.execute_input": "2026-06-16T13:34:26.567436Z",
+     "iopub.status.busy": "2026-06-16T13:34:26.567258Z",
+     "iopub.status.idle": "2026-06-16T13:34:27.733074Z",
+     "shell.execute_reply": "2026-06-16T13:34:27.732213Z"
     }
    },
    "outputs": [],
    "source": [
     "from datasets import Dataset\n",
-    "from openrange_trl import (\n",
-    "    build_grpo_dataset,\n",
-    "    make_environment_factory,\n",
-    "    make_reward_func,\n",
-    ")\n",
+    "from openrange_trl import build_grpo_dataset, make_environment_factory, make_reward_func\n",
     "\n",
+    "num_generations = 2\n",
     "rows = [\n",
-    "    row for row in build_grpo_dataset(snapshot, repeat=4) if \"pentest\" in row[\"task_id\"]\n",
+    "    r\n",
+    "    for r in build_grpo_dataset(snapshot, repeat=num_generations)\n",
+    "    if \"pentest\" in r[\"task_id\"]\n",
     "]\n",
     "dataset = Dataset.from_list(rows)\n",
     "environment_factory = make_environment_factory(\n",
-    "    pack, [snapshot], \"or-runs/cyber/envs\", tools=WEB_TOOLS\n",
+    "    pack,\n",
+    "    [snapshot],\n",
+    "    \"or-runs/cyber/envs\",\n",
+    "    tools=WEB_TOOLS,\n",
+    "    backing=BACKING,\n",
+    "    sandbox=False,\n",
     ")\n",
     "reward_func = make_reward_func()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6cfb4c40",
+   "id": "42745ca9",
    "metadata": {},
    "source": [
-    "## 5. Load the policy + a LoRA adapter\n",
+    "## 6. Load the policy + a LoRA adapter\n",
     "\n",
-    "LoRA adapters on a small instruct model — the base stays frozen (fits a laptop),\n",
-    "GRPO updates only the low-rank adapters. Bump `model_name` to a larger instruct\n",
-    "model for rollouts strong enough to actually land the injection."
+    "LoRA on a small instruct model — the base stays frozen (fits a laptop), GRPO updates only\n",
+    "the low-rank adapters. Bump `model_name` to a larger instruct model for rollouts strong\n",
+    "enough to actually land the pivot."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "43d60920",
+   "execution_count": 5,
+   "id": "a754841e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T19:33:45.911299Z",
-     "iopub.status.busy": "2026-06-15T19:33:45.911233Z",
-     "iopub.status.idle": "2026-06-15T19:33:48.532785Z",
-     "shell.execute_reply": "2026-06-15T19:33:48.532342Z"
+     "iopub.execute_input": "2026-06-16T13:34:27.734492Z",
+     "iopub.status.busy": "2026-06-16T13:34:27.734397Z",
+     "iopub.status.idle": "2026-06-16T13:34:30.291273Z",
+     "shell.execute_reply": "2026-06-16T13:34:30.290784Z"
     }
    },
    "outputs": [
@@ -327,14 +407,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Loading weights: 100%|██████████| 290/290 [00:00<00:00, 10377.51it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "Loading weights: 100%|██████████| 290/290 [00:00<00:00, 10703.80it/s]"
      ]
     }
    ],
@@ -357,36 +430,34 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a037cdda",
+   "id": "4570f927",
    "metadata": {},
    "source": [
-    "## 6. Configure GRPO\n",
+    "## 7. Configure GRPO\n",
     "\n",
-    "Each step samples `num_generations` completions of the **same** prompt — and\n",
-    "`make_environment_factory` boots **one fresh server per completion**, so those N\n",
-    "rollouts are N live worlds attacked **at once** and graded together. `beta=0` drops\n",
-    "the reference model; `use_vllm=False` generates through transformers;\n",
-    "`max_tool_calling_iterations` bounds the recon→exploit→submit turns. `max_steps=1`\n",
-    "makes one call here **one training round** — §7 wraps rounds into the curriculum."
+    "`num_generations` completions of the same prompt, each against its own freshly booted\n",
+    "company. `beta=0` drops the reference model; `use_vllm=False` generates through\n",
+    "transformers; `max_tool_calling_iterations` is raised to **8** because recon → pivot →\n",
+    "submit is several turns, not the one-shot of a single-service bug. `max_steps=1` makes one\n",
+    "call here **one training round** — §8 wraps rounds into the curriculum."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "977bf84b",
+   "execution_count": 6,
+   "id": "ec5ea299",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T19:33:48.534502Z",
-     "iopub.status.busy": "2026-06-15T19:33:48.534188Z",
-     "iopub.status.idle": "2026-06-15T19:33:48.617126Z",
-     "shell.execute_reply": "2026-06-15T19:33:48.616635Z"
+     "iopub.execute_input": "2026-06-16T13:34:30.292977Z",
+     "iopub.status.busy": "2026-06-16T13:34:30.292672Z",
+     "iopub.status.idle": "2026-06-16T13:34:30.379537Z",
+     "shell.execute_reply": "2026-06-16T13:34:30.379105Z"
     }
    },
    "outputs": [],
    "source": [
     "from trl import GRPOConfig\n",
     "\n",
-    "num_generations = 4\n",
     "config = GRPOConfig(\n",
     "    output_dir=\"or-runs/cyber/trainer\",\n",
     "    per_device_train_batch_size=num_generations,\n",
@@ -398,7 +469,7 @@
     "    beta=0.0,\n",
     "    temperature=1.0,\n",
     "    max_completion_length=256,\n",
-    "    max_tool_calling_iterations=4,\n",
+    "    max_tool_calling_iterations=8,\n",
     "    use_vllm=False,\n",
     "    log_completions=False,\n",
     "    logging_steps=1,\n",
@@ -412,30 +483,29 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d78733aa",
+   "id": "67c87834",
    "metadata": {},
    "source": [
-    "## 7. Train — and the world trains back\n",
+    "## 8. Train — and the company hardens back\n",
     "\n",
-    "Training here is a **loop**, not gradient steps on a fixed task. Each round runs\n",
-    "GRPO on the current world; then `auto_evolve` reads the round's reward spread and\n",
-    "moves the world toward the policy's frontier — **harden** when the group is solving,\n",
-    "**soften** when it's stuck — re-admits it (so the new world is still provably\n",
-    "solvable), and the next round trains on *that*. One round is one\n",
-    "`GRPOTrainer.train()`. The gym tracks the agent — this is what \"not a static\n",
-    "benchmark\" means in practice."
+    "Training is a **loop**: each round runs GRPO on the current world, then `auto_evolve` reads\n",
+    "the group's reward spread and, when the world is being solved, **plants a new vulnerability**\n",
+    "on the estate — a decoy the agent must tell apart from the real path — re-admits it (so the\n",
+    "harder world is still provably solvable), and the next round trains on that. We gate\n",
+    "evolution to the pentest family the agent trains on, so every step changes the breach world.\n",
+    "One round is one `GRPOTrainer.train()`; here's a real one against the live containers:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "b9e469dd",
+   "execution_count": 7,
+   "id": "9277400c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T19:33:48.618562Z",
-     "iopub.status.busy": "2026-06-15T19:33:48.618482Z",
-     "iopub.status.idle": "2026-06-15T19:34:10.255197Z",
-     "shell.execute_reply": "2026-06-15T19:34:10.254612Z"
+     "iopub.execute_input": "2026-06-16T13:34:30.380796Z",
+     "iopub.status.busy": "2026-06-16T13:34:30.380725Z",
+     "iopub.status.idle": "2026-06-16T13:34:54.901333Z",
+     "shell.execute_reply": "2026-06-16T13:34:54.900531Z"
     }
    },
    "outputs": [
@@ -443,9 +513,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0.5017', 'grad_norm': '2.517e+05', 'learning_rate': '0.0001', 'num_tokens': '2011', 'completions/mean_length': '127.8', 'completions/min_length': '74', 'completions/max_length': '256', 'completions/clipped_ratio': '0.25', 'completions/mean_terminated_length': '85', 'completions/min_terminated_length': '74', 'completions/max_terminated_length': '98', 'tools/call_frequency': '0.75', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.25', 'rewards/reward_func/std': '0.1667', 'reward': '0.25', 'reward_std': '0.1667', 'frac_reward_zero_std': '0', 'entropy': '3.35', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '20.19', 'epoch': '0.25'}\n",
-      "{'train_runtime': '20.5', 'train_samples_per_second': '0.195', 'train_steps_per_second': '0.049', 'train_loss': '0.5017', 'epoch': '0.25'}\n",
-      "one real GRPO round → rewards [0.0, 0.333, 0.333, 0.333]\n"
+      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '0.0001', 'num_tokens': '1071', 'completions/mean_length': '164.5', 'completions/min_length': '73', 'completions/max_length': '256', 'completions/clipped_ratio': '0.5', 'completions/mean_terminated_length': '73', 'completions/min_terminated_length': '73', 'completions/max_terminated_length': '73', 'tools/call_frequency': '0.5', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.3333', 'rewards/reward_func/std': '0', 'reward': '0.3333', 'reward_std': '0', 'frac_reward_zero_std': '1', 'entropy': '4.401', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '22.88', 'epoch': '0.5'}\n",
+      "{'train_runtime': '23.07', 'train_samples_per_second': '0.087', 'train_steps_per_second': '0.043', 'train_loss': '0', 'epoch': '0.5'}\n",
+      "one real GRPO round → rewards [0.333, 0.333]\n"
      ]
     }
    ],
@@ -464,7 +534,12 @@
     "        if \"pentest\" in r[\"task_id\"]\n",
     "    ]\n",
     "    factory = make_environment_factory(\n",
-    "        pack, [snap], f\"or-runs/cyber/{snap.snapshot_id[-12:]}\", tools=WEB_TOOLS\n",
+    "        pack,\n",
+    "        [snap],\n",
+    "        f\"or-runs/cyber/{snap.snapshot_id[-12:]}\",\n",
+    "        tools=WEB_TOOLS,\n",
+    "        backing=BACKING,\n",
+    "        sandbox=False,\n",
     "    )\n",
     "    trainer = GRPOTrainer(\n",
     "        model=model,\n",
@@ -480,33 +555,37 @@
     "\n",
     "\n",
     "reports = grpo_round(snapshot)\n",
-    "rewards = [round(episode_reward(r).scalar, 3) for r in reports]\n",
-    "print(\"one real GRPO round → rewards\", rewards)"
+    "print(\n",
+    "    \"one real GRPO round → rewards\",\n",
+    "    [round(episode_reward(r).scalar, 3) for r in reports],\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "18c21237",
+   "id": "984b4f68",
    "metadata": {},
    "source": [
-    "On a laptop the 0.5B mostly **reaches the endpoint but never lands the flag**, so the\n",
-    "reward spread stays alive and `auto_evolve` *holds* the world (mastery needs a bigger\n",
-    "model + GPU, where the policy's climb collapses the spread and drives the curriculum).\n",
-    "To watch the loop **move** now, drive each round with the reference `solve` from §3 —\n",
-    "a stand-in for a trained policy. Swap `grpo_round` back in on a GPU; the loop below is\n",
-    "identical."
+    "That round changed nothing: both rollouts scored the same `0.333`, so the spread is zero\n",
+    "and GRPO has no gradient to learn from. On a live world that `0.333` is essentially free —\n",
+    "the running storefront answers a readiness probe before the agent acts — and the 0.5B never\n",
+    "climbs above it: it doesn't pivot to the internal credential. A real climb needs a bigger\n",
+    "model on a GPU, where rollouts genuinely differ. To watch the **loop** itself — solve,\n",
+    "harden, repeat — we stand in the §4 reference breach for that competent policy and run\n",
+    "several rounds; each solve hardens the company. Swap `grpo_round` back in on a GPU and the\n",
+    "policy's own climb drives it."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "9eea1ccb",
+   "execution_count": 8,
+   "id": "1ee78765",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T19:34:10.257835Z",
-     "iopub.status.busy": "2026-06-15T19:34:10.257749Z",
-     "iopub.status.idle": "2026-06-15T19:34:12.888229Z",
-     "shell.execute_reply": "2026-06-15T19:34:12.887849Z"
+     "iopub.execute_input": "2026-06-16T13:34:54.904317Z",
+     "iopub.status.busy": "2026-06-16T13:34:54.904192Z",
+     "iopub.status.idle": "2026-06-16T13:35:30.770337Z",
+     "shell.execute_reply": "2026-06-16T13:35:30.769863Z"
     }
    },
    "outputs": [
@@ -514,50 +593,39 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "round 1: e9148c8625f6  rewards=[1.0, 1.0, 1.0, 1.0]  →  build level 2 on ep_orders-api_0\n"
+      "round 1: world ce3e3fcec648  rewards=[1.0, 1.0]  →  add broken_authz on ep_billing-db_0\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "round 2: c25fabbbdc2e  rewards=[1.0, 1.0, 1.0, 1.0]  →  build level 3 on ep_orders-api_0\n"
+      "round 2: world 998555639550  rewards=[1.0, 1.0]  →  add command_injection on ep_billing-db_0\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "round 3: abc8470d00d3  rewards=[1.0, 1.0, 1.0, 1.0]  →  add broken_authz on ep_orders-db_0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "round 4: 41114faeae7a  rewards=[1.0, 1.0, 1.0, 1.0]  →  add command_injection on ep_orders-db_0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "round 5: 9eb0ac5a4341  rewards=[1.0, 1.0, 1.0, 1.0]  →  add config_disclosure on ep_orders-db_0\n"
+      "round 3: world 54eb8c709473  rewards=[1.0, 1.0]  →  add credential_gated_flag on ep_billing-db_0\n"
      ]
     }
    ],
    "source": [
     "def scripted_round(snap):\n",
-    "    # A reference policy that always solves — a stand-in for a trained model, so the\n",
-    "    # curriculum visibly climbs without a GPU.\n",
     "    factory = make_environment_factory(\n",
-    "        pack, [snap], f\"or-runs/cyber/evolve-{snap.snapshot_id[-12:]}\", tools=WEB_TOOLS\n",
+    "        pack,\n",
+    "        [snap],\n",
+    "        f\"or-runs/cyber/evolve-{snap.snapshot_id[-12:]}\",\n",
+    "        tools=WEB_TOOLS,\n",
+    "        backing=BACKING,\n",
+    "        sandbox=False,\n",
     "    )\n",
     "    reports = []\n",
     "    for _ in range(num_generations):\n",
     "        env = factory()\n",
     "        env.reset(snapshot_id=snap.snapshot_id, task_id=pentest_task(snap).id)\n",
-    "        solve(env, snap)\n",
+    "        breach(env, snap)\n",
     "        env._finalize()\n",
     "        reports.append(env.report)\n",
     "        env.service.close()\n",
@@ -565,8 +633,6 @@
     "\n",
     "\n",
     "def evolve_meta(snap):\n",
-    "    # The patch path nests _evolve under the re-admitted manifest; a builder-grow\n",
-    "    # writes it at the top level. Read whichever is present.\n",
     "    return snap.lineage.get(\"_evolve\") or snap.lineage.get(\"manifest\", {}).get(\n",
     "        \"_evolve\", {}\n",
     "    )\n",
@@ -577,12 +643,20 @@
     "    for r in range(1, rounds + 1):\n",
     "        reports = run_round(snap)\n",
     "        rewards = [round(episode_reward(x).scalar, 3) for x in reports]\n",
-    "        evolved = auto_evolve(snap, *reports, pack=pack, policy=reward_variance_policy)\n",
+    "        evolved = auto_evolve(\n",
+    "            snap,\n",
+    "            *reports,\n",
+    "            pack=pack,\n",
+    "            policy=reward_variance_policy,\n",
+    "            gate=lambda _snap, mut: mut.family == \"webapp.pentest\",\n",
+    "        )\n",
     "        meta = {} if evolved is None else evolve_meta(evolved)\n",
     "        move = (\n",
     "            \"converged\" if evolved is None else meta.get(\"note\", meta.get(\"kind\", \"\"))\n",
     "        )\n",
-    "        print(f\"round {r}: {snap.snapshot_id[-12:]}  rewards={rewards}  →  {move}\")\n",
+    "        print(\n",
+    "            f\"round {r}: world {snap.snapshot_id[-12:]}  rewards={rewards}  →  {move}\"\n",
+    "        )\n",
     "        if evolved is None:\n",
     "            break\n",
     "        snap = evolved\n",
@@ -590,32 +664,32 @@
     "    return chain\n",
     "\n",
     "\n",
-    "chain = run_curriculum(snapshot, rounds=5, run_round=scripted_round)"
+    "chain = run_curriculum(snapshot, rounds=3, run_round=scripted_round)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "077d9b0e",
+   "id": "105f83a3",
    "metadata": {},
    "source": [
-    "## 8. The curriculum is a lineage\n",
+    "## 9. The curriculum is a lineage\n",
     "\n",
-    "Every round's world is a fresh, **admission-checked** child snapshot — `auto_evolve`\n",
-    "mutates the graph, re-admits (so the harder world is still provably solvable), and\n",
-    "tags the child with its parent. Training doesn't grind one fixed task; it produces a\n",
-    "**chain of worlds**, each content-addressed and fully attributable."
+    "Each round's world is a fresh, **admission-checked** child snapshot — `auto_evolve` mutates\n",
+    "the company's vuln surface, re-admits (so the harder world is still provably solvable), and\n",
+    "tags the child with its parent. The estate's *shape* is fixed at admit time; what evolves is\n",
+    "the attack surface around it. Training produces a **chain of worlds**, fully attributable."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "a374702f",
+   "execution_count": 9,
+   "id": "0e168699",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-15T19:34:12.889365Z",
-     "iopub.status.busy": "2026-06-15T19:34:12.889289Z",
-     "iopub.status.idle": "2026-06-15T19:34:12.891528Z",
-     "shell.execute_reply": "2026-06-15T19:34:12.891174Z"
+     "iopub.execute_input": "2026-06-16T13:35:30.771686Z",
+     "iopub.status.busy": "2026-06-16T13:35:30.771599Z",
+     "iopub.status.idle": "2026-06-16T13:35:30.773751Z",
+     "shell.execute_reply": "2026-06-16T13:35:30.773415Z"
     }
    },
    "outputs": [
@@ -623,19 +697,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "e9148c8625f6  parent=        root  vulns=['sql_injection', 'sql_injection', 'sql_injection']\n",
-      "c25fabbbdc2e  parent=e9148c8625f6  vulns=['sql_injection', 'sql_injection', 'sql_injection']\n",
-      "abc8470d00d3  parent=c25fabbbdc2e  vulns=['sql_injection', 'sql_injection', 'sql_injection']\n",
-      "41114faeae7a  parent=abc8470d00d3  vulns=['broken_authz', 'sql_injection', 'sql_injection', 'sql_injection']\n",
-      "9eb0ac5a4341  parent=41114faeae7a  vulns=['broken_authz', 'command_injection', 'sql_injection', 'sql_injection', 'sql_injection']\n",
-      "40178f1a5bcb  parent=9eb0ac5a4341  vulns=['broken_authz', 'command_injection', 'config_disclosure', 'sql_injection', 'sql_injection', 'sql_injection']\n"
+      "ce3e3fcec648  parent=        root  vulns=['config_disclosure', 'metadata_credential_leak', 'ssrf', 'xxe', 'xxe']\n",
+      "998555639550  parent=ce3e3fcec648  vulns=['broken_authz', 'config_disclosure', 'metadata_credential_leak', 'ssrf', 'xxe', 'xxe']\n",
+      "54eb8c709473  parent=998555639550  vulns=['broken_authz', 'command_injection', 'config_disclosure', 'metadata_credential_leak', 'ssrf', 'xxe', 'xxe']\n",
+      "40b1afc4324c  parent=54eb8c709473  vulns=['broken_authz', 'command_injection', 'config_disclosure', 'credential_gated_flag', 'metadata_credential_leak', 'ssrf', 'xxe', 'xxe']\n"
      ]
     }
    ],
    "source": [
     "for snap in chain:\n",
     "    kinds = sorted(\n",
-    "        str(n.attrs.get(\"kind\")) for n in snap.graph.by_kind(\"vulnerability\")\n",
+    "        str(v.attrs.get(\"kind\")) for v in snap.graph.by_kind(\"vulnerability\")\n",
     "    )\n",
     "    parent = (evolve_meta(snap).get(\"parent_snapshot_id\") or \"\")[-12:] or \"root\"\n",
     "    print(f\"{snap.snapshot_id[-12:]}  parent={parent:>12}  vulns={kinds}\")"
@@ -643,27 +715,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cac2979c",
+   "id": "fee451d7",
    "metadata": {},
    "source": [
     "## Where this goes\n",
     "\n",
-    "You watched the world **evolve with the agent** — that loop is the whole point: the\n",
-    "gym hardens toward wherever the policy is, instead of handing it the same fixed task\n",
-    "forever. Two things take it past a laptop:\n",
+    "You watched an agent breach a **real, multi-service company** — recon the estate, pivot\n",
+    "dmz→internal over the network, exfiltrate a confined credential — and the gym **harden** in\n",
+    "response. Two things take it past a laptop:\n",
     "\n",
-    "- **A real climb.** Swap the reference `solve` for `grpo_round` + a larger instruct\n",
-    "  model on a GPU. Now the *policy's* own improvement collapses the reward spread and\n",
-    "  drives the evolution — the same loop, no stand-in.\n",
-    "- **Throughput.** Each round's `num_generations` rollouts boot at once; TRL's\n",
-    "  `AsyncGRPOTrainer` pipelines hundreds against a vLLM server with the same\n",
-    "  `make_environment_factory`. Both trainers reset worlds serially, so a pooled /\n",
-    "  fast world realization is the gym-side lever that keeps a big batch from stalling\n",
-    "  on boots (#294).\n",
+    "- **A real climb.** Swap the reference breach for `grpo_round` + a larger instruct model on a\n",
+    "  GPU. Now the *policy's* own improvement drives the hardening, no stand-in.\n",
+    "- **Throughput.** Each rollout boots a whole company; TRL's `AsyncGRPOTrainer` pipelines many\n",
+    "  against a vLLM server with the same `make_environment_factory`. Both trainers reset worlds\n",
+    "  serially, so a pooled / fast world realization is the gym-side lever that keeps a big batch\n",
+    "  from stalling on container boots (#294).\n",
     "\n",
-    "The torch-free seam + reward/curriculum tests live in `openrange-trl` +\n",
-    "`tests/test_trl_cyber.py`; the gated test that runs a real `GRPOTrainer` across\n",
-    "evolving rounds is `tests/test_trl_live.py`."
+    "Honest scope: a laptop-scale model doesn't complete the pivot — the reward surface and the\n",
+    "breach are real and proven (§4), but mastery needs GPU-scale compute. The deterministic world + reward tests live in `packs/cyber_webapp` +\n",
+    "`tests/test_cyber_company.py`."
    ]
   }
  ],

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -17,7 +17,9 @@ from cyber_webapp import NetworkedContainerWebappRuntime, WebappPack, _is_networ
 from cyber_webapp.reference_solver import solve_chain
 from graphschema import Node, WorldGraph
 from openrange_pack_sdk import Backing, Snapshot
+from openrange_trl import EpisodeEnv
 
+from examples.tools import WEB_TOOLS
 from openrange.core.admit import admit
 from openrange.core.episode import EpisodeService
 
@@ -131,6 +133,53 @@ def test_company_solves_on_process(tmp_path: Path) -> None:
         assert all(flag not in probe for probe in trace.probes)
     finally:
         svc.close()
+
+
+def test_company_reward_surface_grades_the_breach(tmp_path: Path) -> None:
+    # The notebook's reward surface (examples/trl_grpo_cyber.ipynb §4), pinned on the
+    # company world: reaching the storefront earns 1/3, a wrong flag 2/3, and the full
+    # recon→pivot→exfiltrate breach 1.0 (passed). That spread is the GRPO gradient.
+    snap = _admit(_COMPANY_MANIFEST)
+    graph = snap.graph
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    pentest = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+    entry = str(graph.nodes[pentest.entrypoints[0]].attrs["public_url"])
+
+    services: list[EpisodeService] = []
+
+    def _env() -> EpisodeEnv:
+        svc = EpisodeService(WebappPack(), tmp_path / f"env{len(services)}")
+        services.append(svc)
+        env = EpisodeEnv(
+            service=svc, snapshots={snap.snapshot_id: snap}, tools=WEB_TOOLS
+        )
+        env.reset(snapshot_id=snap.snapshot_id, task_id=pentest.id)
+        return env
+
+    def _reward(env: EpisodeEnv) -> float:
+        env._finalize()
+        return env.reward
+
+    try:
+        reach = _env()
+        reach.http_get(entry)
+        assert _reward(reach) == pytest.approx(1 / 3)  # reached_endpoint only
+
+        wrong = _env()
+        wrong.http_get(entry)
+        wrong.submit(json.dumps({"flag": "not-the-real-flag"}))
+        assert _reward(wrong) == pytest.approx(2 / 3)  # + extracted_anything, but wrong
+
+        breach = _env()
+        breach.http_get(entry)
+        trace = solve_chain(graph, lambda p: breach.http_get(p).split("\n", 1)[-1])
+        assert flag in trace.terminal  # genuinely exfiltrated over the wire
+        breach.submit(json.dumps({"flag": flag}))
+        assert _reward(breach) == 1.0
+        assert breach.report is not None and breach.report.passed
+    finally:
+        for svc in services:
+            svc.close()
 
 
 def test_services_are_realistically_named() -> None:


### PR DESCRIPTION
## What

Replaces the single-service SQLi stub in `examples/trl_grpo_cyber.ipynb` with the **flagship**: an LLM agent trained (TRL GRPO) to compromise a **believable multi-service company** on real Docker.

The world: a public **storefront** in a DMZ, plus internal APIs and databases on a **segmented network**. The flag is a credential **confined to an internal service** — no front door. The agent must **recon** the 8-service estate, get a **foothold** (SSRF on the storefront), and **pivot DMZ→internal** to **exfiltrate** the credential. Graded by the world itself — no static dataset of "correct" attacks.

## How it runs

- **Real Docker**: each rollout boots **one container per service** on a real segmented network (`NetworkedContainerWebappRuntime`), storefront published on a host port the policy's `http_get` reaches. Falls back to in-process emulation when Docker is absent (no silent degradation — a failed boot raises).
- Same torch-free TRL seam, same `http_get` / `submit` tools you bring — only the world got real.
- **Reward** is the world's held-out verdict over the HTTP path: reach the storefront `0.333` → submit a wrong flag `0.667` → full breach `1.0`. That spread is what GRPO turns into a gradient.
- **Curriculum**: each solved round, `auto_evolve` **plants a new vulnerability** on the estate (a decoy the agent must tell from the real path) and re-admits, so the world stays provably solvable. Evolution is **gated to the pentest family the agent trains on**, so every round genuinely hardens the breach world — the lineage grows `broken_authz → command_injection → credential_gated_flag`.

§8 shows **one real `GRPOTrainer.train()` round** (the laptop 0.5B collapses at the floor — both rollouts tie at 0.333, no gradient), then drives the curriculum loop with the reference breach as a **stand-in for a trained policy**. Swap `grpo_round` in with a larger model on a GPU and the policy's own climb drives the hardening. Honest about laptop-scale limits throughout.

## Verification

This branch was put through a fresh live re-run **and an adversarial multi-agent audit** (8 dimensions, find-then-skeptic-verify + a completeness critic):

- Notebook executed **live on Docker end-to-end** — twice, **byte-deterministic** (identical content-addressed world-hash chain across runs), **0 errors**, ~1m25s. Committed outputs match `main`'s cleanliness (only `Loading weights` stderr).
- The estate, the breach (genuine over-the-wire exfiltration, not hardcoded), the CONTAINER backing (verified real per-service containers, no PROCESS fallback), and determinism were all independently reproduced.
- The audit caught and **fixed** real overclaims: the curriculum is now genuinely vuln-surface hardening (was 2/3 cosmetic build-level bumps); the §17 "spread stays alive" claim (contradicted by `reward_std=0`) is now honest; the reward surface is now **pinned by a new test on the company world**; `flag_from` no longer uses Python-3.14-only syntax; code cells carry **zero comments**.
- `tests/test_cyber_company.py` — **10 passing** (PROCESS + real-container solve + the new reward-tier test); `tests/test_trl_cyber.py` 15 passing; `ruff` + `mypy` clean.

> Known follow-up (flagged separately): on CONTAINER a no-op agent grades `reached_endpoint=True` because the runtime's readiness probe touches the storefront — so the live-world reward floor is `0.333`, not `0`. The notebook discloses this in §8. The reward surface for every *agent* behavior is identical on PROCESS and CONTAINER.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
