### PR TITLE
Train on an evolving pool of worlds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ docs/runtime/
 docs/cyber-pack-plan.md
 docs/v1-live-eval-audit.md
 .claude/
+
+# vendored read-only reference sources (TRL clone, etc.)
+.refs/
+/open-range.zip

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -476,7 +476,7 @@ class BuildEvent:
 | `feasibility`  | every admission attempt | "attempt K: N infeasible task(s)". `refs` carries the task ids that failed. |
 | `repair`       | between failed attempts | "builder regenerated after attempt K". |
 | `freeze`       | exactly once, on success | "world admitted and frozen". |
-| `evolve`       | curriculum (`auto_evolve`) | "evolved from `<parent>` via `<family>/<direction>`". Appended once to the evolved snapshot's history; `refs` carries the parent `snapshot_id`. The evolved snapshot's `lineage` also carries the structured `_evolve` block (parent id, direction, family, note). |
+| `evolve`       | curriculum (`auto_evolve`) | "evolved from `<parent>` via `<family>/<direction>`". Appended once to the evolved snapshot's history; `refs` carries the parent `snapshot_id`. Every evolution path (grow and patch) also writes one canonical block at `lineage["_evolve"]` (top level, never nested) with a single schema — `{parent_snapshot_id, direction, kind, relevance, family, note}` — so a reader never special-cases which path produced the snapshot. Fields a path can't fill (grow has no `relevance`/`family`) are present and set to `null`. |
 
 `history` is the build **story**, not part of the graph's identity.
 Two builds that produce the same graph but took different repair

--- a/docs/design/evolving-pool-curriculum.md
+++ b/docs/design/evolving-pool-curriculum.md
@@ -191,22 +191,27 @@ over-hardens); and it is a lagging, whole-pool trigger that only fires once the
 gradient is already dead. The published curriculum work uses a *leading,
 per-level* score instead — value-loss (PLR) or regret (ACCEL) — to rank which
 levels to resample and to edit. GRPO has no critic, so it cannot compute those
-directly; the GRPO-native substitute is a per-`(world, task)` priority
-`f(reward-std, |solve_rate − 0.5|, staleness)`. That priority — not the lagging
-collapse gate — is the spine.
+directly; the GRPO-native substitute is a per-`(world, task)` priority that scores
+the learning signal where it lives. The shipped priority is a *learnability* term
+(`1 − |2·solve_rate − 1|`, peaking where the agent sometimes-but-not-always wins),
+plus the regret proxy below, plus a staleness term so nothing starves. That
+priority — not the lagging collapse gate — is the spine.
 
 **Reward-std is not regret.** A world where every rollout reaches rung 2 and none
 reach rung 3 has *low* std (no gradient) yet *high* regret (far from the solvable
 optimum) — the frontier world a regret method would prioritize, and the one a
 variance gate would wrongly retire. The verifier already knows each world's
 solvable ceiling, so a critic-free regret proxy is in reach:
-`ceiling-rung − mean-achieved-rung`. Use it alongside std in the priority.
+`ceiling-rung − mean-achieved-rung`, and the shipped priority uses it. (Reward-std
+is the natural refinement — it separates a live-gradient world from a dead-gradient
+one at the same solve-rate — still to add; §10.)
 
 **Keep a mix.** Catastrophic forgetting is the documented failure of
 non-stationary RL, and revisiting easy tasks is the fix. So the pool reserves a
 floor — about a quarter to a third of each round's groups — for easy-tier members,
-per skill (one skill's easy tail must not be crowded out by another's), enforced
-when the pool's rows are composed, not hoped to emerge. A forgetting metric
+enforced when the pool's rows are composed, not hoped to emerge. (The shipped floor
+is global by difficulty; whether it should be per-skill, so one skill's easy tail
+is not crowded out by another's, is open — §13.) A forgetting metric
 (periodically re-run retired members; alarm if their solve-rate drops) is what
 makes the floor falsifiable. This requires replacing the shipped discard-the-
 parent behaviour with admit-the-child-and-retain-the-parent.
@@ -278,18 +283,22 @@ Two anchors keep open-ended evolution from drifting:
   (§3), not skill-extending.
 - The warm-world pool — booted worlds reused across episodes, now an LRU bounded
   by capacity.
+- The pool itself — `WorldPool` seeds wide, composes each round's rows under the
+  mix floor, and between rounds re-prioritises members (learnability + regret +
+  staleness), evolves the top-`M` into admitted children retaining parents, and
+  bounds the size. Pack-agnostic (difficulty injected) and runner-agnostic (the
+  caller runs a round), so a scripted solver drives it today and a trainer later.
 
 **To build (where the work and the risk live):**
-- A pool builder: union `(snapshot_id, task_id)` rows across members, weighted by
-  priority, with the mix floor enforced at composition.
-- A sampler with a seed contract (replayable), freezing sampling weights *within*
-  a round and updating priorities *between* rounds (so within-round sampling
-  stays i.i.d.).
-- Pool-level evolve: lift the mastery signal to per-member, evolve the top-`M`,
-  admit children into the pool, retain parents under the floor.
+- A replayable weighted sampler. The shipped round composes deterministic
+  top-priority rows under the mix floor; a seed-contract weighted draw (frozen
+  *within* a round, updated *between*) is the refinement that makes within-round
+  sampling i.i.d.
 - The skill-extending operator (append-a-hop) and the monotonicity check (§3, §6).
+- The reward-std term in the priority, and a per-skill (not global) mix floor.
 - The held-out eval pool and the generalization metric (§8).
-- A behavioural difficulty term to layer on the static metric.
+- A behavioural difficulty term layered on the static metric, and persisting the
+  metric onto the lineage so the dashboard can read it (§11).
 
 The cost model: admission is static graph-reachability — cheap and content-
 addressable (cache verdicts by content-hash so unchanged members are not
@@ -300,9 +309,10 @@ admission.
 
 The shipped view tells a chain story ("the company hardens back"). The pool needs
 a different one. First it needs a *measured* difficulty axis — the generation
-knobs the lineage carries today are inputs, not an observed property, so a
-graph-derived metric (chain depth dominating, vuln count secondary) is computed
-and stored per member.
+knobs the lineage carries today are inputs, not an observed property. A graph-
+derived metric (chain depth dominating, vuln count secondary) supplies it:
+`world_difficulty` scores each pool member today; persisting it onto the lineage
+so the dashboard can read it is part of this section's work.
 
 Then: a difficulty band (the pool's members binned by difficulty) sliding toward
 harder over rounds while keeping a visible easy tail; the two axes legible (tasks

--- a/docs/design/evolving-pool-curriculum.md
+++ b/docs/design/evolving-pool-curriculum.md
@@ -1,0 +1,394 @@
+# The curriculum is an evolving pool of worlds-and-tasks
+
+OpenRange's bet is that agents trained on fresh, admission-checked worlds
+generalize better than agents that overfit a fixed benchmark. That bet is
+stated today at eval time ("the agent never sees the same graph twice"). This
+document states it at training time and gives it a shape: what the training loop
+trains on, how it changes over time, and why that is stable for the kind of
+online RL (GRPO) we use.
+
+It is grounded in the published work on automatic curricula and environment
+design (POET, PAIRED, Prioritized Level Replay, ACCEL) and on online RL for
+language models (GRPO, WebRL, Absolute Zero); the appendix lists the sources.
+Where the shipped code already provides a seam, it is named; where the design
+needs something that does not exist yet, it says so plainly.
+
+## 1. The shape of the loop
+
+Worked example first. You want to train a pentest agent. The simplest loop
+trains it on one company world, watches it learn to breach that world, mutates
+the world a little harder, and trains on the harder one — a chain, one world
+live at a time. That is what ships today. It has two holes: the agent sees only
+one world per round, so it has no spread to generalize from; and each round
+throws the previous world away, so nothing stops it forgetting what it learned
+two worlds back.
+
+The fix changes *what the loop trains on*. Instead of one current world, it
+trains on a **pool**: many admitted `(world, task)` pairs, sampled per episode.
+The pool is not the opposite of evolution — the pool is the thing that evolves.
+Generalization comes from the *spread* of worlds the agent sees within a round.
+Curriculum comes from a *slow shift* of the pool's makeup between rounds.
+
+This document is about evolving the *worlds*. Growing the *generator itself* — an
+external knowledge graph that expands as the agent trains and later bootstraps a
+fresh generation pass — is a level up from this and out of scope here.
+
+## 2. Three units: group, pool, round
+
+Named by what each holds fixed.
+
+- **Group** — `G` rollouts on one `(world, task)`. This is the GRPO group, and
+  it is the unit that must stay fixed (§5).
+- **Pool** — the set of admitted `(world, task)` pairs a round samples from.
+  Different groups in a round land on different pairs. Keyed by
+  `(snapshot_id, task_id)`, *not* by world content-hash alone: two tasks on one
+  graph share a content-hash but are different problems, so content-hash keying
+  would under-count.
+- **Round** — one pass of GRPO over the groups drawn from the current pool, then
+  one pool-update that may shift the pool for the next round.
+
+The pool widens along **two axes that cost very differently**:
+
+- **Tasks per world** (cheap). Same realized world, different goal / role /
+  entrypoint — the `TaskFamily`/`TaskSpec` split (entrypoints and goal nodes are
+  task-relative). Reuses a warm world, no boot. It widens *task coverage*, not
+  the world diversity the generalization argument needs.
+- **Worlds in the pool** (a boot each). Different topology, chain depth, flag
+  placement. This is the spread that generalizes.
+
+A round needs a floor of *distinct worlds*, set independently of the warm-cache
+budget, or the cheap task axis silently collapses the spread the bet relies on.
+
+## 3. Ways of evolution
+
+Today's evolution vocabulary is three operators on the vulnerability *set* — add
+a vuln, remove a vuln, swap a vuln's kind — on a fixed topology with a fixed
+solve path. That changes recon difficulty and which exploit to find, but never
+the required skill: the agent solves the same pivot with more or fewer decoys
+around it. That is why the chain felt like a toy — it only ever made the world
+busier, not harder.
+
+It also confines evolution to graph-patches on a fixed estate. But building and
+evolving are the same act — produce an admission-checked world, from scratch (a
+seed) or from a parent (a step) — so an evolution operator can just as well
+**build new structure**: an LLM-realized service or tier, exactly as the builder
+does, under the same gate (§2 of the cyber design: procedural owns correctness,
+the LLM owns variety, behind admission). Enterprise worlds cannot be generated
+in one shot, so this is how they grow — build, train, build, train, each round
+adding to the world, not only mutating what is there.
+
+A real curriculum needs operators that change the *problem*. Classify them by
+what they do to the agent's required skill, because the type decides where the
+operator is allowed to act:
+
+1. **Deepen — append a hop** *(extends the skill)*. Extend the credential chain
+   by one hop: the agent loots one more credential and reuses it one more time.
+   The N-hop solution is a *prefix* of the (N+1)-hop solution, so the policy's
+   learned behaviour stays a valid partial solution. This is the one operator
+   safe to use as a frontier step. The hop can be a graph-patch (the company
+   pack's 1/2/3-hop credential chains already exist) or a whole **LLM-built
+   service** appended to the path — same skill effect, richer surface. Lifting
+   either into a mutation is new work.
+2. **Add a required recon step** *(extends the skill)*. Stop disclosing a host's
+   address so the agent must enumerate to find it. Adds a discovery step the
+   path now requires.
+3. **Plant a decoy vuln** *(leaves the skill unchanged)* — today's `harden`.
+   Adds an off-path vuln the agent routes around. Changes recon difficulty, not
+   the required path. Useful for diversity, wrong for the difficulty frontier —
+   calling it "harden" oversells it.
+4. **Swap the required exploit class** *(replaces the skill)*. Change the vuln on
+   the solve path (e.g. SSRF → a different primitive). The agent must learn a
+   different move.
+5. **Relocate the flag / restructure topology** *(replaces the skill)*. Move the
+   flag to another tier, add or drop a service. The solution changes wholesale.
+6. **Re-skin** *(skill unchanged)*. Rename services and hosts, shuffle layout,
+   vary which host holds the loot. Pure robustness.
+
+The classification *is* the rule:
+
+- The **frontier** — the curriculum's difficulty step between rounds — moves only
+  via **skill-extending** operators (deepen, add-required-recon). They are small
+  and monotone, so the policy climbs a ramp instead of falling off a cliff.
+- **Diversity** — the pool's cross-world spread — comes from **skill-replacing**
+  and **decoy** operators applied at **seeding** (building fresh root worlds),
+  not as small in-place steps. A wholesale path change is fine as a *fresh
+  sample*; it is unsafe as a *step* under a live learning policy (§5).
+- **Re-skinning** is free robustness, applied any time.
+
+**Two axes, one gate.** Skill-effect (above) decides *where* an operator may act.
+A second axis — *how* the change is generated — decides its cost and reach: a
+cheap procedural graph-patch (add a vuln, bump a level) or a richer **LLM-built**
+increment (a new service, a new tier). The two are orthogonal — you can build a
+hop (extends), build a relocated flag (replaces), or build a decoy service
+(decoy) — and both run behind the **same admission gate**, so the LLM never
+ships the part that must be correct and neither can outrun the verifier ceiling
+(§9): the LLM proposes, admission certifies the world is still solvable. One
+discipline keeps it RL-safe: a *large* built increment lands as a **fresh seed
+world** (diversity), never an in-place rebuild of a world a policy is mid-
+training on; the in-place frontier step stays small and skill-extending, patch or
+built hop alike.
+
+So the shipped add/remove/swap-vuln operators are the decoy/replacing kind: fine
+for seeding diversity, wrong for the frontier. The missing pieces are the
+skill-extending operator — append-a-hop, as a patch or an LLM-built service — and
+a check that an operator tagged "frontier" actually extends rather than replaces
+(§6).
+
+## 4. The two-timescale picture
+
+Putting §2 and §3 together: within a round the pool is fixed and sampled wide
+(spread → generalization); between rounds the frontier takes one skill-extending
+step and the seed set may gain a fresh, differently-shaped world (diversity).
+Re-skinning rides underneath both, for free. Stable within a round, gradual
+between rounds, diverse across worlds.
+
+## 5. Why it is stable for GRPO
+
+Three levels of stability. Only the first is free; the other two are constraints
+to enforce and measure.
+
+**Within a group — required, and guaranteed by construction.** GRPO's baseline
+is the average reward of `G` outputs sampled for the *same* problem, and the
+advantage is `(reward − mean) / std` over the group. If the `(world, task)`
+varied inside a group, the mean would no longer be a per-problem baseline and the
+gradient would be polluted by between-problem reward-scale differences. So the
+invariant is firm: **a group is the rollouts sharing one `(snapshot_id,
+task_id)`.** The cyber pack already feeds it — the pentest verdict grades three
+rungs (reach → extract → match) so a group has reward spread to learn from; a
+binary leak/no-leak signal would collapse the group and kill the gradient.
+
+**Within a batch / round — not automatically safe.** Sampling i.i.d. from a
+fixed pool is a stationary objective, and the spread is the generalization
+mechanism — this is ordinary multi-task RL / domain randomization. But
+stationarity at the distribution level does not discharge the batch-level
+estimator: per-group whitening zeroes each group's advantage mean, yet the loss
+sums over groups whose advantage *magnitudes* are not difficulty-invariant — an
+easy world and a hard world do not contribute symmetric gradients in one batch.
+Mitigation: cap the difficulty spread *within a single batch* even when the pool
+is wide across the round, and measure the residual cross-group weighting rather
+than assume it away.
+
+**Between rounds — a bounded heuristic with an explicit anchor.** A slow shift of
+the pool's makeup is sensible, but it carries no automatic guarantee: a bounded
+*data* shift toward the regions where the policy is most wrong — exactly where a
+curriculum pushes — can still produce a large *policy* step (this is why the
+analogy to PPO's policy-space trust region does not hold). So the shift rate is a
+hyperparameter to tune, and it must be anchored by an explicit KL-to-reference
+(§9), not by the implicit KL-bias on-policy RL has on a fixed task.
+
+Bottom line: within-group stability is structural; batch- and round-level
+stability are things the harness enforces and the dashboard measures.
+
+## 6. How the pool evolves: signal, mix, frontier
+
+**Move where there is learning signal.** A world the agent always or never solves
+gives no gradient; signal lives where it sometimes-but-not-always succeeds. The
+shipped `reward_variance_policy` gestures at this — hold a world while its group's
+reward spread is alive, nudge when the spread collapses (harden if the mean is
+high, soften if low). Two honest limits: with graded rungs the spread rarely
+collapses exactly, so the gate mostly *holds* (it stalls rather than
+over-hardens); and it is a lagging, whole-pool trigger that only fires once the
+gradient is already dead. The published curriculum work uses a *leading,
+per-level* score instead — value-loss (PLR) or regret (ACCEL) — to rank which
+levels to resample and to edit. GRPO has no critic, so it cannot compute those
+directly; the GRPO-native substitute is a per-`(world, task)` priority
+`f(reward-std, |solve_rate − 0.5|, staleness)`. That priority — not the lagging
+collapse gate — is the spine.
+
+**Reward-std is not regret.** A world where every rollout reaches rung 2 and none
+reach rung 3 has *low* std (no gradient) yet *high* regret (far from the solvable
+optimum) — the frontier world a regret method would prioritize, and the one a
+variance gate would wrongly retire. The verifier already knows each world's
+solvable ceiling, so a critic-free regret proxy is in reach:
+`ceiling-rung − mean-achieved-rung`. Use it alongside std in the priority.
+
+**Keep a mix.** Catastrophic forgetting is the documented failure of
+non-stationary RL, and revisiting easy tasks is the fix. So the pool reserves a
+floor — about a quarter to a third of each round's groups — for easy-tier members,
+per skill (one skill's easy tail must not be crowded out by another's), enforced
+when the pool's rows are composed, not hoped to emerge. A forgetting metric
+(periodically re-run retired members; alarm if their solve-rate drops) is what
+makes the floor falsifiable. This requires replacing the shipped discard-the-
+parent behaviour with admit-the-child-and-retain-the-parent.
+
+**Move the frontier monotonically.** New frontier worlds extend the required
+skill (§3): append a hop, add a required recon step. A check confirms the
+parent's solution is still a sub-path of the child's, so "frontier" means
+"genuinely harder," not "more decoys."
+
+The anchor that makes open-ended evolution safe: every world entering the pool —
+seeded or evolved — passes the same admission gate, which proves the world is
+*graph-reachable-solvable*. That is weaker than *agent-solvable*: admission
+rejects impossible worlds, and the soften-when-stuck rule retires
+too-hard-for-now ones. The two together keep the pool winnable.
+
+## 7. Pool lifecycle: seed, grow, bound
+
+- **Seed** — build `K` independent root worlds (K admissions over sampled
+  manifests, deduped by `(snapshot_id, task_id)`) so the pool starts wide. The
+  round-one spread comes from seeding, not from evolution.
+- **Grow** — each round, evolve the top-`M` priority members into children, admit
+  the children *into* the pool, and down-weight or retire parents under the mix
+  floor.
+- **Bound** — a maximum pool size `P` with an eviction rule (drop the
+  lowest-priority non-floor members), so the pool is a bounded sampled
+  population, not an ever-growing set.
+
+`G` and pool width trade off at a fixed rollout budget: `G` must stay large
+enough for a low-variance group baseline even as the pool widens, so widening is
+not free. State a floor on `G` and a floor on distinct-worlds-per-round; they
+compete for the same budget.
+
+## 8. Measuring the bet
+
+The bet is a generalization claim, so it needs a held-out split. Reserve an
+**eval pool**: admission-checked but fenced off from training — never sampled
+into a group, never evolved — spanning the difficulty range, including a band
+beyond the current frontier to test extrapolation. The metric is held-out
+solve-rate versus training solve-rate over rounds; the gap between them is the
+bet, made measurable. Without this split, the only available signal is training
+success-rate — exactly the overfit-to-benchmark number the bet warns against.
+
+## 9. Anchors and safety
+
+Two anchors keep open-ended evolution from drifting:
+
+- **The verifier / admission.** Every member, seeded or evolved, is admission-
+  checked, so the pool can never gain an impossible world. Admission proves
+  graph-reachability, not agent-solvability (§6) — name it for what it is.
+- **A KL-to-reference, required once evolving.** Bounding how far the policy
+  drifts from a reference is the load-bearing anchor for the *policy* under a
+  shifting pool. The shipped training config disables it (`beta = 0`), which is
+  fine for a single static world but not for an open-ended evolving pool: with
+  `beta = 0` the verifier is the *only* remaining anchor, so a verifier blind
+  spot becomes a single point of failure. `beta > 0` is a prerequisite for the
+  evolving regime.
+
+## 10. How it maps to the code
+
+**Already there (plumbing):**
+- `make_environment_factory` accepts `Sequence[Snapshot]`, builds a snapshot map,
+  and routes `reset()` by `snapshot_id` — the factory can already host many
+  worlds.
+- `build_grpo_dataset(snapshot)` emits `(snapshot_id, task_id)`-tagged rows for
+  one snapshot.
+- `reward_variance_policy` — the variance-collapse gate, shipped as whole-list.
+- `auto_evolve` — one snapshot to one re-admitted child, with an evolution gate.
+- The cyber mutation vocab — re-admitted and deterministic, but decoy/replacing
+  (§3), not skill-extending.
+- The warm-world pool — booted worlds reused across episodes, now an LRU bounded
+  by capacity.
+
+**To build (where the work and the risk live):**
+- A pool builder: union `(snapshot_id, task_id)` rows across members, weighted by
+  priority, with the mix floor enforced at composition.
+- A sampler with a seed contract (replayable), freezing sampling weights *within*
+  a round and updating priorities *between* rounds (so within-round sampling
+  stays i.i.d.).
+- Pool-level evolve: lift the mastery signal to per-member, evolve the top-`M`,
+  admit children into the pool, retain parents under the floor.
+- The skill-extending operator (append-a-hop) and the monotonicity check (§3, §6).
+- The held-out eval pool and the generalization metric (§8).
+- A behavioural difficulty term to layer on the static metric.
+
+The cost model: admission is static graph-reachability — cheap and content-
+addressable (cache verdicts by content-hash so unchanged members are not
+re-checked). The real per-round cost is world boots and per-episode grading, not
+admission.
+
+## 11. The dashboard
+
+The shipped view tells a chain story ("the company hardens back"). The pool needs
+a different one. First it needs a *measured* difficulty axis — the generation
+knobs the lineage carries today are inputs, not an observed property, so a
+graph-derived metric (chain depth dominating, vuln count secondary) is computed
+and stored per member.
+
+Then: a difficulty band (the pool's members binned by difficulty) sliding toward
+harder over rounds while keeping a visible easy tail; the two axes legible (tasks
+fanned under one warm world vs distinct worlds entering and leaving); per-member
+learnability (alive / mastered / stuck) instead of one global success curve; the
+train-versus-held-out gap; and a signal that distinguishes a *verifier-ceiling*
+stall (no admissible harder world for this backing) from genuine mastery, so the
+two are not confused.
+
+## 12. Prerequisites
+
+1. **The bounded warm cache.** The warm pool ships as an LRU; a pooled round
+   needs its capacity set to at least the distinct-worlds-per-round count, or it
+   thrashes. Exec-surface worlds (command injection, SSTI) never warm and always
+   re-boot — carve them out of throughput claims.
+2. **One canonical lineage `_evolve` block.** Every evolution path writes the
+   same top-level schema (`parent`, `direction`, `kind`, `relevance`, `family`,
+   `note`), so pool/retention tooling reads provenance without special-casing
+   which path produced a snapshot.
+3. **A measured difficulty metric** — the band and the mix floor are undefined
+   without it.
+
+## 13. Open questions
+
+- Is `ceiling-rung − achieved-rung` the right critic-free regret proxy, or does
+  it need a finer estimate? This is the central technical question.
+- The mix ratio and its granularity — a global fraction, or a per-skill floor?
+- Pool size, tasks per world, groups per round, and `G` — and the minimum
+  distinct-worlds-per-round below which the generalization argument stops holding.
+- Offense versus defense. The design assumes the agent is an attacker and the
+  world is read-only (which is why warm reuse is correct). A defense task mutates
+  the world, so it cannot ride the warm cache and may be a different problem
+  entirely. **Scope v1 to offense;** specify the defense problem separately.
+- Live pool versus a multi-parent lineage graph — is the sampled set enough, with
+  lineage kept as a provenance chain?
+
+## 14. Risks
+
+- **Loss of plasticity.** A slowly-shifting pool over many rounds is the regime
+  where networks can lose the ability to learn at all — and the replay that fixes
+  forgetting does not fix this. It needs its own mitigation (periodic resets /
+  continual backprop) and its own dashboard signal; do not mistake a plasticity
+  stall for a curriculum stall.
+- **The cheap axis narrows the round.** A scheduler that maximizes warm-world
+  reuse minimizes cross-world spread — undermining generalization. The round must
+  spread across worlds regardless of what is cheapest to warm.
+- **A soft mix floor reintroduces forgetting.** The floor must be enforced when
+  the pool's rows are composed, not left as a preference.
+- **The verifier caps the frontier.** The frontier can stop advancing because the
+  verifier ran out of instrumented consequences for a backing, not because the
+  agent mastered everything. Surface it, or it reads as mastery.
+
+## Appendix — grounding
+
+Automatic curricula / environment design:
+- Domain randomization as a wide, fixed, stationary distribution that transfers —
+  Tobin et al. 2017 (arXiv:1703.06907); difficulty expansion by a success-rate
+  boundary — OpenAI 2019, Automatic Domain Randomization (arXiv:1910.07113).
+- Curriculum framed as a sequence of MDPs, fixed within a step — Narvekar et al.
+  2020 (JMLR 21(181), arXiv:2003.04960).
+- A population of *levels* with a too-easy/too-hard criterion — Wang et al. 2020,
+  Enhanced POET (arXiv:2003.08536).
+- Regret as the curriculum signal; unsolvable levels score zero regret, so
+  solvability admission is curriculum-correct — Dennis et al. 2020, PAIRED
+  (arXiv:2012.02096).
+- Leading per-level score plus a staleness term — Jiang et al. 2021, Prioritized
+  Level Replay (arXiv:2010.03934); gradients only on curated levels, evaluate
+  fresh ones to score — Jiang et al. 2021, Robust PLR (arXiv:2110.02439).
+- Evolve by small edits to high-regret levels, single agent, level buffer —
+  Parker-Holder et al. 2022, ACCEL (arXiv:2203.01302), the closest analogue.
+
+Online RL for language models:
+- Group-relative advantage and the fixed-group invariant — Shao et al. 2024,
+  DeepSeekMath (arXiv:2402.03300); verifiable rule-based reward + reference —
+  Guo et al. 2025, DeepSeek-R1 (arXiv:2501.12948).
+- PPO's clip is a policy-space trust region (so it is not a data-shift analogue) —
+  Schulman et al. 2017 (arXiv:1707.06347). On-policy RL forgets less than SFT on
+  a fixed task — Shenfeld et al. 2025, "RL's Razor" (arXiv:2509.04259).
+- KL-to-reference — Ouyang et al. 2022, InstructGPT (arXiv:2203.02155).
+- Mix in easy tasks to avoid forgetting: "Continuously mix in easier tasks while
+  learning harder ones to avoid forgetting" — Matiisen et al. 2020 (IEEE TNNLS,
+  arXiv:1707.00183); replay for continual learning — Rolnick et al. 2019, CLEAR
+  (arXiv:1811.11682).
+- Learnability `1 − solve_rate`, signal at intermediate difficulty — Zhao et al.
+  2025, Absolute Zero (arXiv:2505.03335).
+- An evolving online curriculum for an LLM web agent — replay + KL-to-reference +
+  a complexifying task stream — Qi et al. 2025, WebRL (ICLR, arXiv:2411.02337).
+- Loss of plasticity in long non-stationary training — Dohare et al. 2024
+  (Nature 632).

--- a/docs/design/evolving-pool-curriculum.md
+++ b/docs/design/evolving-pool-curriculum.md
@@ -288,17 +288,23 @@ Two anchors keep open-ended evolution from drifting:
   staleness), evolves the top-`M` into admitted children retaining parents, and
   bounds the size. Pack-agnostic (difficulty injected) and runner-agnostic (the
   caller runs a round), so a scripted solver drives it today and a trainer later.
+- The skill-extending frontier operator — the cyber vocab now includes
+  append-a-hop (deepen the credential chain by one hop), and `monotone_chain_gate`
+  admits a frontier step only when the parent's solve walk is a prefix of the
+  child's (§3, §6). The pool threads it as a per-parent gate.
+- The held-out eval pool — `EvalPool` is admitted alongside training but fenced
+  from it; `run_pool_curriculum` measures train-vs-held-out solve-rate each round
+  (`RoundMetrics`), so the generalization gap (§8) is observed, not assumed.
 
 **To build (where the work and the risk live):**
 - A replayable weighted sampler. The shipped round composes deterministic
   top-priority rows under the mix floor; a seed-contract weighted draw (frozen
   *within* a round, updated *between*) is the refinement that makes within-round
   sampling i.i.d.
-- The skill-extending operator (append-a-hop) and the monotonicity check (§3, §6).
 - The reward-std term in the priority, and a per-skill (not global) mix floor.
-- The held-out eval pool and the generalization metric (§8).
 - A behavioural difficulty term layered on the static metric, and persisting the
   metric onto the lineage so the dashboard can read it (§11).
+- The LLM-built variant of append-a-hop (§3's second axis), behind the same gate.
 
 The cost model: admission is static graph-reachability — cheap and content-
 addressable (cache verdicts by content-hash so unchanged members are not

--- a/docs/design/evolving-pool-curriculum.md
+++ b/docs/design/evolving-pool-curriculum.md
@@ -291,6 +291,14 @@ Two anchors keep open-ended evolution from drifting:
   staleness), evolves the top-`M` into admitted children retaining parents, and
   bounds the size. Pack-agnostic (difficulty injected) and runner-agnostic (the
   caller runs a round), so a scripted solver drives it today and a trainer later.
+  It lives in `openrange.pool` — trainer-agnostic, depending only on core — so any
+  adapter drives it; it is *not* part of the TRL adapter. The TRL seam is concrete:
+  `run_round` builds a `datasets.Dataset` from `round_rows` and runs one short
+  GRPO pass per round (TRL reads `train_dataset` fresh each `train()`, so the
+  evolving set just gets reassigned between rounds), and the `snapshot_id`/`task_id`
+  columns flow into TRL's per-rollout `environment.reset()`. TRL has no
+  world-distribution curriculum of its own; its replay buffer and GFPO are
+  complementary *within-batch* signal boosters, a layer below this.
 - The skill-extending frontier operator — the cyber vocab now includes
   append-a-hop (deepen the credential chain by one hop), and `monotone_chain_gate`
   admits a frontier step only when the parent's solve walk is a prefix of the

--- a/docs/design/evolving-pool-curriculum.md
+++ b/docs/design/evolving-pool-curriculum.md
@@ -87,8 +87,8 @@ operator is allowed to act:
    learned behaviour stays a valid partial solution. This is the one operator
    safe to use as a frontier step. The hop can be a graph-patch (the company
    pack's 1/2/3-hop credential chains already exist) or a whole **LLM-built
-   service** appended to the path — same skill effect, richer surface. Lifting
-   either into a mutation is new work.
+   service** appended to the path — same skill effect, richer surface. The patch
+   form ships (`auto_evolve`'s append-a-hop); the LLM-built form is new work.
 2. **Add a required recon step** *(extends the skill)*. Stop disclosing a host's
    address so the agent must enumerate to find it. Adds a discovery step the
    path now requires.
@@ -128,11 +128,11 @@ world** (diversity), never an in-place rebuild of a world a policy is mid-
 training on; the in-place frontier step stays small and skill-extending, patch or
 built hop alike.
 
-So the shipped add/remove/swap-vuln operators are the decoy/replacing kind: fine
-for seeding diversity, wrong for the frontier. The missing pieces are the
-skill-extending operator — append-a-hop, as a patch or an LLM-built service — and
-a check that an operator tagged "frontier" actually extends rather than replaces
-(§6).
+So the add/remove/swap-vuln operators are the decoy/replacing kind: fine for
+seeding diversity, wrong for the frontier. The skill-extending operator —
+append-a-hop as a graph-patch — and the check that a "frontier" step actually
+extends rather than replaces (§6) both now ship; the LLM-built-service form of
+the hop is what remains.
 
 ## 4. The two-timescale picture
 
@@ -217,9 +217,12 @@ makes the floor falsifiable. This requires replacing the shipped discard-the-
 parent behaviour with admit-the-child-and-retain-the-parent.
 
 **Move the frontier monotonically.** New frontier worlds extend the required
-skill (§3): append a hop, add a required recon step. A check confirms the
-parent's solution is still a sub-path of the child's, so "frontier" means
-"genuinely harder," not "more decoys."
+skill (§3): append a hop, add a required recon step. A *structural* check
+confirms the parent's solution is still a sub-path of the child's, so "frontier"
+means "genuinely harder," not "more decoys." That check is not the solvability
+proof — it reads the chain's shape, not whether the new hop actually leaks; the
+independent anchor that the deeper world is still winnable is admission (below)
+and the runtime leak oracle, not the gate itself.
 
 The anchor that makes open-ended evolution safe: every world entering the pool —
 seeded or evolved — passes the same admission gate, which proves the world is
@@ -279,8 +282,8 @@ Two anchors keep open-ended evolution from drifting:
   one snapshot.
 - `reward_variance_policy` — the variance-collapse gate, shipped as whole-list.
 - `auto_evolve` — one snapshot to one re-admitted child, with an evolution gate.
-- The cyber mutation vocab — re-admitted and deterministic, but decoy/replacing
-  (§3), not skill-extending.
+- The cyber mutation vocab — re-admitted and deterministic: the add/remove/swap
+  operators are decoy/replacing (§3); the skill-extending append-a-hop is below.
 - The warm-world pool — booted worlds reused across episodes, now an LRU bounded
   by capacity.
 - The pool itself — `WorldPool` seeds wide, composes each round's rows under the
@@ -398,12 +401,13 @@ Online RL for language models:
   Schulman et al. 2017 (arXiv:1707.06347). On-policy RL forgets less than SFT on
   a fixed task — Shenfeld et al. 2025, "RL's Razor" (arXiv:2509.04259).
 - KL-to-reference — Ouyang et al. 2022, InstructGPT (arXiv:2203.02155).
-- Mix in easy tasks to avoid forgetting: "Continuously mix in easier tasks while
-  learning harder ones to avoid forgetting" — Matiisen et al. 2020 (IEEE TNNLS,
+- Mix in easy tasks to avoid forgetting — select tasks by learning-curve slope
+  and revisit ones that regress — Matiisen et al. 2020 (IEEE TNNLS,
   arXiv:1707.00183); replay for continual learning — Rolnick et al. 2019, CLEAR
   (arXiv:1811.11682).
 - Learnability `1 − solve_rate`, signal at intermediate difficulty — Zhao et al.
-  2025, Absolute Zero (arXiv:2505.03335).
+  2025, Absolute Zero (arXiv:2505.03335); the shipped priority uses a peaked
+  variant `1 − |2·solve_rate − 1|` of that monotone form.
 - An evolving online curriculum for an LLM web agent — replay + KL-to-reference +
   a complexifying task stream — Qi et al. 2025, WebRL (ICLR, arXiv:2411.02337).
 - Loss of plasticity in long non-stationary training — Dohare et al. 2024

--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -57,6 +57,7 @@ from openrange.training import (
     episode_reward,
     episode_trajectory,
 )
+from openrange_trl._pool import WorldPool, run_pool_curriculum
 from openrange_trl.sandbox import (
     SANDBOX_LABEL,
     AgentSandbox,
@@ -449,9 +450,11 @@ __all__ = [
     "EpisodeEnv",
     "SandboxError",
     "Tool",
+    "WorldPool",
     "build_grpo_dataset",
     "env_trajectory",
     "make_environment_factory",
     "make_reward_func",
     "reward_variance_policy",
+    "run_pool_curriculum",
 ]

--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -57,12 +57,6 @@ from openrange.training import (
     episode_reward,
     episode_trajectory,
 )
-from openrange_trl._pool import (
-    EvalPool,
-    RoundMetrics,
-    WorldPool,
-    run_pool_curriculum,
-)
 from openrange_trl.sandbox import (
     SANDBOX_LABEL,
     AgentSandbox,
@@ -453,11 +447,8 @@ __all__ = [
     "AgentSandbox",
     "CommandResult",
     "EpisodeEnv",
-    "EvalPool",
-    "RoundMetrics",
     "SandboxError",
     "Tool",
-    "WorldPool",
     "build_grpo_dataset",
     "env_trajectory",
     "make_environment_factory",

--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -57,7 +57,12 @@ from openrange.training import (
     episode_reward,
     episode_trajectory,
 )
-from openrange_trl._pool import WorldPool, run_pool_curriculum
+from openrange_trl._pool import (
+    EvalPool,
+    RoundMetrics,
+    WorldPool,
+    run_pool_curriculum,
+)
 from openrange_trl.sandbox import (
     SANDBOX_LABEL,
     AgentSandbox,
@@ -448,6 +453,8 @@ __all__ = [
     "AgentSandbox",
     "CommandResult",
     "EpisodeEnv",
+    "EvalPool",
+    "RoundMetrics",
     "SandboxError",
     "Tool",
     "WorldPool",

--- a/packages/openrange-trl/src/openrange_trl/_pool.py
+++ b/packages/openrange-trl/src/openrange_trl/_pool.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 
-from openrange_pack_sdk import Pack, Snapshot
+from openrange_pack_sdk import Mutation, Pack, Snapshot
 
 from openrange.core.admit import AdmissionFailure, admit
 from openrange.core.curriculum import (
@@ -29,6 +29,7 @@ DifficultyFn = Callable[[Snapshot], float]
 PromptRow = dict[str, object]
 RoundReports = Mapping[tuple[str, str], Sequence[EpisodeReport]]
 RunRound = Callable[[list[PromptRow], list[Snapshot]], RoundReports]
+GateFactory = Callable[[Snapshot], EvolutionGate]
 
 _STALENESS_STEP = 0.1
 # The most a round can score a member (learnability + regret, each <= 1): idle
@@ -66,6 +67,22 @@ def _member_priority(reports: Sequence[EpisodeReport]) -> float:
     # from the ceiling, assuming every listed subgoal is reachable.
     regret = sum(gaps) / len(gaps) if gaps else 0.0
     return learnability + regret
+
+
+def _compose_gate(
+    gate: EvolutionGate | None,
+    gate_factory: GateFactory | None,
+    parent: Snapshot,
+) -> EvolutionGate | None:
+    built = gate_factory(parent) if gate_factory is not None else None
+    gates = [g for g in (gate, built) if g is not None]
+    if not gates:
+        return None
+
+    def combined(evolved: Snapshot, mutation: Mutation) -> bool:
+        return all(g(evolved, mutation) for g in gates)
+
+    return combined
 
 
 class WorldPool:
@@ -184,6 +201,7 @@ class WorldPool:
         pack: Pack,
         policy: CurriculumPolicy = direction_from_reports,
         gate: EvolutionGate | None = None,
+        gate_factory: GateFactory | None = None,
         evolve_top: int = 1,
         max_repairs: int = 2,
     ) -> None:
@@ -193,7 +211,9 @@ class WorldPool:
                 member.priority = _member_priority(ran)
             else:
                 member.priority = min(member.priority + _STALENESS_STEP, _MAX_PRIORITY)
-        grown = self._grow(reports, pack, policy, gate, evolve_top, max_repairs)
+        grown = self._grow(
+            reports, pack, policy, gate, gate_factory, evolve_top, max_repairs
+        )
         self._bound(grown)
 
     def _grow(
@@ -202,6 +222,7 @@ class WorldPool:
         pack: Pack,
         policy: CurriculumPolicy,
         gate: EvolutionGate | None,
+        gate_factory: GateFactory | None,
         evolve_top: int,
         max_repairs: int,
     ) -> set[tuple[str, str]]:
@@ -216,7 +237,7 @@ class WorldPool:
                 *reports[member.key],
                 pack=pack,
                 policy=policy,
-                gate=gate,
+                gate=_compose_gate(gate, gate_factory, member.snapshot),
                 max_repairs=max_repairs,
             )
             if child is None:
@@ -258,10 +279,18 @@ def run_pool_curriculum(
     num_generations: int,
     policy: CurriculumPolicy = direction_from_reports,
     gate: EvolutionGate | None = None,
+    gate_factory: GateFactory | None = None,
     evolve_top: int = 1,
 ) -> WorldPool:
     for _ in range(rounds):
         rows = pool.round_rows(groups=groups, num_generations=num_generations)
         reports = run_round(rows, pool.snapshots())
-        pool.update(reports, pack=pack, policy=policy, gate=gate, evolve_top=evolve_top)
+        pool.update(
+            reports,
+            pack=pack,
+            policy=policy,
+            gate=gate,
+            gate_factory=gate_factory,
+            evolve_top=evolve_top,
+        )
     return pool

--- a/packages/openrange-trl/src/openrange_trl/_pool.py
+++ b/packages/openrange-trl/src/openrange_trl/_pool.py
@@ -10,7 +10,7 @@ injected by the caller so the pool stays pack-agnostic.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 
 from openrange_pack_sdk import Mutation, Pack, Snapshot
@@ -50,6 +50,53 @@ class _Member:
     @property
     def key(self) -> tuple[str, str]:
         return (self.snapshot.snapshot_id, self.task_id)
+
+
+def _members_of(
+    snapshot: Snapshot,
+    difficulty: float,
+    family: str | None,
+    out: list[_Member],
+) -> None:
+    for task in snapshot.tasks:
+        fam = str(task.meta.get("family", ""))
+        if family is not None and fam != family:
+            continue
+        out.append(
+            _Member(
+                snapshot=snapshot,
+                task_id=task.id,
+                instruction=task.instruction,
+                family=fam,
+                difficulty=difficulty,
+            )
+        )
+
+
+def _rows_for(members: Iterable[_Member], num_generations: int) -> list[PromptRow]:
+    rows: list[PromptRow] = []
+    for member in members:
+        for _ in range(num_generations):
+            rows.append(
+                {
+                    "prompt": [{"role": "user", "content": member.instruction}],
+                    "snapshot_id": member.snapshot.snapshot_id,
+                    "task_id": member.task_id,
+                }
+            )
+    return rows
+
+
+def _snapshots_of(members: Iterable[_Member]) -> list[Snapshot]:
+    by_id: dict[str, Snapshot] = {}
+    for member in members:
+        by_id.setdefault(member.snapshot.snapshot_id, member.snapshot)
+    return list(by_id.values())
+
+
+def _mean_pass_rate(report_groups: Iterable[Sequence[EpisodeReport]]) -> float:
+    rates = [sum(1 for r in g if r.passed) / len(g) for g in report_groups if g]
+    return sum(rates) / len(rates) if rates else 0.0
 
 
 def _member_priority(reports: Sequence[EpisodeReport]) -> float:
@@ -116,31 +163,10 @@ class WorldPool:
             result = admit(pack, dict(manifest), max_repairs=max_repairs)
             if isinstance(result, AdmissionFailure):
                 continue
-            cls._members_of(result, difficulty_fn(result), family, members)
+            _members_of(result, difficulty_fn(result), family, members)
         return cls(
             members, difficulty_fn=difficulty_fn, max_size=max_size, mix_floor=mix_floor
         )
-
-    @staticmethod
-    def _members_of(
-        snapshot: Snapshot,
-        difficulty: float,
-        family: str | None,
-        out: list[_Member],
-    ) -> None:
-        for task in snapshot.tasks:
-            fam = str(task.meta.get("family", ""))
-            if family is not None and fam != family:
-                continue
-            out.append(
-                _Member(
-                    snapshot=snapshot,
-                    task_id=task.id,
-                    instruction=task.instruction,
-                    family=fam,
-                    difficulty=difficulty,
-                )
-            )
 
     def __len__(self) -> int:
         return len(self._members)
@@ -149,23 +175,10 @@ class WorldPool:
         return set(self._members)
 
     def snapshots(self) -> list[Snapshot]:
-        by_id: dict[str, Snapshot] = {}
-        for member in self._members.values():
-            by_id.setdefault(member.snapshot.snapshot_id, member.snapshot)
-        return list(by_id.values())
+        return _snapshots_of(self._members.values())
 
     def round_rows(self, *, groups: int, num_generations: int) -> list[PromptRow]:
-        rows: list[PromptRow] = []
-        for member in self._select(groups):
-            for _ in range(num_generations):
-                rows.append(
-                    {
-                        "prompt": [{"role": "user", "content": member.instruction}],
-                        "snapshot_id": member.snapshot.snapshot_id,
-                        "task_id": member.task_id,
-                    }
-                )
-        return rows
+        return _rows_for(self._select(groups), num_generations)
 
     def _easy_tier(self) -> set[tuple[str, str]]:
         ranked = sorted(self._members.values(), key=lambda m: (m.difficulty, m.key))
@@ -269,6 +282,65 @@ class WorldPool:
             del self._members[evictable.pop(0).key]
 
 
+@dataclass(frozen=True)
+class RoundMetrics:
+    train_solve_rate: float
+    held_out_solve_rate: float | None = None
+
+    @property
+    def generalization_gap(self) -> float | None:
+        if self.held_out_solve_rate is None:
+            return None
+        return self.train_solve_rate - self.held_out_solve_rate
+
+
+class EvalPool:
+    """A held-out set of admitted worlds, fenced from training.
+
+    It is measured each round but never sampled into a group, evolved, or bounded,
+    so train-vs-held-out solve-rate is the generalization signal the pool bet rests
+    on (``docs/design/evolving-pool-curriculum.md`` §8).
+    """
+
+    def __init__(self, members: Sequence[_Member]) -> None:
+        self._members = list(members)
+
+    @classmethod
+    def seed(
+        cls,
+        pack: Pack,
+        manifests: Sequence[Mapping[str, object]],
+        *,
+        difficulty_fn: DifficultyFn,
+        family: str | None = None,
+        max_repairs: int = 2,
+    ) -> EvalPool:
+        members: list[_Member] = []
+        for manifest in manifests:
+            result = admit(pack, dict(manifest), max_repairs=max_repairs)
+            if isinstance(result, AdmissionFailure):
+                continue
+            _members_of(result, difficulty_fn(result), family, members)
+        return cls(members)
+
+    def __len__(self) -> int:
+        return len(self._members)
+
+    def keys(self) -> set[tuple[str, str]]:
+        return {m.key for m in self._members}
+
+    def snapshots(self) -> list[Snapshot]:
+        return _snapshots_of(self._members)
+
+    def rows(self, *, num_generations: int) -> list[PromptRow]:
+        return _rows_for(self._members, num_generations)
+
+    def solve_rate(self, reports: RoundReports) -> float:
+        return _mean_pass_rate(
+            reports[m.key] for m in self._members if m.key in reports
+        )
+
+
 def run_pool_curriculum(
     pool: WorldPool,
     run_round: RunRound,
@@ -281,10 +353,30 @@ def run_pool_curriculum(
     gate: EvolutionGate | None = None,
     gate_factory: GateFactory | None = None,
     evolve_top: int = 1,
-) -> WorldPool:
+    eval_pool: EvalPool | None = None,
+) -> list[RoundMetrics]:
+    """Run the curriculum, returning per-round train and held-out solve rates.
+
+    The pool is updated in place. When ``eval_pool`` is given it is measured each
+    round but never trained on or evolved, so the train-vs-held-out gap is the
+    generalization signal (§8).
+    """
+    metrics: list[RoundMetrics] = []
     for _ in range(rounds):
         rows = pool.round_rows(groups=groups, num_generations=num_generations)
         reports = run_round(rows, pool.snapshots())
+        held_out: float | None = None
+        if eval_pool is not None and len(eval_pool):
+            eval_reports = run_round(
+                eval_pool.rows(num_generations=num_generations), eval_pool.snapshots()
+            )
+            held_out = eval_pool.solve_rate(eval_reports)
+        metrics.append(
+            RoundMetrics(
+                train_solve_rate=_mean_pass_rate(reports.values()),
+                held_out_solve_rate=held_out,
+            )
+        )
         pool.update(
             reports,
             pack=pack,
@@ -293,4 +385,4 @@ def run_pool_curriculum(
             gate_factory=gate_factory,
             evolve_top=evolve_top,
         )
-    return pool
+    return metrics

--- a/packages/openrange-trl/src/openrange_trl/_pool.py
+++ b/packages/openrange-trl/src/openrange_trl/_pool.py
@@ -31,6 +31,10 @@ RoundReports = Mapping[tuple[str, str], Sequence[EpisodeReport]]
 RunRound = Callable[[list[PromptRow], list[Snapshot]], RoundReports]
 
 _STALENESS_STEP = 0.1
+# The most a round can score a member (learnability + regret, each <= 1): idle
+# members cap here (bounded pump) and fresh children seat here, so a new frontier
+# world is sampled next round instead of evicted before it ever runs.
+_MAX_PRIORITY = 2.0
 
 
 @dataclass
@@ -57,8 +61,9 @@ def _member_priority(reports: Sequence[EpisodeReport]) -> float:
         if subgoals:
             achieved = sum(1 for hit in subgoals.values() if hit)
             gaps.append(1.0 - achieved / len(subgoals))
-    # The regret term keeps a world stuck below its solvable ceiling (low reward
-    # spread, so learnability alone would retire it) at the frontier.
+    # The regret term keeps a world the agent is stuck partway through (low reward
+    # spread, so learnability alone would retire it) at the frontier — the distance
+    # from the ceiling, assuming every listed subgoal is reachable.
     regret = sum(gaps) / len(gaps) if gaps else 0.0
     return learnability + regret
 
@@ -154,7 +159,7 @@ class WorldPool:
         if groups == 0:
             return []
         easy = self._easy_tier()
-        floor_n = min(round(self._mix_floor * groups), len(easy))
+        floor_n = min(round(self._mix_floor * groups), len(easy), groups)
         by_priority = sorted(self._members.values(), key=lambda m: (-m.priority, m.key))
         chosen: list[_Member] = []
         taken: set[tuple[str, str]] = set()
@@ -187,9 +192,9 @@ class WorldPool:
             if ran:
                 member.priority = _member_priority(ran)
             else:
-                member.priority += _STALENESS_STEP
-        self._grow(reports, pack, policy, gate, evolve_top, max_repairs)
-        self._bound()
+                member.priority = min(member.priority + _STALENESS_STEP, _MAX_PRIORITY)
+        grown = self._grow(reports, pack, policy, gate, evolve_top, max_repairs)
+        self._bound(grown)
 
     def _grow(
         self,
@@ -199,7 +204,8 @@ class WorldPool:
         gate: EvolutionGate | None,
         evolve_top: int,
         max_repairs: int,
-    ) -> None:
+    ) -> set[tuple[str, str]]:
+        grown: set[tuple[str, str]] = set()
         ran = sorted(
             (m for m in self._members.values() if reports.get(m.key)),
             key=lambda m: (-m.priority, m.key),
@@ -227,11 +233,13 @@ class WorldPool:
                         instruction=task.instruction,
                         family=member.family,
                         difficulty=difficulty,
+                        priority=_MAX_PRIORITY,
                     )
-                break
+                    grown.add(key)
+        return grown
 
-    def _bound(self) -> None:
-        protected = self._easy_tier()
+    def _bound(self, protected_extra: set[tuple[str, str]]) -> None:
+        protected = self._easy_tier() | protected_extra
         evictable = sorted(
             (m for m in self._members.values() if m.key not in protected),
             key=lambda m: (m.priority, m.key),

--- a/packages/openrange-trl/src/openrange_trl/_pool.py
+++ b/packages/openrange-trl/src/openrange_trl/_pool.py
@@ -217,17 +217,18 @@ class WorldPool:
         gate_factory: GateFactory | None = None,
         evolve_top: int = 1,
         max_repairs: int = 2,
-    ) -> None:
+    ) -> bool:
         for member in self._members.values():
             ran = reports.get(member.key)
             if ran:
                 member.priority = _member_priority(ran)
             else:
                 member.priority = min(member.priority + _STALENESS_STEP, _MAX_PRIORITY)
-        grown = self._grow(
+        grown, capped = self._grow(
             reports, pack, policy, gate, gate_factory, evolve_top, max_repairs
         )
         self._bound(grown)
+        return capped
 
     def _grow(
         self,
@@ -238,8 +239,11 @@ class WorldPool:
         gate_factory: GateFactory | None,
         evolve_top: int,
         max_repairs: int,
-    ) -> set[tuple[str, str]]:
+    ) -> tuple[set[tuple[str, str]], bool]:
         grown: set[tuple[str, str]] = set()
+        # A selected member that yields no child is a frontier cap: the curriculum
+        # wanted to advance it but no admissible harder world passed the gate.
+        capped = False
         ran = sorted(
             (m for m in self._members.values() if reports.get(m.key)),
             key=lambda m: (-m.priority, m.key),
@@ -254,6 +258,7 @@ class WorldPool:
                 max_repairs=max_repairs,
             )
             if child is None:
+                capped = True
                 continue
             difficulty = self._difficulty_fn(child)
             for task in child.tasks:
@@ -270,7 +275,7 @@ class WorldPool:
                         priority=_MAX_PRIORITY,
                     )
                     grown.add(key)
-        return grown
+        return grown, capped
 
     def _bound(self, protected_extra: set[tuple[str, str]]) -> None:
         protected = self._easy_tier() | protected_extra
@@ -286,6 +291,7 @@ class WorldPool:
 class RoundMetrics:
     train_solve_rate: float
     held_out_solve_rate: float | None = None
+    frontier_capped: bool = False
 
     @property
     def generalization_gap(self) -> float | None:
@@ -371,18 +377,19 @@ def run_pool_curriculum(
                 eval_pool.rows(num_generations=num_generations), eval_pool.snapshots()
             )
             held_out = eval_pool.solve_rate(eval_reports)
-        metrics.append(
-            RoundMetrics(
-                train_solve_rate=_mean_pass_rate(reports.values()),
-                held_out_solve_rate=held_out,
-            )
-        )
-        pool.update(
+        capped = pool.update(
             reports,
             pack=pack,
             policy=policy,
             gate=gate,
             gate_factory=gate_factory,
             evolve_top=evolve_top,
+        )
+        metrics.append(
+            RoundMetrics(
+                train_solve_rate=_mean_pass_rate(reports.values()),
+                held_out_solve_rate=held_out,
+                frontier_capped=capped,
+            )
         )
     return metrics

--- a/packages/openrange-trl/src/openrange_trl/_pool.py
+++ b/packages/openrange-trl/src/openrange_trl/_pool.py
@@ -1,0 +1,259 @@
+"""The curriculum as an evolving pool of worlds-and-tasks.
+
+See ``docs/design/evolving-pool-curriculum.md``. The pool is harness-side (core
+ships no curriculum algorithm): it seeds wide, samples a round's prompts with a
+mix floor so an easy tail always survives, and between rounds shifts slowly —
+re-prioritising members by how much they can still teach, evolving the most
+promising into admitted children while keeping their parents. Difficulty is
+injected by the caller so the pool stays pack-agnostic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+
+from openrange_pack_sdk import Pack, Snapshot
+
+from openrange.core.admit import AdmissionFailure, admit
+from openrange.core.curriculum import (
+    CurriculumPolicy,
+    EvolutionGate,
+    auto_evolve,
+    direction_from_reports,
+)
+from openrange.core.episode import EpisodeReport
+from openrange.training import episode_reward
+
+DifficultyFn = Callable[[Snapshot], float]
+PromptRow = dict[str, object]
+RoundReports = Mapping[tuple[str, str], Sequence[EpisodeReport]]
+RunRound = Callable[[list[PromptRow], list[Snapshot]], RoundReports]
+
+_STALENESS_STEP = 0.1
+
+
+@dataclass
+class _Member:
+    snapshot: Snapshot
+    task_id: str
+    instruction: str
+    family: str
+    difficulty: float
+    priority: float = 1.0
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.snapshot.snapshot_id, self.task_id)
+
+
+def _member_priority(reports: Sequence[EpisodeReport]) -> float:
+    scalars = [episode_reward(r).scalar for r in reports]
+    mean = sum(scalars) / len(scalars)
+    learnability = 1.0 - abs(2.0 * mean - 1.0)
+    gaps = []
+    for report in reports:
+        subgoals = report.episode_result.subgoals
+        if subgoals:
+            achieved = sum(1 for hit in subgoals.values() if hit)
+            gaps.append(1.0 - achieved / len(subgoals))
+    # The regret term keeps a world stuck below its solvable ceiling (low reward
+    # spread, so learnability alone would retire it) at the frontier.
+    regret = sum(gaps) / len(gaps) if gaps else 0.0
+    return learnability + regret
+
+
+class WorldPool:
+    def __init__(
+        self,
+        members: Sequence[_Member],
+        *,
+        difficulty_fn: DifficultyFn,
+        max_size: int,
+        mix_floor: float = 0.3,
+    ) -> None:
+        self._members: dict[tuple[str, str], _Member] = {m.key: m for m in members}
+        self._difficulty_fn = difficulty_fn
+        self._max_size = max_size
+        self._mix_floor = mix_floor
+
+    @classmethod
+    def seed(
+        cls,
+        pack: Pack,
+        manifests: Sequence[Mapping[str, object]],
+        *,
+        difficulty_fn: DifficultyFn,
+        max_size: int,
+        family: str | None = None,
+        mix_floor: float = 0.3,
+        max_repairs: int = 2,
+    ) -> WorldPool:
+        members: list[_Member] = []
+        for manifest in manifests:
+            result = admit(pack, dict(manifest), max_repairs=max_repairs)
+            if isinstance(result, AdmissionFailure):
+                continue
+            cls._members_of(result, difficulty_fn(result), family, members)
+        return cls(
+            members, difficulty_fn=difficulty_fn, max_size=max_size, mix_floor=mix_floor
+        )
+
+    @staticmethod
+    def _members_of(
+        snapshot: Snapshot,
+        difficulty: float,
+        family: str | None,
+        out: list[_Member],
+    ) -> None:
+        for task in snapshot.tasks:
+            fam = str(task.meta.get("family", ""))
+            if family is not None and fam != family:
+                continue
+            out.append(
+                _Member(
+                    snapshot=snapshot,
+                    task_id=task.id,
+                    instruction=task.instruction,
+                    family=fam,
+                    difficulty=difficulty,
+                )
+            )
+
+    def __len__(self) -> int:
+        return len(self._members)
+
+    def keys(self) -> set[tuple[str, str]]:
+        return set(self._members)
+
+    def snapshots(self) -> list[Snapshot]:
+        by_id: dict[str, Snapshot] = {}
+        for member in self._members.values():
+            by_id.setdefault(member.snapshot.snapshot_id, member.snapshot)
+        return list(by_id.values())
+
+    def round_rows(self, *, groups: int, num_generations: int) -> list[PromptRow]:
+        rows: list[PromptRow] = []
+        for member in self._select(groups):
+            for _ in range(num_generations):
+                rows.append(
+                    {
+                        "prompt": [{"role": "user", "content": member.instruction}],
+                        "snapshot_id": member.snapshot.snapshot_id,
+                        "task_id": member.task_id,
+                    }
+                )
+        return rows
+
+    def _easy_tier(self) -> set[tuple[str, str]]:
+        ranked = sorted(self._members.values(), key=lambda m: (m.difficulty, m.key))
+        return {m.key for m in ranked[: max(1, len(ranked) // 3)]}
+
+    def _select(self, groups: int) -> list[_Member]:
+        groups = min(groups, len(self._members))
+        if groups == 0:
+            return []
+        easy = self._easy_tier()
+        floor_n = min(round(self._mix_floor * groups), len(easy))
+        by_priority = sorted(self._members.values(), key=lambda m: (-m.priority, m.key))
+        chosen: list[_Member] = []
+        taken: set[tuple[str, str]] = set()
+        for member in by_priority:
+            if len(chosen) >= floor_n:
+                break
+            if member.key in easy:
+                chosen.append(member)
+                taken.add(member.key)
+        for member in by_priority:
+            if len(chosen) >= groups:
+                break
+            if member.key not in taken:
+                chosen.append(member)
+                taken.add(member.key)
+        return chosen
+
+    def update(
+        self,
+        reports: RoundReports,
+        *,
+        pack: Pack,
+        policy: CurriculumPolicy = direction_from_reports,
+        gate: EvolutionGate | None = None,
+        evolve_top: int = 1,
+        max_repairs: int = 2,
+    ) -> None:
+        for member in self._members.values():
+            ran = reports.get(member.key)
+            if ran:
+                member.priority = _member_priority(ran)
+            else:
+                member.priority += _STALENESS_STEP
+        self._grow(reports, pack, policy, gate, evolve_top, max_repairs)
+        self._bound()
+
+    def _grow(
+        self,
+        reports: RoundReports,
+        pack: Pack,
+        policy: CurriculumPolicy,
+        gate: EvolutionGate | None,
+        evolve_top: int,
+        max_repairs: int,
+    ) -> None:
+        ran = sorted(
+            (m for m in self._members.values() if reports.get(m.key)),
+            key=lambda m: (-m.priority, m.key),
+        )
+        for member in ran[:evolve_top]:
+            child = auto_evolve(
+                member.snapshot,
+                *reports[member.key],
+                pack=pack,
+                policy=policy,
+                gate=gate,
+                max_repairs=max_repairs,
+            )
+            if child is None:
+                continue
+            difficulty = self._difficulty_fn(child)
+            for task in child.tasks:
+                if str(task.meta.get("family", "")) != member.family:
+                    continue
+                key = (child.snapshot_id, task.id)
+                if key not in self._members:
+                    self._members[key] = _Member(
+                        snapshot=child,
+                        task_id=task.id,
+                        instruction=task.instruction,
+                        family=member.family,
+                        difficulty=difficulty,
+                    )
+                break
+
+    def _bound(self) -> None:
+        protected = self._easy_tier()
+        evictable = sorted(
+            (m for m in self._members.values() if m.key not in protected),
+            key=lambda m: (m.priority, m.key),
+        )
+        while len(self._members) > self._max_size and evictable:
+            del self._members[evictable.pop(0).key]
+
+
+def run_pool_curriculum(
+    pool: WorldPool,
+    run_round: RunRound,
+    *,
+    rounds: int,
+    pack: Pack,
+    groups: int,
+    num_generations: int,
+    policy: CurriculumPolicy = direction_from_reports,
+    gate: EvolutionGate | None = None,
+    evolve_top: int = 1,
+) -> WorldPool:
+    for _ in range(rounds):
+        rows = pool.round_rows(groups=groups, num_generations=num_generations)
+        reports = run_round(rows, pool.snapshots())
+        pool.update(reports, pack=pack, policy=policy, gate=gate, evolve_top=evolve_top)
+    return pool

--- a/packs/cyber_webapp/cyber_webapp/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/__init__.py
@@ -23,6 +23,7 @@ from cyber_webapp.invariants import (
     secret_must_be_held,
     sqli_targets_db_backed_service,
 )
+from cyber_webapp.mutation import monotone_chain_gate
 from cyber_webapp.ontology import ONTOLOGY_ID, webapp_ontology
 from cyber_webapp.realize import (
     ContainerWebappRuntime,
@@ -103,6 +104,7 @@ __all__ = [
     "WebappRuntime",
     "credential_reuse_binding",
     "minimum_backing",
+    "monotone_chain_gate",
     "no_orphan_nodes",
     "oracle_path_exists",
     "secret_must_be_held",

--- a/packs/cyber_webapp/cyber_webapp/difficulty.py
+++ b/packs/cyber_webapp/cyber_webapp/difficulty.py
@@ -3,8 +3,7 @@
 The pivot chain depth — how many credentials must be looted and reused in
 sequence to reach the flag — is what makes a world harder, so it dominates; vuln
 count only breaks ties between equal-depth worlds. The weight exceeds the
-per-world vuln count (single digits) so depth always outranks surface. This is
-the static proxy; a behavioural term (solve rate) refines it once a world runs.
+per-world vuln count (single digits) so depth always outranks surface.
 """
 
 from __future__ import annotations

--- a/packs/cyber_webapp/cyber_webapp/difficulty.py
+++ b/packs/cyber_webapp/cyber_webapp/difficulty.py
@@ -1,0 +1,24 @@
+"""A world's difficulty as one comparable number, read from the graph.
+
+The pivot chain depth — how many credentials must be looted and reused in
+sequence to reach the flag — is what makes a world harder, so it dominates; vuln
+count only breaks ties between equal-depth worlds. The weight exceeds the
+per-world vuln count (single digits) so depth always outranks surface. This is
+the static proxy; a behavioural term (solve rate) refines it once a world runs.
+"""
+
+from __future__ import annotations
+
+from graphschema import WorldGraph
+
+_CHAIN_WEIGHT = 10
+
+
+def world_difficulty(graph: WorldGraph) -> int:
+    vulns = list(graph.by_kind("vulnerability"))
+    chain_depth = sum(
+        1
+        for vuln in vulns
+        if str(vuln.attrs.get("kind", "")).startswith("credential_gated")
+    )
+    return chain_depth * _CHAIN_WEIGHT + len(vulns)

--- a/packs/cyber_webapp/cyber_webapp/difficulty.py
+++ b/packs/cyber_webapp/cyber_webapp/difficulty.py
@@ -1,9 +1,7 @@
 """A world's difficulty as one comparable number, read from the graph.
 
-The pivot chain depth — how many credentials must be looted and reused in
-sequence to reach the flag — is what makes a world harder, so it dominates; vuln
-count only breaks ties between equal-depth worlds. The weight exceeds the
-per-world vuln count (single digits) so depth always outranks surface.
+The chain weight must exceed the per-world vuln count (single digits) so chain
+depth always outranks vuln count, which only breaks ties between equal depths.
 """
 
 from __future__ import annotations

--- a/packs/cyber_webapp/cyber_webapp/mutation.py
+++ b/packs/cyber_webapp/cyber_webapp/mutation.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 
 from graphschema import Edge, GraphPatch, Node, Visibility, WorldGraph
-from openrange_pack_sdk import EpisodeReportLike, Mutation
+from openrange_pack_sdk import EpisodeReportLike, Mutation, Snapshot
 
 from cyber_webapp.ontology import ONTOLOGY_ID
 from cyber_webapp.vulnerabilities import CATALOG as VULN_CATALOG
@@ -25,6 +25,13 @@ _ADD_ABSENT_RELEVANCE = 0.5
 # Less drastic than fully removing all instances; rotates which exploit
 # the agent has to learn while holding attack-surface count steady.
 _SWAP_PRESENT_RELEVANCE = 0.2
+
+# Above the decoy harden (0.5) so deepening the chain is the preferred frontier
+# step: it extends the required skill instead of adding an off-path vuln.
+_APPEND_HOP_RELEVANCE = 0.9
+
+_GATE_PATH = "/internal/vault"
+_TOKEN_PARAMS: tuple[str, ...] = ("token", "api_key", "auth", "session", "key")
 
 
 def coerce_string_list(value: object) -> list[str]:
@@ -46,6 +53,10 @@ def available_mutations(
     path_hits = _successful_path_hits(reports)
 
     options: list[Mutation] = []
+
+    hop = _harden_append_hop_mutation(graph, family_id)
+    if hop is not None:
+        options.append(hop)
 
     options.extend(
         _harden_add_absent_mutations(graph, family_id, vulns_by_kind),
@@ -235,6 +246,204 @@ def _diversify_swap_kind_mutations(
             ),
         )
     return mutations
+
+
+def _harden_append_hop_mutation(
+    graph: WorldGraph,
+    family_id: str,
+) -> Mutation | None:
+    # The skill-extending frontier step: deepen the credential chain by one hop so
+    # the parent's whole looting sequence is preserved and extended. The flag is
+    # served from runtime secrets by whichever vuln is credential_gated_flag, so
+    # flipping the terminal gate to a relay and adding a fresh flag gate on a spare
+    # host moves the chain's end without moving anything in the flag's store.
+    terminal = _credential_gated_flag(graph)
+    if terminal is None:
+        return None
+    term_ep = _affects_target_id(graph, terminal.id)
+    if term_ep is None:
+        return None
+    new_host = _spare_internal_service(graph, _chain_service_ids(graph))
+    if new_host is None:
+        return None
+    new_host_name = str(new_host.attrs.get("name", new_host.id))
+
+    term_params = dict(terminal.attrs.get("params", {}))
+    next_index = sum(
+        1 for n in graph.by_kind("credential") if n.id.startswith("cred_chain_")
+    )
+    new_cred_id = f"cred_chain_{next_index}"
+    seed = f"{terminal.id}:append:{next_index}"
+    new_token = hashlib.sha256(seed.encode()).hexdigest()[:24]
+    new_param = _TOKEN_PARAMS[_stable_index(seed + ":param", len(_TOKEN_PARAMS))]
+    new_ep_id = f"ep_{new_host_name}_vault"
+    new_flag_id = _fresh_vuln_id("credential_gated_flag", set(graph.nodes))
+
+    relay = Node(
+        id=terminal.id,
+        kind="vulnerability",
+        attrs={
+            "kind": "credential_gated_relay",
+            "family": str(terminal.attrs.get("family", "code_web")),
+            "params": {
+                "credential": term_params.get("credential", ""),
+                "token_param": term_params.get("token_param", "token"),
+                "next_credential": new_token,
+                "next_vault_host": new_host_name,
+                "next_vault_path": _GATE_PATH,
+                "next_token_param": new_param,
+            },
+        },
+        visibility=Visibility.HIDDEN,
+    )
+    cred = Node(
+        id=new_cred_id,
+        kind="credential",
+        attrs={"kind": "token", "value_ref": new_token},
+    )
+    endpoint = Node(
+        id=new_ep_id,
+        kind="endpoint",
+        attrs={
+            "path": _GATE_PATH,
+            "public_url": f"/svc/{new_host_name}{_GATE_PATH}",
+            "method": "GET",
+            "auth_required": True,
+            "behavior_ref": "credential.gate",
+        },
+    )
+    flag = Node(
+        id=new_flag_id,
+        kind="vulnerability",
+        attrs={
+            "kind": "credential_gated_flag",
+            "family": "code_web",
+            "params": {"credential": new_token, "token_param": new_param},
+        },
+        visibility=Visibility.HIDDEN,
+    )
+    patch = GraphPatch(
+        nodes_added=[cred, endpoint, flag],
+        nodes_updated=[relay],
+        edges_added=[
+            _chain_edge(new_host.id, "exposes", new_ep_id),
+            _chain_edge(new_flag_id, "affects", new_ep_id, _GATE_PATH),
+            _chain_edge(terminal.id, "enables", new_flag_id),
+            _chain_edge(new_ep_id, "requires_credential", new_cred_id),
+            _chain_edge(terminal.id, "produces", new_cred_id),
+        ],
+    )
+    return Mutation(
+        patch=patch,
+        direction="harden",
+        relevance=_APPEND_HOP_RELEVANCE,
+        family=family_id,
+        note=f"append a credential hop via {new_host_name}",
+    )
+
+
+def _chain_edge(src: str, kind: str, dst: str, injection_site: str = "") -> Edge:
+    attrs = {"injection_site": injection_site} if injection_site else {}
+    return Edge(id=_edge_id(src, kind, dst), kind=kind, src=src, dst=dst, attrs=attrs)
+
+
+def _credential_gated_flag(graph: WorldGraph) -> Node | None:
+    for node in graph.by_kind("vulnerability"):
+        if node.attrs.get("kind") == "credential_gated_flag":
+            return node
+    return None
+
+
+def _service_of_endpoint(graph: WorldGraph, endpoint_id: str) -> Node | None:
+    for edge in graph.in_edges(endpoint_id, "exposes"):
+        return graph.nodes.get(edge.src)
+    return None
+
+
+def _chain_service_ids(graph: WorldGraph) -> set[str]:
+    used: set[str] = set()
+    for vuln in graph.by_kind("vulnerability"):
+        if not str(vuln.attrs.get("kind", "")).startswith("credential"):
+            continue
+        endpoint_id = _affects_target_id(graph, vuln.id)
+        service = _service_of_endpoint(graph, endpoint_id) if endpoint_id else None
+        if service is not None:
+            used.add(service.id)
+    return used
+
+
+def _spare_internal_service(graph: WorldGraph, used: set[str]) -> Node | None:
+    spares = [
+        node
+        for node in graph.by_kind("service")
+        if node.attrs.get("exposure") != "public" and node.id not in used
+    ]
+    return min(spares, key=lambda n: n.id, default=None)
+
+
+def _credential_walk(graph: WorldGraph) -> list[tuple[str, str]]:
+    # The solution as the solver walks it: the ordered (host, credential) pairs
+    # presented at each gate, following the enables chain from the leak to the
+    # flag gate. The monotonicity gate compares two of these.
+    enables: dict[str, list[str]] = {}
+    for edge in graph.edges.values():
+        if edge.kind == "enables":
+            enables.setdefault(edge.src, []).append(edge.dst)
+    current = next(
+        (
+            n
+            for n in graph.by_kind("vulnerability")
+            if n.attrs.get("kind") == "credential_leak"
+        ),
+        None,
+    )
+    walk: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    while current is not None and current.id not in seen:
+        seen.add(current.id)
+        kind = str(current.attrs.get("kind", ""))
+        if kind in ("credential_gated_relay", "credential_gated_flag"):
+            endpoint_id = _affects_target_id(graph, current.id)
+            service = _service_of_endpoint(graph, endpoint_id) if endpoint_id else None
+            host = str(service.attrs.get("name", service.id)) if service else ""
+            cred = str(dict(current.attrs.get("params", {})).get("credential", ""))
+            walk.append((host, cred))
+            if kind == "credential_gated_flag":
+                break
+        following = sorted(enables.get(current.id, []))
+        current = next(
+            (
+                graph.nodes[nid]
+                for nid in following
+                if nid in graph.nodes
+                and str(graph.nodes[nid].attrs.get("kind", "")).startswith(
+                    "credential_gated"
+                )
+            ),
+            None,
+        )
+    return walk
+
+
+def monotone_chain_gate(parent: Snapshot) -> Callable[[Snapshot, Mutation], bool]:
+    """An evolution gate that admits a child only if it extends the parent's
+    credential chain by exactly one hop — the parent's solve walk is a literal
+    prefix of the child's. Rejects decoys, swaps, and relocations tagged "harden",
+    and rejects a parent that has no chain to extend.
+    """
+    parent_walk = _credential_walk(parent.graph)
+
+    def gate(evolved: Snapshot, mutation: Mutation) -> bool:
+        del mutation
+        if not parent_walk:
+            return False
+        child_walk = _credential_walk(evolved.graph)
+        return (
+            len(child_walk) == len(parent_walk) + 1
+            and child_walk[: len(parent_walk)] == parent_walk
+        )
+
+    return gate
 
 
 def _vulns_by_kind(graph: WorldGraph) -> dict[str, list[str]]:

--- a/packs/cyber_webapp/cyber_webapp/mutation.py
+++ b/packs/cyber_webapp/cyber_webapp/mutation.py
@@ -252,12 +252,9 @@ def _harden_append_hop_mutation(
     graph: WorldGraph,
     family_id: str,
 ) -> Mutation | None:
-    # The skill-extending frontier step: deepen the credential chain by one hop, so
-    # the parent's whole looting sequence is preserved and extended. The terminal
-    # flag gate flips to a relay; a fresh flag gate is added on a spare host, and the
-    # flag's backing store is repointed to that host so it owns the flag under the
-    # per-service scoped seed the CONTAINER backing uses, not only the shared PROCESS
-    # seed — keeping the deepened world solvable across backings.
+    # The flag's backing store is repointed to the new host so it owns the flag under
+    # the per-service scoped seed the CONTAINER backing uses, not only the shared
+    # PROCESS seed — keeping the deepened world solvable across backings.
     terminal = _credential_gated_flag(graph)
     if terminal is None:
         return None
@@ -414,9 +411,6 @@ def _flag_store(graph: WorldGraph) -> str | None:
 
 
 def _credential_walk(graph: WorldGraph) -> list[tuple[str, str]]:
-    # The solution as the solver walks it: the ordered (host, credential) pairs
-    # presented at each gate, following the enables chain from the leak to the
-    # flag gate. The monotonicity gate compares two of these.
     enables: dict[str, list[str]] = {}
     for edge in graph.edges.values():
         if edge.kind == "enables":
@@ -458,10 +452,9 @@ def _credential_walk(graph: WorldGraph) -> list[tuple[str, str]]:
 
 
 def monotone_chain_gate(parent: Snapshot) -> Callable[[Snapshot, Mutation], bool]:
-    """An evolution gate that admits a child only if it extends the parent's
-    credential chain by exactly one hop — the parent's solve walk is a literal
-    prefix of the child's. Rejects decoys, swaps, and relocations tagged "harden",
-    and rejects a parent that has no chain to extend.
+    """Admit a child only if it extends the parent's credential chain by exactly
+    one hop: the parent's solve walk must be a literal prefix of the child's. A
+    parent with no chain to extend is rejected.
     """
     parent_walk = _credential_walk(parent.graph)
 

--- a/packs/cyber_webapp/cyber_webapp/mutation.py
+++ b/packs/cyber_webapp/cyber_webapp/mutation.py
@@ -252,16 +252,24 @@ def _harden_append_hop_mutation(
     graph: WorldGraph,
     family_id: str,
 ) -> Mutation | None:
-    # The skill-extending frontier step: deepen the credential chain by one hop so
-    # the parent's whole looting sequence is preserved and extended. The flag is
-    # served from runtime secrets by whichever vuln is credential_gated_flag, so
-    # flipping the terminal gate to a relay and adding a fresh flag gate on a spare
-    # host moves the chain's end without moving anything in the flag's store.
+    # The skill-extending frontier step: deepen the credential chain by one hop, so
+    # the parent's whole looting sequence is preserved and extended. The terminal
+    # flag gate flips to a relay; a fresh flag gate is added on a spare host, and the
+    # flag's backing store is repointed to that host so it owns the flag under the
+    # per-service scoped seed the CONTAINER backing uses, not only the shared PROCESS
+    # seed — keeping the deepened world solvable across backings.
     terminal = _credential_gated_flag(graph)
     if terminal is None:
         return None
     term_ep = _affects_target_id(graph, terminal.id)
     if term_ep is None:
+        return None
+    store = _flag_store(graph)
+    backed_by = next(
+        (e for e in graph.edges.values() if e.kind == "backed_by" and e.dst == store),
+        None,
+    )
+    if store is None or backed_by is None:
         return None
     new_host = _spare_internal_service(graph, _chain_service_ids(graph))
     if new_host is None:
@@ -325,12 +333,14 @@ def _harden_append_hop_mutation(
     patch = GraphPatch(
         nodes_added=[cred, endpoint, flag],
         nodes_updated=[relay],
+        edges_removed=[backed_by.id],
         edges_added=[
             _chain_edge(new_host.id, "exposes", new_ep_id),
             _chain_edge(new_flag_id, "affects", new_ep_id, _GATE_PATH),
             _chain_edge(terminal.id, "enables", new_flag_id),
             _chain_edge(new_ep_id, "requires_credential", new_cred_id),
             _chain_edge(terminal.id, "produces", new_cred_id),
+            _chain_edge(new_host.id, "backed_by", store),
         ],
     )
     return Mutation(
@@ -379,6 +389,28 @@ def _spare_internal_service(graph: WorldGraph, used: set[str]) -> Node | None:
         if node.attrs.get("exposure") != "public" and node.id not in used
     ]
     return min(spares, key=lambda n: n.id, default=None)
+
+
+def _flag_store(graph: WorldGraph) -> str | None:
+    flag = next(
+        (n for n in graph.by_kind("secret") if n.attrs.get("kind") == "flag"), None
+    )
+    if flag is None:
+        return None
+    record = next(
+        (e.src for e in graph.edges.values() if e.kind == "holds" and e.dst == flag.id),
+        None,
+    )
+    if record is None:
+        return None
+    return next(
+        (
+            e.src
+            for e in graph.edges.values()
+            if e.kind == "contains" and e.dst == record
+        ),
+        None,
+    )
 
 
 def _credential_walk(graph: WorldGraph) -> list[tuple[str, str]]:

--- a/src/openrange/__init__.py
+++ b/src/openrange/__init__.py
@@ -56,6 +56,12 @@ from openrange.npc import (
     NPCS,
     NPCRegistry,
 )
+from openrange.pool import (
+    EvalPool,
+    RoundMetrics,
+    WorldPool,
+    run_pool_curriculum,
+)
 from openrange.runtime import (
     DashboardServerHandle,
     EpisodeContext,
@@ -99,6 +105,7 @@ __all__ = [
     "EpisodeRuntimeError",
     "EpisodeService",
     "EpisodeUpdate",
+    "EvalPool",
     "GraphPatch",
     "Issue",
     "NPCS",
@@ -112,6 +119,7 @@ __all__ = [
     "PackRegistry",
     "Reward",
     "Role",
+    "RoundMetrics",
     "RunConfig",
     "SnapshotStore",
     "Solver",
@@ -123,12 +131,14 @@ __all__ = [
     "TrajectoryStep",
     "Visibility",
     "WorldGraph",
+    "WorldPool",
     "admit",
     "apply_patch",
     "auto_evolve",
     "direction_from_reports",
     "episode_reward",
     "episode_trajectory",
+    "run_pool_curriculum",
     "snapshot_to_dict",
     "to_jsonl",
     "validate",

--- a/src/openrange/core/curriculum.py
+++ b/src/openrange/core/curriculum.py
@@ -112,6 +112,10 @@ def auto_evolve(
                 continue
         return evolved
 
+    # The grow fallback is a difficulty-knob rebuild (a fresh resample), not an
+    # in-place chain step, so it is intentionally outside the gate: a pack that uses
+    # grow for a monotone frontier must keep ``default_prior`` None, as the cyber
+    # pack does, so this path never fires there.
     try:
         return _grow_snapshot(snapshot, pack, direction, max_repairs=max_repairs)
     except Exception:  # noqa: BLE001 — pack-supplied code is untrusted

--- a/src/openrange/core/curriculum.py
+++ b/src/openrange/core/curriculum.py
@@ -191,6 +191,27 @@ def _grow_snapshot(
     return grown
 
 
+def _evolve_block(
+    *,
+    parent_snapshot_id: str,
+    direction: str,
+    kind: str,
+    relevance: float | None = None,
+    family: str | None = None,
+    note: str = "",
+) -> dict[str, object]:
+    # One schema for every path: grow's absent fields are explicit None, not
+    # omitted, so a reader never special-cases which path made the snapshot.
+    return {
+        "parent_snapshot_id": parent_snapshot_id,
+        "direction": direction,
+        "kind": kind,
+        "relevance": relevance,
+        "family": family,
+        "note": note,
+    }
+
+
 def _with_grow_lineage(
     result: Snapshot,
     parent: Snapshot,
@@ -214,11 +235,11 @@ def _with_grow_lineage(
         lineage={
             **dict(result.lineage),
             "curriculum_difficulty": difficulty,
-            "_evolve": {
-                "parent_snapshot_id": parent.snapshot_id,
-                "direction": direction,
-                "kind": "grow",
-            },
+            "_evolve": _evolve_block(
+                parent_snapshot_id=parent.snapshot_id,
+                direction=direction,
+                kind="grow",
+            ),
         },
         history=(*result.history, event),
     )
@@ -254,17 +275,7 @@ def _evolve_snapshot(
         regenerated.extend(family.generate(evolved_graph, base_manifest, None))
 
     wrapped = _PreBuiltPack(pack, evolved_graph, regenerated)
-    evolved_manifest = {
-        **base_manifest,
-        "_evolve": {
-            "parent_snapshot_id": snapshot.snapshot_id,
-            "direction": mutation.direction,
-            "relevance": mutation.relevance,
-            "family": mutation.family,
-            "note": mutation.note,
-        },
-    }
-    result = admit(wrapped, manifest=evolved_manifest, max_repairs=max_repairs)
+    result = admit(wrapped, manifest=dict(base_manifest), max_repairs=max_repairs)
     if isinstance(result, AdmissionFailure):
         return None
     assert isinstance(result, _Snapshot)
@@ -286,6 +297,14 @@ def _evolve_snapshot(
     lineage = dict(result.lineage)
     if isinstance(carried, dict):
         lineage.setdefault("curriculum_difficulty", carried)
+    lineage["_evolve"] = _evolve_block(
+        parent_snapshot_id=snapshot.snapshot_id,
+        direction=mutation.direction,
+        kind="patch",
+        relevance=mutation.relevance,
+        family=mutation.family,
+        note=mutation.note,
+    )
     return _Snapshot(
         snapshot_id=result.snapshot_id,
         ontology_id=result.ontology_id,

--- a/src/openrange/core/curriculum.py
+++ b/src/openrange/core/curriculum.py
@@ -114,8 +114,8 @@ def auto_evolve(
 
     # The grow fallback is a difficulty-knob rebuild (a fresh resample), not an
     # in-place chain step, so it is intentionally outside the gate: a pack that uses
-    # grow for a monotone frontier must keep ``default_prior`` None, as the cyber
-    # pack does, so this path never fires there.
+    # grow for a monotone frontier must keep ``default_prior`` None so this path
+    # never fires there.
     try:
         return _grow_snapshot(snapshot, pack, direction, max_repairs=max_repairs)
     except Exception:  # noqa: BLE001 — pack-supplied code is untrusted

--- a/src/openrange/core/curriculum.py
+++ b/src/openrange/core/curriculum.py
@@ -112,10 +112,8 @@ def auto_evolve(
                 continue
         return evolved
 
-    # The grow fallback is a difficulty-knob rebuild (a fresh resample), not an
-    # in-place chain step, so it is intentionally outside the gate: a pack that uses
-    # grow for a monotone frontier must keep ``default_prior`` None so this path
-    # never fires there.
+    # Intentionally outside the gate: a pack using grow for a monotone frontier
+    # must keep ``default_prior`` None so this fallback never fires there.
     try:
         return _grow_snapshot(snapshot, pack, direction, max_repairs=max_repairs)
     except Exception:  # noqa: BLE001 — pack-supplied code is untrusted
@@ -204,8 +202,7 @@ def _evolve_block(
     family: str | None = None,
     note: str = "",
 ) -> dict[str, object]:
-    # One schema for every path: grow's absent fields are explicit None, not
-    # omitted, so a reader never special-cases which path made the snapshot.
+    # Absent fields are explicit None, not omitted, so every path shares one schema.
     return {
         "parent_snapshot_id": parent_snapshot_id,
         "direction": direction,

--- a/src/openrange/core/episode.py
+++ b/src/openrange/core/episode.py
@@ -216,8 +216,8 @@ class EpisodeService:
         else:
             self.npc_agent_backend = None
         self._episodes: dict[str, _RunningEpisode] = {}
-        # An LRU of booted worlds: a round sampling D distinct worlds needs
-        # capacity >= D or it thrashes (boot-evict-boot).
+        # LRU of booted worlds; capacity below a round's distinct-world
+        # count thrashes (boot-evict-boot).
         self._warm: OrderedDict[str, RuntimeHandle] = OrderedDict()
         self._warm_capacity = max(1, warm_capacity)
         # Cached reports for stopped episodes — populated by

--- a/src/openrange/core/episode.py
+++ b/src/openrange/core/episode.py
@@ -8,6 +8,7 @@ import threading
 import time
 import uuid
 import weakref
+from collections import OrderedDict
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -196,6 +197,7 @@ class EpisodeService:
         npc_agent_backend: AgentBackend | None = None,
         npc_llm_model: str | None = None,
         backing: Backing = Backing.PROCESS,
+        warm_capacity: int = 1,
     ) -> None:
         self.pack = pack
         self.run_root = Path(run_root)
@@ -214,7 +216,10 @@ class EpisodeService:
         else:
             self.npc_agent_backend = None
         self._episodes: dict[str, _RunningEpisode] = {}
-        self._warm: dict[str, RuntimeHandle] = {}
+        # An LRU of booted worlds: a round sampling D distinct worlds needs
+        # capacity >= D or it thrashes (boot-evict-boot).
+        self._warm: OrderedDict[str, RuntimeHandle] = OrderedDict()
+        self._warm_capacity = max(1, warm_capacity)
         # Cached reports for stopped episodes — populated by
         # ``stop_episode`` so ``check_episode`` keeps working after the
         # running entry is evicted.
@@ -301,17 +306,19 @@ class EpisodeService:
         if not _is_poolable(running.runtime):
             return False
         snapshot_id = running.snapshot.snapshot_id
-        # One warm world at a time: a new snapshot_id evicts the prior.
-        self._evict_warm(keep=snapshot_id)
         self._warm[snapshot_id] = running.runtime
+        self._warm.move_to_end(snapshot_id)
+        while len(self._warm) > self._warm_capacity:
+            _, evicted = self._warm.popitem(last=False)
+            with contextlib.suppress(Exception):
+                evicted.stop()
         return True
 
-    def _evict_warm(self, *, keep: str | None = None) -> None:
-        for snapshot_id in list(self._warm):
-            if snapshot_id == keep:
-                continue
+    def _evict_warm(self) -> None:
+        while self._warm:
+            _, runtime = self._warm.popitem()
             with contextlib.suppress(Exception):
-                self._warm.pop(snapshot_id).stop()
+                runtime.stop()
 
     def stop_episode(self, episode: EpisodeHandle) -> EpisodeReport:
         """Stop the runtime, run the success check, return the report.

--- a/src/openrange/dashboard/view.py
+++ b/src/openrange/dashboard/view.py
@@ -427,16 +427,8 @@ def _manifest_from_lineage(lineage: Mapping[str, object]) -> Mapping[str, object
 
 
 def _evolve_block(lineage: Mapping[str, object]) -> Mapping[str, object]:
-    # A grow step records ``_evolve`` at the top level; a patch step nests it
-    # under the manifest.
     top = lineage.get("_evolve")
-    if isinstance(top, Mapping):
-        return cast(Mapping[str, object], top)
-    manifest = _manifest_from_lineage(lineage)
-    nested = manifest.get("_evolve")
-    if isinstance(nested, Mapping):
-        return cast(Mapping[str, object], nested)
-    return {}
+    return cast(Mapping[str, object], top) if isinstance(top, Mapping) else {}
 
 
 def _parent_snapshot_id(lineage: Mapping[str, object]) -> str | None:

--- a/src/openrange/pool.py
+++ b/src/openrange/pool.py
@@ -3,11 +3,8 @@
 See ``docs/design/evolving-pool-curriculum.md``. Trainer-agnostic: it depends
 only on OpenRange core (admission, ``auto_evolve``) and the episode report, never
 on a training backend, so any adapter (``openrange-trl``, …) drives it through
-the caller-supplied ``run_round``. It seeds wide, samples a round's prompts with
-a mix floor so an easy tail always survives, and between rounds shifts slowly —
-re-prioritising members by how much they can still teach, evolving the most
-promising into admitted children while keeping their parents. Difficulty is
-injected by the caller so the pool stays pack-agnostic.
+the caller-supplied ``run_round``. A mix floor keeps an easy tail in every round.
+Difficulty is injected by the caller so the pool stays pack-agnostic.
 """
 
 from __future__ import annotations
@@ -34,9 +31,8 @@ RunRound = Callable[[list[PromptRow], list[Snapshot]], RoundReports]
 GateFactory = Callable[[Snapshot], EvolutionGate]
 
 _STALENESS_STEP = 0.1
-# The most a round can score a member (learnability + regret, each <= 1): idle
-# members cap here (bounded pump) and fresh children seat here, so a new frontier
-# world is sampled next round instead of evicted before it ever runs.
+# Idle members cap here and fresh children seat here, so a new frontier world is
+# sampled next round instead of evicted before it ever runs.
 _MAX_PRIORITY = 2.0
 
 
@@ -111,9 +107,8 @@ def _member_priority(reports: Sequence[EpisodeReport]) -> float:
         if subgoals:
             achieved = sum(1 for hit in subgoals.values() if hit)
             gaps.append(1.0 - achieved / len(subgoals))
-    # The regret term keeps a world the agent is stuck partway through (low reward
-    # spread, so learnability alone would retire it) at the frontier — the distance
-    # from the ceiling, assuming every listed subgoal is reachable.
+    # Regret keeps a world the agent is stuck partway through at the frontier, where
+    # learnability alone (low reward spread) would retire it.
     regret = sum(gaps) / len(gaps) if gaps else 0.0
     return learnability + regret
 
@@ -243,8 +238,8 @@ class WorldPool:
         max_repairs: int,
     ) -> tuple[set[tuple[str, str]], bool]:
         grown: set[tuple[str, str]] = set()
-        # A selected member that yields no child is a frontier cap: the curriculum
-        # wanted to advance it but no admissible harder world passed the gate.
+        # Frontier cap: a member was due to advance but no admissible harder world
+        # passed the gate.
         capped = False
         ran = sorted(
             (m for m in self._members.values() if reports.get(m.key)),
@@ -303,11 +298,9 @@ class RoundMetrics:
 
 
 class EvalPool:
-    """A held-out set of admitted worlds, fenced from training.
-
-    It is measured each round but never sampled into a group, evolved, or bounded,
-    so train-vs-held-out solve-rate is the generalization signal the pool bet rests
-    on (``docs/design/evolving-pool-curriculum.md`` §8).
+    """A held-out set of admitted worlds, measured each round but never sampled,
+    evolved, or bounded, so train-vs-held-out solve-rate is the generalization
+    signal (``docs/design/evolving-pool-curriculum.md`` §8).
     """
 
     def __init__(self, members: Sequence[_Member]) -> None:
@@ -363,11 +356,10 @@ def run_pool_curriculum(
     evolve_top: int = 1,
     eval_pool: EvalPool | None = None,
 ) -> list[RoundMetrics]:
-    """Run the curriculum, returning per-round train and held-out solve rates.
+    """Run the curriculum, updating ``pool`` in place.
 
-    The pool is updated in place. When ``eval_pool`` is given it is measured each
-    round but never trained on or evolved, so the train-vs-held-out gap is the
-    generalization signal (§8).
+    When ``eval_pool`` is given it is measured each round but never trained on or
+    evolved, so the train-vs-held-out gap is the generalization signal (§8).
     """
     metrics: list[RoundMetrics] = []
     for _ in range(rounds):

--- a/src/openrange/pool.py
+++ b/src/openrange/pool.py
@@ -1,8 +1,10 @@
 """The curriculum as an evolving pool of worlds-and-tasks.
 
-See ``docs/design/evolving-pool-curriculum.md``. The pool is harness-side (core
-ships no curriculum algorithm): it seeds wide, samples a round's prompts with a
-mix floor so an easy tail always survives, and between rounds shifts slowly —
+See ``docs/design/evolving-pool-curriculum.md``. Trainer-agnostic: it depends
+only on OpenRange core (admission, ``auto_evolve``) and the episode report, never
+on a training backend, so any adapter (``openrange-trl``, …) drives it through
+the caller-supplied ``run_round``. It seeds wide, samples a round's prompts with
+a mix floor so an easy tail always survives, and between rounds shifts slowly —
 re-prioritising members by how much they can still teach, evolving the most
 promising into admitted children while keeping their parents. Difficulty is
 injected by the caller so the pool stays pack-agnostic.

--- a/tests/test_curriculum.py
+++ b/tests/test_curriculum.py
@@ -421,14 +421,42 @@ def test_auto_evolve_picks_highest_relevance_in_direction() -> None:
     assert "vuln.sqli" in out.graph.nodes
     # The original snapshot is untouched (re-admission must not mutate).
     assert "ep.high" not in snap.graph.nodes
-    # Lineage carries the parent snapshot id so callers can chain.
-    out_manifest = out.lineage["manifest"]
-    assert isinstance(out_manifest, Mapping)
-    evolve_meta = out_manifest.get("_evolve")
+    # Lineage carries one canonical, top-level _evolve block (same schema for
+    # every evolution path), so a reader never special-cases grow vs patch.
+    evolve_meta = out.lineage["_evolve"]
     assert isinstance(evolve_meta, Mapping)
     assert evolve_meta["parent_snapshot_id"] == snap.snapshot_id
     assert evolve_meta["direction"] == "harden"
+    assert evolve_meta["kind"] == "patch"
+    assert evolve_meta["relevance"] == 0.9
+    assert evolve_meta["family"] == "stub.family"
     assert evolve_meta["note"] == "high"
+    # The block is not nested under the manifest any more.
+    out_manifest = out.lineage["manifest"]
+    assert isinstance(out_manifest, Mapping)
+    assert "_evolve" not in out_manifest
+
+
+def test_evolve_block_is_one_schema_across_paths() -> None:
+    # Grow and patch write the same six-field block, so a reader keying on
+    # ``relevance`` never KeyErrors on a grow child (it is present, just None).
+    from openrange.core.curriculum import _evolve_block
+
+    keys = {"parent_snapshot_id", "direction", "kind", "relevance", "family", "note"}
+    grow = _evolve_block(parent_snapshot_id="p", direction="harden", kind="grow")
+    patch = _evolve_block(
+        parent_snapshot_id="p",
+        direction="harden",
+        kind="patch",
+        relevance=0.7,
+        family="webapp.pentest",
+        note="add x",
+    )
+    assert set(grow) == keys
+    assert set(patch) == keys
+    assert grow["relevance"] is None
+    assert grow["family"] is None
+    assert patch["relevance"] == 0.7
 
 
 def test_auto_evolve_gate_skips_rejected_candidate() -> None:
@@ -691,12 +719,11 @@ def test_auto_evolve_e2e_on_webapp_pack() -> None:
         )
     assert isinstance(out, Snapshot)
     assert out.snapshot_id != snap.snapshot_id
-    out_manifest = out.lineage["manifest"]
-    assert isinstance(out_manifest, Mapping)
-    evolve_meta = out_manifest.get("_evolve")
+    evolve_meta = out.lineage["_evolve"]
     assert isinstance(evolve_meta, Mapping)
     assert evolve_meta["parent_snapshot_id"] == snap.snapshot_id
     assert evolve_meta["direction"] == "harden"
+    assert evolve_meta["kind"] == "patch"
 
 
 def test_auto_evolve_hardens_a_build_episode() -> None:

--- a/tests/test_curriculum.py
+++ b/tests/test_curriculum.py
@@ -421,8 +421,6 @@ def test_auto_evolve_picks_highest_relevance_in_direction() -> None:
     assert "vuln.sqli" in out.graph.nodes
     # The original snapshot is untouched (re-admission must not mutate).
     assert "ep.high" not in snap.graph.nodes
-    # Lineage carries one canonical, top-level _evolve block (same schema for
-    # every evolution path), so a reader never special-cases grow vs patch.
     evolve_meta = out.lineage["_evolve"]
     assert isinstance(evolve_meta, Mapping)
     assert evolve_meta["parent_snapshot_id"] == snap.snapshot_id
@@ -431,15 +429,14 @@ def test_auto_evolve_picks_highest_relevance_in_direction() -> None:
     assert evolve_meta["relevance"] == 0.9
     assert evolve_meta["family"] == "stub.family"
     assert evolve_meta["note"] == "high"
-    # The block is not nested under the manifest any more.
     out_manifest = out.lineage["manifest"]
     assert isinstance(out_manifest, Mapping)
     assert "_evolve" not in out_manifest
 
 
 def test_evolve_block_is_one_schema_across_paths() -> None:
-    # Grow and patch write the same six-field block, so a reader keying on
-    # ``relevance`` never KeyErrors on a grow child (it is present, just None).
+    # Grow leaves relevance/family present-but-None so callers keying on them
+    # never KeyError across paths.
     from openrange.core.curriculum import _evolve_block
 
     keys = {"parent_snapshot_id", "direction", "kind", "relevance", "family", "note"}

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -20,6 +20,7 @@ from cyber_webapp import (
     _is_networked,
     monotone_chain_gate,
 )
+from cyber_webapp.codegen.seeding import project_seed
 from cyber_webapp.difficulty import world_difficulty
 from cyber_webapp.mutation import available_mutations
 from cyber_webapp.reference_solver import solve_chain
@@ -500,10 +501,11 @@ def test_pool_holds_when_no_harder_world_admits(tmp_path: Path) -> None:
     member = next(iter(pool._members.values()))
     before = pool.keys()
     report = _breach_report(pack, tmp_path, member.snapshot)
-    pool.update(
+    capped = pool.update(
         {member.key: [report]}, pack=pack, gate=lambda _evolved, _mutation: False
     )
     assert pool.keys() == before
+    assert capped is True
 
 
 def test_regrowing_the_same_parent_does_not_duplicate(tmp_path: Path) -> None:
@@ -549,6 +551,32 @@ def test_append_a_hop_deepens_the_chain_and_stays_solvable(tmp_path: Path) -> No
     # +10 is the chain-depth weight: a hop was appended, not an off-path decoy (+1).
     assert world_difficulty(child.graph) - parent_diff >= 10
     assert _breach_report(pack, tmp_path / "child", child).passed
+
+
+def test_append_a_hop_keeps_the_flag_owned_under_scoped_seeding(tmp_path: Path) -> None:
+    # Cross-backing parity: the deepened world must be solvable under the per-service
+    # scoped seed the CONTAINER backing uses, not only the shared PROCESS seed — so
+    # the new flag-gate host must OWN the flag store, not merely serve it.
+    pack = WebappPack()
+    parent = _admit(_LATERAL_MANIFEST)
+    report = _breach_report(pack, tmp_path, parent)
+    child = auto_evolve(
+        parent, report, pack=pack, gate=monotone_chain_gate(parent), max_repairs=3
+    )
+    assert child is not None
+    g = child.graph
+    term = next(
+        n
+        for n in g.by_kind("vulnerability")
+        if n.attrs.get("kind") == "credential_gated_flag"
+    )
+    term_ep = next(
+        e.dst for e in g.edges.values() if e.kind == "affects" and e.src == term.id
+    )
+    gate_host = next(
+        e.src for e in g.edges.values() if e.kind == "exposes" and e.dst == term_ep
+    )
+    assert project_seed(g, only_services=frozenset({gate_host})).get("flag")
 
 
 def test_monotone_chain_gate_requires_one_more_hop(tmp_path: Path) -> None:
@@ -674,6 +702,7 @@ def test_held_out_eval_pool_is_fenced_and_measured(tmp_path: Path) -> None:
     assert all(m.train_solve_rate == 1.0 for m in metrics)
     assert all(m.held_out_solve_rate == 1.0 for m in metrics)
     assert all(m.generalization_gap == 0.0 for m in metrics)
+    assert not any(m.frontier_capped for m in metrics)
     assert held_out.keys() == eval_keys
     assert not (train.keys() & eval_keys)
 

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -14,14 +14,15 @@ from pathlib import Path
 
 import pytest
 from cyber_webapp import NetworkedContainerWebappRuntime, WebappPack, _is_networked
+from cyber_webapp.difficulty import world_difficulty
 from cyber_webapp.reference_solver import solve_chain
 from graphschema import Node, WorldGraph
 from openrange_pack_sdk import Backing, PoolableRuntime, Snapshot
-from openrange_trl import EpisodeEnv
+from openrange_trl import EpisodeEnv, WorldPool, run_pool_curriculum
 
 from examples.tools import WEB_TOOLS
 from openrange.core.admit import admit
-from openrange.core.episode import EpisodeService
+from openrange.core.episode import EpisodeReport, EpisodeService
 
 _COMPANY_MANIFEST = {
     "pack": {"id": "webapp"},
@@ -239,6 +240,146 @@ def test_write_exec_world_is_not_poolable() -> None:
         Backing.PROCESS,
     )
     assert isinstance(sqli, PoolableRuntime) and sqli.poolable()
+
+
+def test_world_difficulty_rises_with_chain_depth() -> None:
+    # Difficulty is read from the graph and dominated by the pivot chain depth,
+    # so a credential chain outranks a flat world that merely carries more vulns.
+    flat = world_difficulty(_admit(_DEFAULT_MANIFEST).graph)
+    company = world_difficulty(_admit(_COMPANY_MANIFEST).graph)
+    lateral = world_difficulty(
+        _admit({**_COMPANY_MANIFEST, "lateral_movement": True}).graph
+    )
+    assert flat < company < lateral
+
+
+def test_warm_cache_is_a_bounded_lru(tmp_path: Path) -> None:
+    # A round visiting more worlds than the cache budget keeps the most recent N
+    # warm and evicts the least-recently-used, rather than holding only one.
+    snaps = [_admit({**_COMPANY_MANIFEST, "seed": s}) for s in (1, 2, 3)]
+    assert len({s.snapshot_id for s in snaps}) == 3
+    svc = EpisodeService(WebappPack(), tmp_path, warm_capacity=2)
+    try:
+        for snap in snaps:
+            pentest = next(
+                t for t in snap.tasks if t.meta.get("family") == "webapp.pentest"
+            )
+            svc.stop_episode(svc.start_episode(snap, pentest.id))
+        warm_ids = list(svc._warm)
+        assert len(warm_ids) == 2
+        assert snaps[0].snapshot_id not in warm_ids
+        assert {snaps[1].snapshot_id, snaps[2].snapshot_id} == set(warm_ids)
+    finally:
+        svc.close()
+
+
+def test_pool_round_keeps_the_easy_tail() -> None:
+    # Even at the lowest priority, an easy-tier world stays in the round — the
+    # mix floor is enforced when the round is composed, not left to chance.
+    pack = WebappPack()
+    pool = WorldPool.seed(
+        pack,
+        [
+            _DEFAULT_MANIFEST,
+            _COMPANY_MANIFEST,
+            {**_COMPANY_MANIFEST, "lateral_movement": True},
+        ],
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=8,
+        mix_floor=0.5,
+    )
+    easiest = min(pool._members.values(), key=lambda m: m.difficulty)
+    for member in pool._members.values():
+        member.priority = 0.0 if member is easiest else 1.0
+    rows = pool.round_rows(groups=2, num_generations=1)
+    chosen = {row["snapshot_id"] for row in rows}
+    assert easiest.snapshot.snapshot_id in chosen
+
+
+def test_pool_curriculum_grows_bounds_and_keeps_a_mix(tmp_path: Path) -> None:
+    # Drive the pool through the real episode harness on PROCESS: seed wide, breach
+    # each sampled world, evolve between rounds. The pool grows a harder world,
+    # stays bounded, keeps its easy tail, and is deterministic.
+    import re
+
+    pack = WebappPack()
+    seeds = [{**_COMPANY_MANIFEST, "seed": s} for s in range(4)]
+
+    def flag_from(body: str) -> str:
+        try:
+            obj = json.loads(body)
+        except json.JSONDecodeError:
+            obj = None
+        if isinstance(obj, dict):
+            for key in ("credential", "data", "flag", "secret"):
+                value = obj.get(key)
+                if isinstance(value, str):
+                    return value
+        found = re.search(r"(?:ghp_|sk_live_|AKIA)[A-Za-z0-9_]+|[0-9a-f-]{32,36}", body)
+        return found.group(0) if found else ""
+
+    round_no = [0]
+
+    def run_round(
+        rows: list[dict[str, object]], snapshots: list[Snapshot]
+    ) -> dict[tuple[str, str], list[EpisodeReport]]:
+        round_no[0] += 1
+        by_id = {s.snapshot_id: s for s in snapshots}
+        svc = EpisodeService(
+            pack, tmp_path / f"r{round_no[0]}", warm_capacity=len(by_id)
+        )
+        env = EpisodeEnv(service=svc, snapshots=by_id, tools=WEB_TOOLS)
+        out: dict[tuple[str, str], list[EpisodeReport]] = {}
+        try:
+            for row in rows:
+                sid, tid = str(row["snapshot_id"]), str(row["task_id"])
+                snap = by_id[sid]
+                task = next(t for t in snap.tasks if t.id == tid)
+                entry = str(snap.graph.nodes[task.entrypoints[0]].attrs["public_url"])
+                env.reset(snapshot_id=sid, task_id=tid)
+                env.http_get(entry)
+                trace = solve_chain(
+                    snap.graph, lambda p: env.http_get(p).split("\n", 1)[-1]
+                )
+                env.submit(json.dumps({"flag": flag_from(trace.terminal)}))
+                env._finalize()
+                assert env.report is not None
+                out.setdefault((sid, tid), []).append(env.report)
+            return out
+        finally:
+            svc.close()
+
+    def pentest_only(_evolved: Snapshot, mutation: object) -> bool:
+        return getattr(mutation, "family", None) == "webapp.pentest"
+
+    def build_and_run() -> tuple[WorldPool, float]:
+        pool = WorldPool.seed(
+            pack,
+            seeds,
+            difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+            family="webapp.pentest",
+            max_size=5,
+        )
+        assert len(pool) == 4
+        seed_min = min(m.difficulty for m in pool._members.values())
+        run_pool_curriculum(
+            pool,
+            run_round,
+            rounds=2,
+            pack=pack,
+            groups=3,
+            num_generations=2,
+            gate=pentest_only,
+        )
+        return pool, seed_min
+
+    pool, seed_min = build_and_run()
+    diffs = [m.difficulty for m in pool._members.values()]
+    assert 4 < len(pool) <= 5
+    assert min(diffs) == seed_min
+    assert max(diffs) > seed_min
+    assert pool.keys() == build_and_run()[0].keys()
 
 
 def test_services_are_realistically_named() -> None:

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -26,19 +26,19 @@ from cyber_webapp.mutation import available_mutations
 from cyber_webapp.reference_solver import solve_chain
 from graphschema import Node, WorldGraph
 from openrange_pack_sdk import Backing, PoolableRuntime, Snapshot
-from openrange_trl import (
-    EpisodeEnv,
-    EvalPool,
-    RoundMetrics,
-    WorldPool,
-    run_pool_curriculum,
-)
-from openrange_trl._pool import _MAX_PRIORITY
+from openrange_trl import EpisodeEnv
 
 from examples.tools import WEB_TOOLS
 from openrange.core.admit import admit
 from openrange.core.curriculum import auto_evolve
 from openrange.core.episode import EpisodeReport, EpisodeService
+from openrange.pool import (
+    _MAX_PRIORITY,
+    EvalPool,
+    RoundMetrics,
+    WorldPool,
+    run_pool_curriculum,
+)
 
 _COMPANY_MANIFEST = {
     "pack": {"id": "webapp"},

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -5,6 +5,7 @@ same recon→pivot recovers the flag across real containers."""
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 import urllib.error
@@ -19,6 +20,7 @@ from cyber_webapp.reference_solver import solve_chain
 from graphschema import Node, WorldGraph
 from openrange_pack_sdk import Backing, PoolableRuntime, Snapshot
 from openrange_trl import EpisodeEnv, WorldPool, run_pool_curriculum
+from openrange_trl._pool import _MAX_PRIORITY
 
 from examples.tools import WEB_TOOLS
 from openrange.core.admit import admit
@@ -57,6 +59,41 @@ def _get(base_url: str, path: str) -> tuple[int, str]:
             return resp.status, resp.read().decode()
     except urllib.error.HTTPError as exc:
         return exc.code, exc.read().decode()
+
+
+def _flag_from(body: str) -> str:
+    try:
+        obj = json.loads(body)
+    except json.JSONDecodeError:
+        obj = None
+    if isinstance(obj, dict):
+        for key in ("credential", "data", "flag", "secret"):
+            value = obj.get(key)
+            if isinstance(value, str):
+                return value
+    found = re.search(r"(?:ghp_|sk_live_|AKIA)[A-Za-z0-9_]+|[0-9a-f-]{32,36}", body)
+    return found.group(0) if found else ""
+
+
+def _pentest_only(_evolved: Snapshot, mutation: object) -> bool:
+    return getattr(mutation, "family", None) == "webapp.pentest"
+
+
+def _breach_report(pack: WebappPack, work_dir: Path, snap: Snapshot) -> EpisodeReport:
+    task = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+    svc = EpisodeService(pack, work_dir)
+    env = EpisodeEnv(service=svc, snapshots={snap.snapshot_id: snap}, tools=WEB_TOOLS)
+    try:
+        entry = str(snap.graph.nodes[task.entrypoints[0]].attrs["public_url"])
+        env.reset(snapshot_id=snap.snapshot_id, task_id=task.id)
+        env.http_get(entry)
+        trace = solve_chain(snap.graph, lambda p: env.http_get(p).split("\n", 1)[-1])
+        env.submit(json.dumps({"flag": _flag_from(trace.terminal)}))
+        env._finalize()
+        assert env.report is not None
+        return env.report
+    finally:
+        svc.close()
 
 
 def test_company_world_is_multi_service_and_segmented() -> None:
@@ -301,24 +338,8 @@ def test_pool_curriculum_grows_bounds_and_keeps_a_mix(tmp_path: Path) -> None:
     # Drive the pool through the real episode harness on PROCESS: seed wide, breach
     # each sampled world, evolve between rounds. The pool grows a harder world,
     # stays bounded, keeps its easy tail, and is deterministic.
-    import re
-
     pack = WebappPack()
     seeds = [{**_COMPANY_MANIFEST, "seed": s} for s in range(4)]
-
-    def flag_from(body: str) -> str:
-        try:
-            obj = json.loads(body)
-        except json.JSONDecodeError:
-            obj = None
-        if isinstance(obj, dict):
-            for key in ("credential", "data", "flag", "secret"):
-                value = obj.get(key)
-                if isinstance(value, str):
-                    return value
-        found = re.search(r"(?:ghp_|sk_live_|AKIA)[A-Za-z0-9_]+|[0-9a-f-]{32,36}", body)
-        return found.group(0) if found else ""
-
     round_no = [0]
 
     def run_round(
@@ -342,16 +363,13 @@ def test_pool_curriculum_grows_bounds_and_keeps_a_mix(tmp_path: Path) -> None:
                 trace = solve_chain(
                     snap.graph, lambda p: env.http_get(p).split("\n", 1)[-1]
                 )
-                env.submit(json.dumps({"flag": flag_from(trace.terminal)}))
+                env.submit(json.dumps({"flag": _flag_from(trace.terminal)}))
                 env._finalize()
                 assert env.report is not None
                 out.setdefault((sid, tid), []).append(env.report)
             return out
         finally:
             svc.close()
-
-    def pentest_only(_evolved: Snapshot, mutation: object) -> bool:
-        return getattr(mutation, "family", None) == "webapp.pentest"
 
     def build_and_run() -> tuple[WorldPool, float]:
         pool = WorldPool.seed(
@@ -370,7 +388,7 @@ def test_pool_curriculum_grows_bounds_and_keeps_a_mix(tmp_path: Path) -> None:
             pack=pack,
             groups=3,
             num_generations=2,
-            gate=pentest_only,
+            gate=_pentest_only,
         )
         return pool, seed_min
 
@@ -380,6 +398,118 @@ def test_pool_curriculum_grows_bounds_and_keeps_a_mix(tmp_path: Path) -> None:
     assert min(diffs) == seed_min
     assert max(diffs) > seed_min
     assert pool.keys() == build_and_run()[0].keys()
+
+
+def test_grown_child_survives_a_full_pool(tmp_path: Path) -> None:
+    # A freshly grown frontier child is the hardest, newest member; when the pool is
+    # full and older members have drifted up on staleness, it must not be the one
+    # evicted the same round it is born.
+    pack = WebappPack()
+    pool = WorldPool.seed(
+        pack,
+        [
+            {**_COMPANY_MANIFEST, "seed": 0},
+            {**_COMPANY_MANIFEST, "lateral_movement": True, "seed": 1},
+            {**_COMPANY_MANIFEST, "lateral_movement": True, "seed": 2},
+        ],
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=3,
+    )
+    assert len(pool) == 3
+    original = pool.keys()
+    easiest = min(pool._members.values(), key=lambda m: m.difficulty)
+    for member in pool._members.values():
+        if member is not easiest:
+            member.priority = 1.5
+    report = _breach_report(pack, tmp_path, easiest.snapshot)
+    pool.update({easiest.key: [report]}, pack=pack, gate=_pentest_only)
+    assert len(pool) == 3
+    assert pool.keys() - original
+
+
+def test_staleness_priority_is_capped() -> None:
+    # An idle member climbs on staleness but never past the ceiling, so a
+    # never-sampled world cannot run away and crowd out the learning frontier.
+    pack = WebappPack()
+    pool = WorldPool.seed(
+        pack,
+        [_DEFAULT_MANIFEST, _COMPANY_MANIFEST],
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=8,
+    )
+    for _ in range(40):
+        pool.update({}, pack=pack, gate=_pentest_only)
+    priorities = [m.priority for m in pool._members.values()]
+    assert max(priorities) == _MAX_PRIORITY
+    assert all(p <= _MAX_PRIORITY for p in priorities)
+
+
+def test_round_rows_never_exceeds_groups() -> None:
+    # mix_floor is a fraction; even if a caller passes one above 1, the easy floor
+    # never inflates a round past the group budget it was sized for.
+    pack = WebappPack()
+    pool = WorldPool.seed(
+        pack,
+        [{**_COMPANY_MANIFEST, "seed": s} for s in range(6)],
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=8,
+        mix_floor=2.0,
+    )
+    assert len(pool) == 6
+    rows = pool.round_rows(groups=1, num_generations=2)
+    groups = {(row["snapshot_id"], row["task_id"]) for row in rows}
+    assert len(groups) == 1
+    assert pool.round_rows(groups=0, num_generations=2) == []
+
+
+def test_pool_holds_when_no_harder_world_admits(tmp_path: Path) -> None:
+    # When the frontier cannot advance — every candidate mutation is refused — the
+    # round still completes: no child is grown and the pool is left intact.
+    pack = WebappPack()
+    pool = WorldPool.seed(
+        pack,
+        [_COMPANY_MANIFEST],
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=5,
+    )
+    member = next(iter(pool._members.values()))
+    before = pool.keys()
+    report = _breach_report(pack, tmp_path, member.snapshot)
+    pool.update(
+        {member.key: [report]}, pack=pack, gate=lambda _evolved, _mutation: False
+    )
+    assert pool.keys() == before
+
+
+def test_regrowing_the_same_parent_does_not_duplicate(tmp_path: Path) -> None:
+    # Evolution is deterministic, so growing the same parent twice yields the same
+    # child key; the pool admits it once and the second round leaves the set intact.
+    pack = WebappPack()
+    pool = WorldPool.seed(
+        pack,
+        [_COMPANY_MANIFEST],
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=5,
+    )
+    parent = next(iter(pool._members.values()))
+    pool.update(
+        {parent.key: [_breach_report(pack, tmp_path / "a", parent.snapshot)]},
+        pack=pack,
+        gate=_pentest_only,
+    )
+    grew_to = pool.keys()
+    assert len(grew_to) == 2
+    pool.update(
+        {parent.key: [_breach_report(pack, tmp_path / "b", parent.snapshot)]},
+        pack=pack,
+        gate=_pentest_only,
+    )
+    assert pool.keys() == grew_to
 
 
 def test_services_are_realistically_named() -> None:

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -14,8 +14,14 @@ import urllib.request
 from pathlib import Path
 
 import pytest
-from cyber_webapp import NetworkedContainerWebappRuntime, WebappPack, _is_networked
+from cyber_webapp import (
+    NetworkedContainerWebappRuntime,
+    WebappPack,
+    _is_networked,
+    monotone_chain_gate,
+)
 from cyber_webapp.difficulty import world_difficulty
+from cyber_webapp.mutation import available_mutations
 from cyber_webapp.reference_solver import solve_chain
 from graphschema import Node, WorldGraph
 from openrange_pack_sdk import Backing, PoolableRuntime, Snapshot
@@ -24,6 +30,7 @@ from openrange_trl._pool import _MAX_PRIORITY
 
 from examples.tools import WEB_TOOLS
 from openrange.core.admit import admit
+from openrange.core.curriculum import auto_evolve
 from openrange.core.episode import EpisodeReport, EpisodeService
 
 _COMPANY_MANIFEST = {
@@ -39,6 +46,7 @@ _DEFAULT_MANIFEST = {
     "npc": [],
     "seed": 3,
 }
+_LATERAL_MANIFEST = {**_COMPANY_MANIFEST, "lateral_movement": True}
 
 
 def _admit(manifest: dict[str, object]) -> Snapshot:
@@ -92,6 +100,36 @@ def _breach_report(pack: WebappPack, work_dir: Path, snap: Snapshot) -> EpisodeR
         env._finalize()
         assert env.report is not None
         return env.report
+    finally:
+        svc.close()
+
+
+def _solve_round(
+    pack: WebappPack,
+    work_dir: Path,
+    rows: list[dict[str, object]],
+    snapshots: list[Snapshot],
+) -> dict[tuple[str, str], list[EpisodeReport]]:
+    by_id = {s.snapshot_id: s for s in snapshots}
+    svc = EpisodeService(pack, work_dir, warm_capacity=len(by_id))
+    env = EpisodeEnv(service=svc, snapshots=by_id, tools=WEB_TOOLS)
+    out: dict[tuple[str, str], list[EpisodeReport]] = {}
+    try:
+        for row in rows:
+            sid, tid = str(row["snapshot_id"]), str(row["task_id"])
+            snap = by_id[sid]
+            task = next(t for t in snap.tasks if t.id == tid)
+            entry = str(snap.graph.nodes[task.entrypoints[0]].attrs["public_url"])
+            env.reset(snapshot_id=sid, task_id=tid)
+            env.http_get(entry)
+            trace = solve_chain(
+                snap.graph, lambda p: env.http_get(p).split("\n", 1)[-1]
+            )
+            env.submit(json.dumps({"flag": _flag_from(trace.terminal)}))
+            env._finalize()
+            assert env.report is not None
+            out.setdefault((sid, tid), []).append(env.report)
+        return out
     finally:
         svc.close()
 
@@ -346,30 +384,7 @@ def test_pool_curriculum_grows_bounds_and_keeps_a_mix(tmp_path: Path) -> None:
         rows: list[dict[str, object]], snapshots: list[Snapshot]
     ) -> dict[tuple[str, str], list[EpisodeReport]]:
         round_no[0] += 1
-        by_id = {s.snapshot_id: s for s in snapshots}
-        svc = EpisodeService(
-            pack, tmp_path / f"r{round_no[0]}", warm_capacity=len(by_id)
-        )
-        env = EpisodeEnv(service=svc, snapshots=by_id, tools=WEB_TOOLS)
-        out: dict[tuple[str, str], list[EpisodeReport]] = {}
-        try:
-            for row in rows:
-                sid, tid = str(row["snapshot_id"]), str(row["task_id"])
-                snap = by_id[sid]
-                task = next(t for t in snap.tasks if t.id == tid)
-                entry = str(snap.graph.nodes[task.entrypoints[0]].attrs["public_url"])
-                env.reset(snapshot_id=sid, task_id=tid)
-                env.http_get(entry)
-                trace = solve_chain(
-                    snap.graph, lambda p: env.http_get(p).split("\n", 1)[-1]
-                )
-                env.submit(json.dumps({"flag": _flag_from(trace.terminal)}))
-                env._finalize()
-                assert env.report is not None
-                out.setdefault((sid, tid), []).append(env.report)
-            return out
-        finally:
-            svc.close()
+        return _solve_round(pack, tmp_path / f"r{round_no[0]}", rows, snapshots)
 
     def build_and_run() -> tuple[WorldPool, float]:
         pool = WorldPool.seed(
@@ -510,6 +525,103 @@ def test_regrowing_the_same_parent_does_not_duplicate(tmp_path: Path) -> None:
         gate=_pentest_only,
     )
     assert pool.keys() == grew_to
+
+
+def test_append_a_hop_deepens_the_chain_and_stays_solvable(tmp_path: Path) -> None:
+    # The skill-extending frontier move: a breached lateral world evolves into one
+    # whose credential chain is a hop deeper, and the deeper world is still solvable
+    # end to end through the real harness.
+    pack = WebappPack()
+    parent = _admit(_LATERAL_MANIFEST)
+    parent_diff = world_difficulty(parent.graph)
+    report = _breach_report(pack, tmp_path / "parent", parent)
+    assert report.passed
+    child = auto_evolve(
+        parent, report, pack=pack, gate=monotone_chain_gate(parent), max_repairs=3
+    )
+    assert child is not None
+    # +10 is the chain-depth weight: a hop was appended, not an off-path decoy (+1).
+    assert world_difficulty(child.graph) - parent_diff >= 10
+    assert _breach_report(pack, tmp_path / "child", child).passed
+
+
+def test_monotone_chain_gate_requires_one_more_hop(tmp_path: Path) -> None:
+    # The independent check that a "harden" genuinely extends the chain: a world does
+    # not extend itself, a chainless world has nothing to extend, and the one-hop
+    # deeper child is accepted.
+    pack = WebappPack()
+    parent = _admit(_LATERAL_MANIFEST)
+    any_mutation = available_mutations(parent.graph, "webapp.pentest", [])[0]
+    gate = monotone_chain_gate(parent)
+    assert not gate(parent, any_mutation)
+    assert not monotone_chain_gate(_admit(_DEFAULT_MANIFEST))(parent, any_mutation)
+    report = _breach_report(pack, tmp_path, parent)
+    deeper = auto_evolve(parent, report, pack=pack, gate=gate, max_repairs=3)
+    assert deeper is not None
+    assert gate(deeper, any_mutation)
+
+
+def test_pool_grows_a_deeper_chain_under_the_monotone_gate(tmp_path: Path) -> None:
+    # End to end: a pool of lateral worlds, driven by the real harness, evolves a
+    # member into one with a deeper credential chain. The monotone gate admits the
+    # appended hop; without a genuine extension nothing would grow.
+    pack = WebappPack()
+    pool = WorldPool.seed(
+        pack,
+        [_LATERAL_MANIFEST],
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=4,
+    )
+    assert len(pool) == 1
+    seed_diff = next(iter(pool._members.values())).difficulty
+    round_no = [0]
+
+    def run_round(
+        rows: list[dict[str, object]], snapshots: list[Snapshot]
+    ) -> dict[tuple[str, str], list[EpisodeReport]]:
+        round_no[0] += 1
+        return _solve_round(pack, tmp_path / f"r{round_no[0]}", rows, snapshots)
+
+    run_pool_curriculum(
+        pool,
+        run_round,
+        rounds=1,
+        pack=pack,
+        groups=1,
+        num_generations=2,
+        gate_factory=monotone_chain_gate,
+    )
+    diffs = [m.difficulty for m in pool._members.values()]
+    assert len(pool) == 2
+    assert max(diffs) - seed_diff >= 10
+
+
+def test_pool_chain_deepens_until_internal_hosts_run_out(tmp_path: Path) -> None:
+    # With no gate, append-a-hop is the top harden, so the frontier deepens a hop a
+    # round; once every internal host is on the chain no hop is offered and the
+    # frontier caps (the verifier-ceiling case).
+    pack = WebappPack()
+    pool = WorldPool.seed(
+        pack,
+        [_LATERAL_MANIFEST],
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=12,
+    )
+    start = max(m.difficulty for m in pool._members.values())
+    round_no = [0]
+
+    def run_round(
+        rows: list[dict[str, object]], snapshots: list[Snapshot]
+    ) -> dict[tuple[str, str], list[EpisodeReport]]:
+        round_no[0] += 1
+        return _solve_round(pack, tmp_path / f"r{round_no[0]}", rows, snapshots)
+
+    run_pool_curriculum(
+        pool, run_round, rounds=5, pack=pack, groups=1, num_generations=2
+    )
+    assert max(m.difficulty for m in pool._members.values()) >= start + 10
 
 
 def test_services_are_realistically_named() -> None:

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -325,8 +325,6 @@ def test_write_exec_world_is_not_poolable() -> None:
 
 
 def test_world_difficulty_rises_with_chain_depth() -> None:
-    # Difficulty is read from the graph and dominated by the pivot chain depth,
-    # so a credential chain outranks a flat world that merely carries more vulns.
     flat = world_difficulty(_admit(_DEFAULT_MANIFEST).graph)
     company = world_difficulty(_admit(_COMPANY_MANIFEST).graph)
     lateral = world_difficulty(
@@ -336,8 +334,6 @@ def test_world_difficulty_rises_with_chain_depth() -> None:
 
 
 def test_warm_cache_is_a_bounded_lru(tmp_path: Path) -> None:
-    # A round visiting more worlds than the cache budget keeps the most recent N
-    # warm and evicts the least-recently-used, rather than holding only one.
     snaps = [_admit({**_COMPANY_MANIFEST, "seed": s}) for s in (1, 2, 3)]
     assert len({s.snapshot_id for s in snaps}) == 3
     svc = EpisodeService(WebappPack(), tmp_path, warm_capacity=2)
@@ -356,8 +352,8 @@ def test_warm_cache_is_a_bounded_lru(tmp_path: Path) -> None:
 
 
 def test_pool_round_keeps_the_easy_tail() -> None:
-    # Even at the lowest priority, an easy-tier world stays in the round — the
-    # mix floor is enforced when the round is composed, not left to chance.
+    # The mix floor is enforced at round composition, so the easiest world stays in
+    # even when its priority is zeroed.
     pack = WebappPack()
     pool = WorldPool.seed(
         pack,
@@ -380,9 +376,6 @@ def test_pool_round_keeps_the_easy_tail() -> None:
 
 
 def test_pool_curriculum_grows_bounds_and_keeps_a_mix(tmp_path: Path) -> None:
-    # Drive the pool through the real episode harness on PROCESS: seed wide, breach
-    # each sampled world, evolve between rounds. The pool grows a harder world,
-    # stays bounded, keeps its easy tail, and is deterministic.
     pack = WebappPack()
     seeds = [{**_COMPANY_MANIFEST, "seed": s} for s in range(4)]
     round_no = [0]
@@ -423,9 +416,8 @@ def test_pool_curriculum_grows_bounds_and_keeps_a_mix(tmp_path: Path) -> None:
 
 
 def test_grown_child_survives_a_full_pool(tmp_path: Path) -> None:
-    # A freshly grown frontier child is the hardest, newest member; when the pool is
-    # full and older members have drifted up on staleness, it must not be the one
-    # evicted the same round it is born.
+    # A child must not be evicted the round it is born: older members are forced
+    # above it on staleness, yet eviction falls on one of them.
     pack = WebappPack()
     pool = WorldPool.seed(
         pack,
@@ -451,8 +443,6 @@ def test_grown_child_survives_a_full_pool(tmp_path: Path) -> None:
 
 
 def test_staleness_priority_is_capped() -> None:
-    # An idle member climbs on staleness but never past the ceiling, so a
-    # never-sampled world cannot run away and crowd out the learning frontier.
     pack = WebappPack()
     pool = WorldPool.seed(
         pack,
@@ -469,8 +459,8 @@ def test_staleness_priority_is_capped() -> None:
 
 
 def test_round_rows_never_exceeds_groups() -> None:
-    # mix_floor is a fraction; even if a caller passes one above 1, the easy floor
-    # never inflates a round past the group budget it was sized for.
+    # mix_floor is a fraction: a value above 1 must not inflate a round past its
+    # group budget.
     pack = WebappPack()
     pool = WorldPool.seed(
         pack,
@@ -488,8 +478,6 @@ def test_round_rows_never_exceeds_groups() -> None:
 
 
 def test_pool_holds_when_no_harder_world_admits(tmp_path: Path) -> None:
-    # When the frontier cannot advance — every candidate mutation is refused — the
-    # round still completes: no child is grown and the pool is left intact.
     pack = WebappPack()
     pool = WorldPool.seed(
         pack,
@@ -509,8 +497,8 @@ def test_pool_holds_when_no_harder_world_admits(tmp_path: Path) -> None:
 
 
 def test_regrowing_the_same_parent_does_not_duplicate(tmp_path: Path) -> None:
-    # Evolution is deterministic, so growing the same parent twice yields the same
-    # child key; the pool admits it once and the second round leaves the set intact.
+    # Evolution is deterministic: the same parent yields the same child key, so the
+    # second growth is a no-op rather than a duplicate.
     pack = WebappPack()
     pool = WorldPool.seed(
         pack,
@@ -536,9 +524,6 @@ def test_regrowing_the_same_parent_does_not_duplicate(tmp_path: Path) -> None:
 
 
 def test_append_a_hop_deepens_the_chain_and_stays_solvable(tmp_path: Path) -> None:
-    # The skill-extending frontier move: a breached lateral world evolves into one
-    # whose credential chain is a hop deeper, and the deeper world is still solvable
-    # end to end through the real harness.
     pack = WebappPack()
     parent = _admit(_LATERAL_MANIFEST)
     parent_diff = world_difficulty(parent.graph)
@@ -554,9 +539,9 @@ def test_append_a_hop_deepens_the_chain_and_stays_solvable(tmp_path: Path) -> No
 
 
 def test_append_a_hop_keeps_the_flag_owned_under_scoped_seeding(tmp_path: Path) -> None:
-    # Cross-backing parity: the deepened world must be solvable under the per-service
-    # scoped seed the CONTAINER backing uses, not only the shared PROCESS seed — so
-    # the new flag-gate host must OWN the flag store, not merely serve it.
+    # Cross-backing parity: under the per-service scoped seed CONTAINER uses (not the
+    # shared PROCESS seed), the new flag-gate host must OWN the flag store, not just
+    # serve it.
     pack = WebappPack()
     parent = _admit(_LATERAL_MANIFEST)
     report = _breach_report(pack, tmp_path, parent)
@@ -580,9 +565,6 @@ def test_append_a_hop_keeps_the_flag_owned_under_scoped_seeding(tmp_path: Path) 
 
 
 def test_monotone_chain_gate_requires_one_more_hop(tmp_path: Path) -> None:
-    # The independent check that a "harden" genuinely extends the chain: a world does
-    # not extend itself, a chainless world has nothing to extend, and the one-hop
-    # deeper child is accepted.
     pack = WebappPack()
     parent = _admit(_LATERAL_MANIFEST)
     any_mutation = available_mutations(parent.graph, "webapp.pentest", [])[0]
@@ -596,9 +578,6 @@ def test_monotone_chain_gate_requires_one_more_hop(tmp_path: Path) -> None:
 
 
 def test_pool_grows_a_deeper_chain_under_the_monotone_gate(tmp_path: Path) -> None:
-    # End to end: a pool of lateral worlds, driven by the real harness, evolves a
-    # member into one with a deeper credential chain. The monotone gate admits the
-    # appended hop; without a genuine extension nothing would grow.
     pack = WebappPack()
     pool = WorldPool.seed(
         pack,
@@ -632,9 +611,6 @@ def test_pool_grows_a_deeper_chain_under_the_monotone_gate(tmp_path: Path) -> No
 
 
 def test_pool_chain_deepens_until_internal_hosts_run_out(tmp_path: Path) -> None:
-    # With no gate, append-a-hop is the top harden, so the frontier deepens a hop a
-    # round; once every internal host is on the chain no hop is offered and the
-    # frontier caps (the verifier-ceiling case).
     pack = WebappPack()
     pool = WorldPool.seed(
         pack,
@@ -659,8 +635,6 @@ def test_pool_chain_deepens_until_internal_hosts_run_out(tmp_path: Path) -> None
 
 
 def test_held_out_eval_pool_is_fenced_and_measured(tmp_path: Path) -> None:
-    # The generalization bet (§8): an eval pool admitted alongside training but
-    # fenced from it — measured each round, never sampled into a group or evolved.
     pack = WebappPack()
     train = WorldPool.seed(
         pack,
@@ -697,8 +671,8 @@ def test_held_out_eval_pool_is_fenced_and_measured(tmp_path: Path) -> None:
         eval_pool=held_out,
     )
     assert len(metrics) == 2
-    # The scripted solver breaches every world, so both rates are 1.0 and the gap
-    # is 0 — what is under test is the wiring: both measured, the eval set fenced.
+    # The scripted solver breaches every world, so both rates are 1.0 and the gap is
+    # 0; the wiring (both measured, eval set fenced) is what is under test.
     assert all(m.train_solve_rate == 1.0 for m in metrics)
     assert all(m.held_out_solve_rate == 1.0 for m in metrics)
     assert all(m.generalization_gap == 0.0 for m in metrics)

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -25,7 +25,13 @@ from cyber_webapp.mutation import available_mutations
 from cyber_webapp.reference_solver import solve_chain
 from graphschema import Node, WorldGraph
 from openrange_pack_sdk import Backing, PoolableRuntime, Snapshot
-from openrange_trl import EpisodeEnv, WorldPool, run_pool_curriculum
+from openrange_trl import (
+    EpisodeEnv,
+    EvalPool,
+    RoundMetrics,
+    WorldPool,
+    run_pool_curriculum,
+)
 from openrange_trl._pool import _MAX_PRIORITY
 
 from examples.tools import WEB_TOOLS
@@ -622,6 +628,59 @@ def test_pool_chain_deepens_until_internal_hosts_run_out(tmp_path: Path) -> None
         pool, run_round, rounds=5, pack=pack, groups=1, num_generations=2
     )
     assert max(m.difficulty for m in pool._members.values()) >= start + 10
+
+
+def test_held_out_eval_pool_is_fenced_and_measured(tmp_path: Path) -> None:
+    # The generalization bet (§8): an eval pool admitted alongside training but
+    # fenced from it — measured each round, never sampled into a group or evolved.
+    pack = WebappPack()
+    train = WorldPool.seed(
+        pack,
+        [{**_COMPANY_MANIFEST, "seed": s} for s in (0, 1)],
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=5,
+    )
+    held_out = EvalPool.seed(
+        pack,
+        [{**_COMPANY_MANIFEST, "seed": 2}, _LATERAL_MANIFEST],
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+    )
+    assert len(held_out) == 2
+    eval_keys = held_out.keys()
+    assert not (train.keys() & eval_keys)
+    round_no = [0]
+
+    def run_round(
+        rows: list[dict[str, object]], snapshots: list[Snapshot]
+    ) -> dict[tuple[str, str], list[EpisodeReport]]:
+        round_no[0] += 1
+        return _solve_round(pack, tmp_path / f"r{round_no[0]}", rows, snapshots)
+
+    metrics = run_pool_curriculum(
+        train,
+        run_round,
+        rounds=2,
+        pack=pack,
+        groups=2,
+        num_generations=2,
+        gate=_pentest_only,
+        eval_pool=held_out,
+    )
+    assert len(metrics) == 2
+    # The scripted solver breaches every world, so both rates are 1.0 and the gap
+    # is 0 — what is under test is the wiring: both measured, the eval set fenced.
+    assert all(m.train_solve_rate == 1.0 for m in metrics)
+    assert all(m.held_out_solve_rate == 1.0 for m in metrics)
+    assert all(m.generalization_gap == 0.0 for m in metrics)
+    assert held_out.keys() == eval_keys
+    assert not (train.keys() & eval_keys)
+
+
+def test_generalization_gap_is_train_minus_held_out() -> None:
+    assert RoundMetrics(0.8, 0.5).generalization_gap == pytest.approx(0.3)
+    assert RoundMetrics(0.8).generalization_gap is None
 
 
 def test_services_are_realistically_named() -> None:


### PR DESCRIPTION
## What

The design doc for the next step of the training curriculum — training on a
**pool of worlds that evolves over time** instead of a single world mutated in
place — and a first working version of that loop, plus the groundwork it stands
on.

### The design (`docs/design/evolving-pool-curriculum.md`)

Train on many admitted worlds at once, sampled per episode (the spread is what
lets the agent generalize), and shift that set slowly between rounds rather than
hardening one world. The doc explains why this is stable for the online RL we
use, writes down the **ways a world can evolve** — including **building new
structure** (an LLM-realized service or tier), since building and evolving are
the same admission-checked loop and you can't generate an enterprise world in one
shot — and grounds the whole thing in the published work on automatic curricula
(POET, PAIRED, PLR, ACCEL) and online RL for LLMs (GRPO, WebRL, Absolute Zero).
The rule is about *placement*: only a small, skill-extending change is used as the
difficulty step; larger and path-replacing builds seed fresh worlds for diversity.

### The pool loop

Seed a pool of admitted worlds; each round, sample a round's prompts with a **mix
floor** so an easy tail always survives; between rounds, re-prioritise members by
how much they can still teach (learnability + a regret term that keeps a world
stuck below its solvable ceiling at the frontier) and **evolve the most promising
into admitted children, keeping their parents** and staying within a size bound.
It is pack-agnostic (difficulty is injected) and runner-agnostic (the caller
supplies how a round runs), so the same loop drives a scripted solver today and a
real trainer later.

### The groundwork it stands on

- **Measure how hard a world is, from its graph** — credential-chain depth
  dominates, vuln count breaks ties.
- **Record a world's origin in one place, one shape** — every evolved world
  writes a single top-level block, so provenance reads without special-casing how
  it was produced (documented in `CONTRACTS.md`).
- **Keep more than one booted world warm** — a bounded least-recently-used cache,
  so training that visits several worlds per round doesn't re-boot every episode.

## Verification

Driven **end to end through the real episode harness** on the in-process backing,
not just unit tests: a pool seeded from four worlds breaches each sampled world,
grows a harder world between rounds, stays bounded, keeps its easy tail, and is
deterministic. New unit and integration tests; `mypy`, `ruff`, and the impacted
suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
