### PR TITLE
perf(cyber): keep poolable worlds warm and reuse them across episodes (#294)

### DIFF
--- a/packages/openrange-pack-sdk/src/openrange_pack_sdk/__init__.py
+++ b/packages/openrange-pack-sdk/src/openrange_pack_sdk/__init__.py
@@ -34,6 +34,7 @@ from openrange_pack_sdk._protocols import (
     EpisodeReportLike,
     LLMBackend,
     Pack,
+    PoolableRuntime,
     RuntimeHandle,
     TaskFamily,
 )
@@ -89,6 +90,7 @@ __all__ = [
     "Pack",
     "PackError",
     "PackPrior",
+    "PoolableRuntime",
     "ProceduralBuilder",
     "RuntimeHandle",
     "SandboxResult",

--- a/packages/openrange-pack-sdk/src/openrange_pack_sdk/_protocols.py
+++ b/packages/openrange-pack-sdk/src/openrange_pack_sdk/_protocols.py
@@ -43,6 +43,20 @@ class RuntimeHandle(Protocol):
 
 
 @runtime_checkable
+class PoolableRuntime(Protocol):
+    """A world that can stay booted and be reused across episodes.
+
+    ``poolable`` is the per-world safety guard: it returns ``False`` when the
+    world's mutations could cross episodes, so the harness must not reuse it.
+    ``reset_episode`` returns a warm world to a clean state and raises when the
+    world is no longer usable, signalling the harness to fall back to a reboot.
+    """
+
+    def poolable(self) -> bool: ...
+    def reset_episode(self) -> None: ...
+
+
+@runtime_checkable
 class EpisodeReportLike(Protocol):
     """The slice of an episode report that families read.
 

--- a/packs/cyber_webapp/cyber_webapp/container.py
+++ b/packs/cyber_webapp/cyber_webapp/container.py
@@ -56,6 +56,19 @@ def minimum_backing(graph: WorldGraph) -> Backing:
     return Backing.PROCESS
 
 
+def has_write_exec_surface(graph: WorldGraph) -> bool:
+    """True if any vuln has the ``code_exec`` shape (command_injection, ssti).
+
+    Such a world mutates its own container during an episode, so it can't be kept
+    warm and reused — its state would cross episodes.
+    """
+    for vuln in graph.by_kind("vulnerability"):
+        entry = CATALOG.get(str(vuln.attrs.get("kind")))
+        if entry is not None and entry.shape == "code_exec":
+            return True
+    return False
+
+
 # A fixed in-container port (the host maps it to an ephemeral port at run time, the way
 # the PROCESS backing binds port 0).
 CONTAINER_PORT = 8000

--- a/packs/cyber_webapp/cyber_webapp/realize.py
+++ b/packs/cyber_webapp/cyber_webapp/realize.py
@@ -31,6 +31,7 @@ from cyber_webapp.codegen.entrypoint import (
 from cyber_webapp.container import (
     ServiceImage,
     hardening_run_args,
+    has_write_exec_surface,
     image_files,
     realize_services,
 )
@@ -136,6 +137,20 @@ class _WebappRuntime(SubprocessRuntime):
         self.reset()
         super().restore(state)
         self._log_offset = log_offset
+
+    def poolable(self) -> bool:
+        return not has_write_exec_surface(self._graph)
+
+    def reset_episode(self) -> None:
+        self._clear_request_logs()
+        self._log_offset = 0
+        if self._solver_root is not None:
+            (self._solver_root / self.RESULT_FILE).unlink(missing_ok=True)
+
+    def _clear_request_logs(self) -> None:
+        log = self._request_log_path()
+        if log is not None and log.exists():
+            log.write_bytes(b"")
 
     def _request_log_path(self) -> Path | None:
         if self.pack_root is None:
@@ -264,6 +279,51 @@ def _sweep_built_images() -> None:
         subprocess.run(["docker", "rmi", "-f", tag], capture_output=True)
 
 
+_WORLD_LABEL = "openrange.cyber.world=1"
+_world_containers: set[str] = set()
+_world_networks: set[str] = set()
+_world_sweep_registered = False
+
+
+def _register_world_sweep() -> None:
+    global _world_sweep_registered
+    if not _world_sweep_registered:
+        atexit.register(_sweep_world_resources)
+        _world_sweep_registered = True
+
+
+def _track_world_container(name: str) -> None:
+    _world_containers.add(name)
+    _register_world_sweep()
+
+
+def _track_world_network(name: str) -> None:
+    _world_networks.add(name)
+    _register_world_sweep()
+
+
+def _sweep_world_resources() -> None:
+    # A SIGKILL leaks past atexit; the openrange.cyber.world label lets an
+    # external prune reclaim what this leaves behind.
+    for name in list(_world_containers):
+        subprocess.run(["docker", "rm", "-f", name], capture_output=True)
+    for net in list(_world_networks):
+        subprocess.run(["docker", "network", "rm", net], capture_output=True)
+
+
+def _truncate_container_log(cname: str | None) -> None:
+    if cname is None:
+        return
+    done = subprocess.run(
+        ["docker", "exec", cname, "sh", "-c", f": > {_CONTAINER_LOG_PATH}"],
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    if done.returncode != 0:
+        raise WebappRuntimeError(f"warm world container {cname} is not reusable")
+
+
 class ContainerWebappRuntime(_WebappRuntime):
     """CONTAINER backing: the world runs as a real docker container.
 
@@ -287,12 +347,15 @@ class ContainerWebappRuntime(_WebappRuntime):
         del solver_root
         _ensure_image(self._tag, str(env_root / "pack"))
         self._cname = f"openrange-cyber-{uuid.uuid4().hex[:12]}"
+        _track_world_container(self._cname)
         return [
             "docker",
             "run",
             "--rm",
             "--name",
             self._cname,
+            "--label",
+            _WORLD_LABEL,
             "-p",
             f"127.0.0.1:0:{_CONTAINER_PORT}",
             *hardening_run_args(),
@@ -331,10 +394,14 @@ class ContainerWebappRuntime(_WebappRuntime):
             return None
         return done.stdout if done.returncode == 0 else b""
 
+    def _clear_request_logs(self) -> None:
+        _truncate_container_log(self._cname)
+
     def stop(self) -> None:
         super().stop()
         if self._cname is not None:
             subprocess.run(["docker", "rm", "-f", self._cname], capture_output=True)
+            _world_containers.discard(self._cname)
 
 
 class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
@@ -378,12 +445,13 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
         if self._network_created:  # pragma: no cover - idempotent across resets
             return
         subprocess.run(
-            ["docker", "network", "create", self._network],
+            ["docker", "network", "create", "--label", _WORLD_LABEL, self._network],
             check=True,
             capture_output=True,
             timeout=30,
         )
         self._network_created = True
+        _track_world_network(self._network)
 
     def _start_internals(self) -> None:
         if self._internal_runs:  # pragma: no cover - idempotent across resets
@@ -394,6 +462,7 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
             )
             cname = f"{self._network}-{service.name}"
             self._build_service_image(tag, service.build_files)
+            _track_world_container(cname)
             subprocess.run(
                 [
                     "docker",
@@ -401,6 +470,8 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
                     "-d",
                     "--name",
                     cname,
+                    "--label",
+                    _WORLD_LABEL,
                     "--network",
                     self._network,
                     "--network-alias",
@@ -465,13 +536,20 @@ class NetworkedContainerWebappRuntime(ContainerWebappRuntime):
     def poll_events(self) -> tuple[Mapping[str, Any], ...]:
         return ()
 
+    def _clear_request_logs(self) -> None:
+        super()._clear_request_logs()
+        for cname, _tag in self._internal_runs:
+            _truncate_container_log(cname)
+
     def stop(self) -> None:
         super().stop()
         for cname, _tag in self._internal_runs:
             subprocess.run(["docker", "rm", "-f", cname], capture_output=True)
+            _world_containers.discard(cname)
         self._internal_runs.clear()
         if self._network_created:
             subprocess.run(
                 ["docker", "network", "rm", self._network], capture_output=True
             )
             self._network_created = False
+            _world_networks.discard(self._network)

--- a/src/openrange/core/episode.py
+++ b/src/openrange/core/episode.py
@@ -12,7 +12,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from openrange_pack_sdk import (
     NPC,
@@ -21,6 +21,7 @@ from openrange_pack_sdk import (
     EpisodeResult,
     OpenRangeError,
     Pack,
+    PoolableRuntime,
     RuntimeHandle,
     Snapshot,
     TaskSpec,
@@ -213,6 +214,7 @@ class EpisodeService:
         else:
             self.npc_agent_backend = None
         self._episodes: dict[str, _RunningEpisode] = {}
+        self._warm: dict[str, RuntimeHandle] = {}
         # Cached reports for stopped episodes — populated by
         # ``stop_episode`` so ``check_episode`` keeps working after the
         # running entry is evicted.
@@ -240,9 +242,8 @@ class EpisodeService:
         episode_root.mkdir(parents=True)
 
         started_at = time.perf_counter()
-        runtime = self.pack.realize(snapshot.graph, self.backing)
+        runtime = self._acquire_runtime(snapshot)
         try:
-            runtime.reset()
             surface_mapping = MappingProxyType(dict(runtime.surface()))
         except Exception:
             with contextlib.suppress(Exception):
@@ -278,6 +279,40 @@ class EpisodeService:
             self._start_auto_tick(running, rate)
         return handle
 
+    def _acquire_runtime(self, snapshot: Snapshot) -> RuntimeHandle:
+        warm = self._warm.pop(snapshot.snapshot_id, None)
+        if warm is not None:
+            try:
+                cast(PoolableRuntime, warm).reset_episode()
+                return warm
+            except Exception:
+                with contextlib.suppress(Exception):
+                    warm.stop()
+        runtime = self.pack.realize(snapshot.graph, self.backing)
+        try:
+            runtime.reset()
+        except Exception:
+            with contextlib.suppress(Exception):
+                runtime.stop()
+            raise
+        return runtime
+
+    def _stash_warm(self, running: _RunningEpisode) -> bool:
+        if not _is_poolable(running.runtime):
+            return False
+        snapshot_id = running.snapshot.snapshot_id
+        # One warm world at a time: a new snapshot_id evicts the prior.
+        self._evict_warm(keep=snapshot_id)
+        self._warm[snapshot_id] = running.runtime
+        return True
+
+    def _evict_warm(self, *, keep: str | None = None) -> None:
+        for snapshot_id in list(self._warm):
+            if snapshot_id == keep:
+                continue
+            with contextlib.suppress(Exception):
+                self._warm.pop(snapshot_id).stop()
+
     def stop_episode(self, episode: EpisodeHandle) -> EpisodeReport:
         """Stop the runtime, run the success check, return the report.
         A second call returns the cached report; does not re-stop. The
@@ -302,15 +337,16 @@ class EpisodeService:
         episode_result = self._check_success(running, final_state)
         running.episode_result = episode_result
         running.stopped_at = time.perf_counter()
-        try:
-            running.runtime.stop()
-        except Exception as exc:  # noqa: BLE001
-            # A failed stop must not mask the solver's result.
-            self._record_system(
-                running,
-                {"stop_error": type(exc).__name__},
-                observation={"reason": str(exc)},
-            )
+        if not self._stash_warm(running):
+            try:
+                running.runtime.stop()
+            except Exception as exc:  # noqa: BLE001
+                # A failed stop must not mask the solver's result.
+                self._record_system(
+                    running,
+                    {"stop_error": type(exc).__name__},
+                    observation={"reason": str(exc)},
+                )
         running.stopped = True
         self._record_system(
             running,
@@ -679,7 +715,7 @@ class EpisodeService:
         running.tick_stop = None
 
     def close(self) -> None:
-        """Best-effort stop of all live episodes."""
+        """Best-effort stop of all live episodes and warm (pooled) worlds."""
         for running in list(self._episodes.values()):
             self._stop_auto_tick(running)
             self._stop_npcs(running)
@@ -688,6 +724,7 @@ class EpisodeService:
                     running.runtime.stop()
                 running.stopped = True
         self._episodes.clear()
+        self._evict_warm()
 
 
 def _resolve_task(snapshot: Snapshot, task_id: str | None) -> TaskSpec:
@@ -765,6 +802,11 @@ def _atexit_stop_episodes(svc_ref: weakref.ref[EpisodeService]) -> None:
         except Exception:  # noqa: BLE001 — best-effort cleanup
             continue
         running.stopped = True
+    svc._evict_warm()
+
+
+def _is_poolable(runtime: RuntimeHandle) -> bool:
+    return isinstance(runtime, PoolableRuntime) and runtime.poolable()
 
 
 def _auto_tick_loop(

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -16,7 +16,7 @@ import pytest
 from cyber_webapp import NetworkedContainerWebappRuntime, WebappPack, _is_networked
 from cyber_webapp.reference_solver import solve_chain
 from graphschema import Node, WorldGraph
-from openrange_pack_sdk import Backing, Snapshot
+from openrange_pack_sdk import Backing, PoolableRuntime, Snapshot
 from openrange_trl import EpisodeEnv
 
 from examples.tools import WEB_TOOLS
@@ -182,6 +182,65 @@ def test_company_reward_surface_grades_the_breach(tmp_path: Path) -> None:
             svc.close()
 
 
+def test_warm_pool_reuses_a_poolable_world(tmp_path: Path) -> None:
+    # A poolable world (the company: no write/exec vuln) is booted once and reused
+    # across episodes on one EpisodeService — as a TRL env is reused across training
+    # steps. stop_episode keeps it warm; the next start_episode hands back the SAME
+    # runtime after a cheap reset_episode, and each episode still grades the breach.
+    snap = _admit(_COMPANY_MANIFEST)
+    pentest = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+    flag = str(snap.graph.nodes["secret_flag"].attrs["value_ref"])
+    entry = str(snap.graph.nodes[pentest.entrypoints[0]].attrs["public_url"])
+
+    svc = EpisodeService(WebappPack(), tmp_path)
+    env = EpisodeEnv(service=svc, snapshots={snap.snapshot_id: snap}, tools=WEB_TOOLS)
+    warm: list[object] = []
+    try:
+        for _ in range(2):
+            env.reset(snapshot_id=snap.snapshot_id, task_id=pentest.id)
+            env.http_get(entry)
+            trace = solve_chain(
+                snap.graph, lambda p: env.http_get(p).split("\n", 1)[-1]
+            )
+            assert flag in trace.terminal  # exfiltrated over the wire, each episode
+            env.submit(json.dumps({"flag": flag}))
+            env._finalize()
+            assert env.report is not None and env.report.passed
+            warm.append(svc._warm[snap.snapshot_id])  # kept warm, not torn down
+        assert warm[0] is warm[1]  # the SAME world was reused, not rebooted
+    finally:
+        svc.close()
+    assert not svc._warm  # close() evicts the warm world
+
+
+def test_write_exec_world_is_not_poolable() -> None:
+    # A command_injection world runs an agent-driven shell on a writable container,
+    # so its state can cross episodes — it must never be kept warm. A response-leak
+    # world (sql_injection) only reads immutable state, so it is poolable.
+    cmdi = WebappPack().realize(
+        _admit(
+            {
+                **_DEFAULT_MANIFEST,
+                "loot_shapes": {"file": 1, "db": 0},
+                "vuln_kinds": {"command_injection": 1},
+            }
+        ).graph,
+        Backing.PROCESS,
+    )
+    assert isinstance(cmdi, PoolableRuntime) and not cmdi.poolable()
+    sqli = WebappPack().realize(
+        _admit(
+            {
+                **_DEFAULT_MANIFEST,
+                "loot_shapes": {"db": 1, "file": 0},
+                "vuln_kinds": {"sql_injection": 1},
+            }
+        ).graph,
+        Backing.PROCESS,
+    )
+    assert isinstance(sqli, PoolableRuntime) and sqli.poolable()
+
+
 def test_services_are_realistically_named() -> None:
     # Coherence (DESIGN.md §2: realism is procedural-first, from curated pools): names
     # read like a real company estate, not the mechanical api1/db2 shape.
@@ -283,3 +342,36 @@ def test_company_solves_across_real_containers() -> None:
         assert "secret_flag" in final["leaked_secret_ids"]
     finally:
         runtime.stop()
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker engine not reachable")
+def test_warm_pool_reuses_real_containers(tmp_path: Path) -> None:
+    # On the CONTAINER backing, a poolable company world is booted once and reused:
+    # reset_episode truncates the in-container request logs over docker exec, so a
+    # second episode on the SAME containers re-exfiltrates cleanly — no full reboot.
+    snap = _admit(_COMPANY_MANIFEST)
+    pentest = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+    flag = str(snap.graph.nodes["secret_flag"].attrs["value_ref"])
+    entry = str(snap.graph.nodes[pentest.entrypoints[0]].attrs["public_url"])
+
+    svc = EpisodeService(WebappPack(), tmp_path, backing=Backing.CONTAINER)
+    env = EpisodeEnv(service=svc, snapshots={snap.snapshot_id: snap}, tools=WEB_TOOLS)
+    warm: list[object] = []
+    try:
+        for _ in range(2):
+            env.reset(snapshot_id=snap.snapshot_id, task_id=pentest.id)
+            env.http_get(entry)
+            trace = solve_chain(
+                snap.graph, lambda p: env.http_get(p).split("\n", 1)[-1]
+            )
+            assert flag in trace.terminal
+            env.submit(json.dumps({"flag": flag}))
+            env._finalize()
+            assert env.report is not None and env.report.passed
+            warm.append(svc._warm[snap.snapshot_id])
+        assert (
+            warm[0] is warm[1]
+        )  # the same per-service containers reused, not rebooted
+    finally:
+        svc.close()
+    assert not svc._warm


### PR DESCRIPTION
## What

First slice of #294: **keep poolable worlds warm and reuse them across episodes**, instead of a full `realize` + boot + teardown every episode.

On the CONTAINER backing each episode of the company world costs ~5s of pure docker lifecycle (boot ~1.2s, then a ~2.9s `SIGTERM`-grace teardown), and a TRL trainer resets its `B` environments **serially** every step — so at GPU batch scale the trainer starves on container boots, not on training. #300 already content-addressed the *images*; this keeps the *running world* warm.

## How

- **`PoolableRuntime`** — a new **optional** SDK protocol, separate from `RuntimeHandle` so it's non-breaking and per-pack opt-in (no existing pack or `isinstance(_, RuntimeHandle)` check changes). It adds `poolable()` + `reset_episode()`.
- **Cyber runtime** (`realize.py`):
  - `reset_episode()` returns a warm world to a clean, episode-ready state cheaply — truncate the in-container request log (one `docker exec` per service), reset the log cursor, delete the solver result. It raises if a container has died so the harness reboots.
  - `poolable()` gates via `has_write_exec_surface`: a world with a **write/exec** vuln (`command_injection` / `ssti` — the `code_exec` shape) is **never** kept warm; it keeps the full-reboot path, so its mutations can't cross episodes. Read-only worlds (response-leak / file-read, incl. the company's `ssrf`/`xxe`) are poolable.
  - Warm containers + network carry an `openrange.cyber.world` label and a process-scoped `atexit` sweep, so a killed run can't leak them.
- **`EpisodeService`** — a `{snapshot_id → warm runtime}` cache. `stop_episode` checks a poolable world *back in* instead of tearing it down; `start_episode` hands it back after a cheap `reset_episode` (no realize/boot/teardown). One warm world per snapshot — a curriculum re-root evicts the prior, and `close()` / `atexit` evict all.

## Why it's correct

The cyber world is read-only to the agent: data is in-memory SQLite loaded from a seed that's **unlinked at boot** (immutable; even multi-statement SQLi can't mutate it), so the only per-episode mutable state is the request log. Clear it and the next episode is clean — verified by a two-episode reuse run where episode 2 on the *same* containers re-exfiltrates the flag with no contamination and identical grading.

## Measured (live on Docker, company world, full breach each episode)

| | per-episode setup+teardown | B=16 GRPO step (world setup) |
|---|---|---|
| reboot each (today) | ~5.1s | ~82s |
| **warm reuse** | **~0.49s** | **~8s** |

≈ **10×** steady-state. (Boot is paid once on episode 0; episodes 1+ pay only `reset_episode`.)

## Verification

- **184 impacted tests pass** (cyber + SDK suites), incl. 3 new: PROCESS warm-reuse correctness, the write/exec gate, and a docker-gated real-container reuse test. `mypy` clean (74 files), `ruff`/hooks green.
- Reuse correctness proven on **both** PROCESS and real containers.
- **Leak backstop dogfooded**: a `SIGKILL` of a run mid-episode left 8 orphaned containers; pruning by the `openrange.cyber.world` label reclaimed all 8 + the network.

## Deferred (this is the first slice)

- A **shared `<B` pool** with cross-slot checkout (the per-EpisodeService cache amortizes boot across *steps*, which is the dominant training pattern; cross-rollout sharing within a step is the next increment).
- Making write/exec worlds poolable via a uniform in-container app-restart (removes the gate; not needed for the company target).

> Real-agent run: a Strands agent (gemma-31B at a self-hosted vLLM endpoint) drove the warm-pooled company world end-to-end — recon (`/`, `/openapi.json`, `/health/internal` leaking the internal upstreams), found the SSRF endpoint, and attempted real SSRF payloads (it didn't crack the param name, so it didn't breach). Strands handles the endpoint's reasoning-channel format fine; real LLM tool-calling against the pool works. Pool reuse + grading are validated by the deterministic benchmark above plus a clean non-solving-agent reuse check (two reach-only episodes → both 0.333, world reused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
