### PR TITLE
docs(trl): show the cyber gym driven by any agent, not just TRL (§10)

### DIFF
--- a/examples/trl_grpo_cyber.ipynb
+++ b/examples/trl_grpo_cyber.ipynb
@@ -715,6 +715,76 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b67c5967",
+   "metadata": {},
+   "source": [
+    "## 10. Or drive it with any agent\n",
+    "\n",
+    "Nothing here is TRL-specific — the world is an HTTP target behind the `EpisodeEnv`\n",
+    "surface, graded the same way. Point any agent framework at the same `http_get` /\n",
+    "`submit` tools. Here's the company breached by a [Strands](https://strandsagents.com)\n",
+    "agent against any OpenAI-compatible endpoint: `pip install strands-agents openai`, set\n",
+    "`OPENAI_BASE_URL` (and optionally `OPENAI_MODEL`), and a capable model lands the pivot\n",
+    "in a handful of calls."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "5646d2d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "set OPENAI_BASE_URL to drive the same world with any LLM agent\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "endpoint = os.environ.get(\"OPENAI_BASE_URL\")\n",
+    "if endpoint:\n",
+    "    from strands import Agent, tool\n",
+    "    from strands.models.openai import OpenAIModel\n",
+    "\n",
+    "    live = environment_factory()\n",
+    "    live.reset(snapshot_id=snapshot.snapshot_id, task_id=pentest_task(snapshot).id)\n",
+    "\n",
+    "    @tool\n",
+    "    def http_get(path: str) -> str:\n",
+    "        \"GET a path on the target; returns the status line then the body.\"\n",
+    "        return live.http_get(path)[:1500]\n",
+    "\n",
+    "    @tool\n",
+    "    def submit(flag: str) -> str:\n",
+    "        \"Submit the recovered credential to end the episode.\"\n",
+    "        return live.submit(json.dumps({\"flag\": flag}))\n",
+    "\n",
+    "    model = OpenAIModel(\n",
+    "        client_args={\n",
+    "            \"base_url\": endpoint,\n",
+    "            \"api_key\": os.environ.get(\"OPENAI_API_KEY\", \"EMPTY\"),\n",
+    "        },\n",
+    "        model_id=os.environ.get(\"OPENAI_MODEL\", \"gpt-4o-mini\"),\n",
+    "    )\n",
+    "    agent = Agent(\n",
+    "        model=model,\n",
+    "        tools=[http_get, submit],\n",
+    "        callback_handler=None,\n",
+    "        system_prompt=\"Recon the target, find the hidden credential, and submit it.\",\n",
+    "    )\n",
+    "    agent(f\"Target: {entry_url(snapshot)}\")\n",
+    "    live._finalize()\n",
+    "    print(f\"strands agent \\u2192 reward {live.reward:.3f}\")\n",
+    "else:\n",
+    "    print(\"set OPENAI_BASE_URL to drive the same world with any LLM agent\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "fee451d7",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## What

Adds a short **§10 "Or drive it with any agent"** to the cyber tutorial (`examples/trl_grpo_cyber.ipynb`). The notebook trains the world with TRL GRPO; this shows the same world driven by a **Strands** agent against any OpenAI-compatible endpoint — making the point that the gym is framework-agnostic (the world is an HTTP target behind the `EpisodeEnv` surface, graded the same way).

## Kept lean (no bloat)

- **One markdown cell + one code cell** — folded into the tutorial as the relevant step, not a standalone example file.
- Reuses the notebook's existing helpers (`environment_factory`, `entry_url`, `pentest_task`, `json`), so the cell is just: bind `http_get` / `submit` as Strands `@tool`s, point an `OpenAIModel` at `OPENAI_BASE_URL`, run one episode, print the reward.
- **Guarded**: a no-op unless `OPENAI_BASE_URL` is set, so the committed notebook still runs clean without an endpoint (every other cell's output is untouched — no re-execution, no GRPO re-roll).

## Validated

The `if endpoint:` path is the cleaned-up version of a run I drove live: a Strands agent (gemma-31B on a self-hosted vLLM endpoint) recon'd the estate over this exact surface (storefront → openapi → the internal-upstream leak) and attempted the SSRF pivot. `ruff` clean; the build-script source-of-truth is kept in sync.