### PR TITLE
Make pool evolution demonstrably react to agent performance

### DIFF
--- a/examples/trl_grpo_cyber.ipynb
+++ b/examples/trl_grpo_cyber.ipynb
@@ -40,7 +40,11 @@
    "cell_type": "markdown",
    "id": "2d6753bf",
    "metadata": {},
-   "source": "## 2. Admit the company world\n\n`company: True` builds a segmented 6–8-service estate instead of a single service — deterministic and LLM-free, so this snapshot is byte-identical on every machine. We also pick the backing: real Docker if it's running, else the in-process emulation."
+   "source": [
+    "## 2. Admit the company world\n",
+    "\n",
+    "`company: True` builds a segmented 6–8-service estate instead of a single service — deterministic and LLM-free, so this snapshot is byte-identical on every machine. We also pick the backing: real Docker if it's running, else the in-process emulation."
+   ]
   },
   {
    "cell_type": "code",
@@ -108,7 +112,11 @@
    "cell_type": "markdown",
    "id": "3c21d1c6",
    "metadata": {},
-   "source": "## 3. The estate\n\nPrint the world's layout — just the graph, nothing running yet. One public **storefront** sits in the `dmz`; the other services (databases, internal APIs) are on an isolated **internal** network. The flag is a credential on one of those internal databases — so the storefront is the only way in, and the dmz→internal **pivot** is mandatory."
+   "source": [
+    "## 3. The estate\n",
+    "\n",
+    "Print the world's layout — just the graph, nothing running yet. One public **storefront** sits in the `dmz`; the other services (databases, internal APIs) are on an isolated **internal** network. The flag is a credential on one of those internal databases — so the storefront is the only way in, and the dmz→internal **pivot** is mandatory."
+   ]
   },
   {
    "cell_type": "code",
@@ -175,7 +183,11 @@
    "cell_type": "markdown",
    "id": "03aa8f63",
    "metadata": {},
-   "source": "## 4. See the reward before you train\n\nThe reward grades the **HTTP path** against three subgoals: reach the entry, extract *something*, submit the *right* flag. Driving the env's tools by hand maps three behaviors onto it (no model, no GPU). The richest is the **full breach**: reach the storefront, **SSRF-pivot into the internal service, and exfiltrate the credential** — every coordinate read from the world graph (no hardcoded secrets) via the pack's reference solver."
+   "source": [
+    "## 4. See the reward before you train\n",
+    "\n",
+    "The reward grades the **HTTP path** against three subgoals: reach the entry, extract *something*, submit the *right* flag. Driving the env's tools by hand maps three behaviors onto it (no model, no GPU). The richest is the **full breach**: reach the storefront, **SSRF-pivot into the internal service, and exfiltrate the credential** — every coordinate read from the world graph (no hardcoded secrets) via the pack's reference solver."
+   ]
   },
   {
    "cell_type": "code",
@@ -460,7 +472,13 @@
    "cell_type": "markdown",
    "id": "67c87834",
    "metadata": {},
-   "source": "## 8. Train on an evolving pool of worlds\n\nTraining runs over a *pool* of worlds, not one. Each round samples a spread from the pool — a **mix floor** always keeps an easy one in — trains a GRPO pass, then evolves the worlds the model learns most from into harder admitted children, keeping the parents. The pool is the curriculum, and it sharpens as the model improves.\n\n`run_pool_curriculum` drives the loop; `make_grpo_rounds` returns the `(train_round, eval_round)` pair. `eval_round` scores a **fenced held-out** pool under a frozen update — no learning — so the train-vs-held-out gap measures generalization, not memorization. One real round:"
+   "source": [
+    "## 8. Train on an evolving pool of worlds\n",
+    "\n",
+    "Training runs over a *pool* of worlds, not one. Each round samples a spread from the pool — a **mix floor** always keeps an easy one in — trains a GRPO pass, then evolves the worlds the model learns most from into harder admitted children, keeping the parents. The pool is the curriculum, and it sharpens as the model improves.\n",
+    "\n",
+    "`run_pool_curriculum` drives the loop; `make_grpo_rounds` returns the `(train_round, eval_round)` pair. `eval_round` scores a **fenced held-out** pool under a frozen update — no learning — so the train-vs-held-out gap measures generalization, not memorization. One real round:"
+   ]
   },
   {
    "cell_type": "code",
@@ -538,12 +556,9 @@
    "id": "984b4f68",
    "metadata": {},
    "source": [
-    "The round trained, but the 0.5B can't pivot — its solve-rate is the **free `0.333`** the\n",
-    "running storefront answers before the agent acts, with zero spread, so GRPO has no gradient.\n",
-    "A real climb needs a bigger model on a GPU, where rollouts genuinely differ and the\n",
-    "*policy's* own improvement deepens the pool. To watch the **loop** itself — solve, harden,\n",
-    "keep an easy tail — we stand in the §4 reference breach for that competent policy below and\n",
-    "seed a fresh pool; swap `make_grpo_run_round` back in on a GPU and the climb drives it."
+    "The round trained, but the 0.5B can't pivot — its solve-rate is the **free `0.333`** the running storefront answers before the agent acts, with zero spread, so GRPO has no gradient. A real climb needs a bigger model on a GPU; on a laptop we script the agent's performance with the §4 reference breach to watch the **loop** itself.\n",
+    "\n",
+    "The pool *follows performance*. Run the **same three seeds twice** — once with a solving agent, once with a stuck one. Solving **hardens** the frontier; getting stuck **softens** it. (The default policy decides direction from the round's solve-rate; the gate just keeps children on the pentest family.)"
    ]
   },
   {
@@ -560,57 +575,68 @@
    },
    "outputs": [],
    "source": [
-    "def scripted_round(rows, snapshots):\n",
-    "    by_id = {s.snapshot_id: s for s in snapshots}\n",
-    "    reports = {}\n",
-    "    for row in rows:\n",
-    "        snap = by_id[row[\"snapshot_id\"]]\n",
-    "        svc = EpisodeService(\n",
-    "            pack, f\"or-runs/cyber/pool-{snap.snapshot_id[-12:]}\", backing=BACKING\n",
-    "        )\n",
-    "        env = EpisodeEnv(\n",
-    "            service=svc, snapshots={snap.snapshot_id: snap}, tools=WEB_TOOLS\n",
-    "        )\n",
+    "def make_round(solving):\n",
+    "    def _round(rows, snapshots):\n",
+    "        by_id = {s.snapshot_id: s for s in snapshots}\n",
+    "        svc = EpisodeService(pack, \"or-runs/cyber/adaptive\", backing=BACKING)\n",
+    "        env = EpisodeEnv(service=svc, snapshots=by_id, tools=WEB_TOOLS)\n",
+    "        reports = {}\n",
     "        try:\n",
-    "            env.reset(snapshot_id=row[\"snapshot_id\"], task_id=row[\"task_id\"])\n",
-    "            breach(env, snap)\n",
-    "            env._finalize()\n",
-    "            key = (row[\"snapshot_id\"], row[\"task_id\"])\n",
-    "            reports.setdefault(key, []).append(env.report)\n",
+    "            for row in rows:\n",
+    "                snap = by_id[row[\"snapshot_id\"]]\n",
+    "                env.reset(snapshot_id=row[\"snapshot_id\"], task_id=row[\"task_id\"])\n",
+    "                if solving:\n",
+    "                    breach(env, snap)\n",
+    "                else:\n",
+    "                    env.http_get(entry_url(snap))\n",
+    "                env._finalize()\n",
+    "                key = (row[\"snapshot_id\"], row[\"task_id\"])\n",
+    "                reports.setdefault(key, []).append(env.report)\n",
+    "            return reports\n",
     "        finally:\n",
     "            svc.close()\n",
-    "    return reports\n",
+    "\n",
+    "    return _round\n",
     "\n",
     "\n",
-    "pool = WorldPool.seed(\n",
-    "    pack,\n",
-    "    [company(s) for s in range(3)],\n",
-    "    difficulty_fn=lambda s: float(world_difficulty(s.graph)),\n",
-    "    family=\"webapp.pentest\",\n",
-    "    max_size=6,\n",
-    ")\n",
-    "seeded = sorted(world_difficulty(s.graph) for s in pool.snapshots())\n",
-    "run_pool_curriculum(\n",
-    "    pool,\n",
-    "    scripted_round,\n",
-    "    rounds=3,\n",
-    "    pack=pack,\n",
-    "    groups=2,\n",
-    "    num_generations=2,\n",
-    "    gate=lambda _snap, mut: mut.family == \"webapp.pentest\",\n",
-    ")\n",
-    "band = sorted(world_difficulty(s.graph) for s in pool.snapshots())\n",
-    "print(\n",
-    "    f\"pool difficulty band: seeded {seeded}  →  \"\n",
-    "    f\"after 3 rounds {band}  ({len(pool)} worlds)\"\n",
-    ")"
+    "def diff_band(p):\n",
+    "    return sorted(world_difficulty(s.graph) for s in p.snapshots())\n",
+    "\n",
+    "\n",
+    "runs = {}\n",
+    "for label, solving in ((\"solves\", True), (\"stuck\", False)):\n",
+    "    p = WorldPool.seed(\n",
+    "        pack,\n",
+    "        [company(s) for s in range(3)],\n",
+    "        difficulty_fn=lambda s: float(world_difficulty(s.graph)),\n",
+    "        family=\"webapp.pentest\",\n",
+    "        max_size=8,\n",
+    "    )\n",
+    "    seeded = diff_band(p)\n",
+    "    run_pool_curriculum(\n",
+    "        p,\n",
+    "        make_round(solving),\n",
+    "        rounds=3,\n",
+    "        pack=pack,\n",
+    "        groups=len(p),\n",
+    "        num_generations=1,\n",
+    "        gate=lambda _snap, mut: mut.family == \"webapp.pentest\",\n",
+    "    )\n",
+    "    runs[label] = p\n",
+    "    print(f\"agent {label:6} : seeded {seeded}  ->  {diff_band(p)}\")\n",
+    "\n",
+    "pool = runs[\"solves\"]"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "105f83a3",
    "metadata": {},
-   "source": "## 9. The pool is a population\n\nThe pool ends wider and harder than it started. Each evolved world is an **admission-checked** child: `auto_evolve` deepens or decoys the breach, re-admits it (so the harder world is still provably solvable), and records its parent. The easy seeds stay in under the mix floor. What you train on is a *band* of worlds drifting toward harder — not one fixed task — every world traceable to the one it came from."
+   "source": [
+    "## 9. The pool tracks the agent\n",
+    "\n",
+    "Same seeds, opposite outcomes: under a solving agent the band moved **up**, under a stuck one it moved **down** — the curriculum follows performance, it doesn't just ratchet harder. Each evolved world is an **admission-checked** child that records its parent *and* its direction (`auto_evolve` re-admits it, so a harder child is still provably solvable — and a softer one too), while the easy seeds stay in under the mix floor. Here's the solving run's lineage:"
+   ]
   },
   {
    "cell_type": "code",
@@ -629,9 +655,10 @@
     "for snap in sorted(pool.snapshots(), key=lambda s: world_difficulty(s.graph)):\n",
     "    evolve = snap.lineage.get(\"_evolve\") or {}\n",
     "    parent = (evolve.get(\"parent_snapshot_id\") or \"\")[-12:] or \"root\"\n",
+    "    direction = evolve.get(\"direction\") or \"seed\"\n",
     "    print(\n",
     "        f\"{snap.snapshot_id[-12:]}  difficulty={world_difficulty(snap.graph):<3} \"\n",
-    "        f\"parent={parent}\"\n",
+    "        f\"{direction:<7} parent={parent}\"\n",
     "    )"
    ]
   },

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -112,6 +112,23 @@ def _breach_report(pack: WebappPack, work_dir: Path, snap: Snapshot) -> EpisodeR
         svc.close()
 
 
+def _reach_only_report(
+    pack: WebappPack, work_dir: Path, snap: Snapshot
+) -> EpisodeReport:
+    task = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+    svc = EpisodeService(pack, work_dir)
+    env = EpisodeEnv(service=svc, snapshots={snap.snapshot_id: snap}, tools=WEB_TOOLS)
+    try:
+        entry = str(snap.graph.nodes[task.entrypoints[0]].attrs["public_url"])
+        env.reset(snapshot_id=snap.snapshot_id, task_id=task.id)
+        env.http_get(entry)
+        env._finalize()
+        assert env.report is not None
+        return env.report
+    finally:
+        svc.close()
+
+
 def _solve_round(
     pack: WebappPack,
     work_dir: Path,
@@ -522,6 +539,91 @@ def test_regrowing_the_same_parent_does_not_duplicate(tmp_path: Path) -> None:
         gate=_pentest_only,
     )
     assert pool.keys() == grew_to
+
+
+def test_evolution_hardens_a_world_the_agent_masters(tmp_path: Path) -> None:
+    pack = WebappPack()
+    pool = WorldPool.seed(
+        pack,
+        [_LATERAL_MANIFEST],
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=8,
+    )
+    member = next(iter(pool._members.values()))
+    before = pool.keys()
+    report = _breach_report(pack, tmp_path, member.snapshot)
+    assert report.passed
+    pool.update({member.key: [report]}, pack=pack, gate=_pentest_only)
+    new = pool.keys() - before
+    assert len(new) == 1
+    child = pool._members[next(iter(new))]
+    evolve = child.snapshot.lineage["_evolve"]
+    assert evolve["direction"] == "harden"
+    assert child.difficulty > member.difficulty
+
+
+def test_evolution_softens_the_world_the_agent_is_stuck_on(tmp_path: Path) -> None:
+    pack = WebappPack()
+    pool = WorldPool.seed(
+        pack,
+        [_COMPANY_MANIFEST, _LATERAL_MANIFEST],
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=8,
+    )
+    by_diff = sorted(pool._members.values(), key=lambda m: m.difficulty)
+    easy, hard = by_diff[0], by_diff[-1]
+    before = pool.keys()
+    reports = {
+        easy.key: [_breach_report(pack, tmp_path / "easy", easy.snapshot)],
+        hard.key: [_reach_only_report(pack, tmp_path / "hard", hard.snapshot)],
+    }
+    assert reports[easy.key][0].passed and not reports[hard.key][0].passed
+    pool.update(reports, pack=pack, gate=_pentest_only)
+    new = pool.keys() - before
+    assert len(new) == 1
+    child = pool._members[next(iter(new))]
+    evolve = child.snapshot.lineage["_evolve"]
+    assert evolve["parent_snapshot_id"] == hard.snapshot.snapshot_id
+    assert evolve["direction"] == "soften"
+    assert child.difficulty < hard.difficulty
+
+
+def test_evolution_selects_whichever_world_the_agent_struggles_with(
+    tmp_path: Path,
+) -> None:
+    def evolve_with_stuck(stuck_is_hard: bool) -> tuple[str, str]:
+        pack = WebappPack()
+        pool = WorldPool.seed(
+            pack,
+            [_COMPANY_MANIFEST, _LATERAL_MANIFEST],
+            difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+            family="webapp.pentest",
+            max_size=8,
+        )
+        by_diff = sorted(pool._members.values(), key=lambda m: m.difficulty)
+        easy, hard = by_diff[0], by_diff[-1]
+        stuck, solved = (hard, easy) if stuck_is_hard else (easy, hard)
+        before = pool.keys()
+        tag = "hard" if stuck_is_hard else "easy"
+        reports = {
+            solved.key: [
+                _breach_report(pack, tmp_path / f"{tag}-solved", solved.snapshot)
+            ],
+            stuck.key: [
+                _reach_only_report(pack, tmp_path / f"{tag}-stuck", stuck.snapshot)
+            ],
+        }
+        pool.update(reports, pack=pack, gate=_pentest_only)
+        child = pool._members[next(iter(pool.keys() - before))]
+        parent = str(child.snapshot.lineage["_evolve"]["parent_snapshot_id"])
+        return parent, stuck.snapshot.snapshot_id
+
+    evolved_parent, stuck_id = evolve_with_stuck(stuck_is_hard=True)
+    assert evolved_parent == stuck_id
+    evolved_parent, stuck_id = evolve_with_stuck(stuck_is_hard=False)
+    assert evolved_parent == stuck_id
 
 
 def test_append_a_hop_deepens_the_chain_and_stays_solvable(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

The evolving world pool is already performance-driven by default — it ranks worlds by how much each can still teach (learnability + regret) and picks `harden` / `soften` / `diversify` from the round's solve-rate. But nothing *demonstrated or tested* that through the pool itself: the live GRPO run forced always-harden, and the notebook's scripted cell always solved, so both only ever hardened. This pins the real behaviour and shows it honestly.

- **Tests** (`tests/test_cyber_company.py`) — three integration tests that drive the real `WorldPool` / `run_pool_curriculum` path:
  - a world the agent solves is **hardened** into a deeper child,
  - a world it's stuck on is **softened** (the child's parent is the stuck world),
  - the world selected to evolve **follows performance** — it flips when you flip which world the agent fails.
  The "stuck" signal is a real episode that reaches the entry but never submits — no fabricated reports.
- **Notebook** (`examples/trl_grpo_cyber.ipynb`) — §8's scripted cell ran the same breach every time, so the pool could only harden. It now runs the *same three seeds twice* — a solving agent vs a stuck one — so the band moves **up** under solving and **down** under stuck, from the same start. §9 reframes around that and prints each child's direction next to its parent.

## Verification

- `test_cyber_company.py`: 33/33 green; ruff + format clean.
- The notebook demo was driven end-to-end through the real episode harness (the same calls): solving `[5,5,7] → [5,5,7,8,9]`, stuck `[5,5,7] → [5,5,5,7]`.
- Also confirmed live: driving the pool with a real local Qwen3.5-4B (it reaches every world but can't land the exploit, so it fails uniformly) softened the frontier `7 → 5` — performance-driven softening with a real model. A live *harden* needs a stronger agent than a 4B can manage on these worlds; that direction is covered by the tests and the notebook's solving run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
