### PR TITLE
cyber: keep evolution and generation from producing broken worlds

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/__init__.py
@@ -22,6 +22,7 @@ from cyber_webapp.invariants import (
     oracle_path_exists,
     secret_must_be_held,
     sqli_targets_db_backed_service,
+    unique_vuln_per_endpoint,
 )
 from cyber_webapp.mutation import monotone_chain_gate
 from cyber_webapp.ontology import ONTOLOGY_ID, webapp_ontology
@@ -52,6 +53,7 @@ class WebappPack(Pack):
             oracle_path_exists,
             sqli_targets_db_backed_service,
             credential_reuse_binding,
+            unique_vuln_per_endpoint,
         ]
 
     def make_builder(self, prior: PackPrior | None) -> Builder:

--- a/packs/cyber_webapp/cyber_webapp/invariants.py
+++ b/packs/cyber_webapp/cyber_webapp/invariants.py
@@ -134,6 +134,34 @@ def oracle_path_exists(graph: WorldGraph) -> list[Issue]:
     return issues
 
 
+def unique_vuln_per_endpoint(graph: WorldGraph) -> list[Issue]:
+    """A vulnerability's (kind, endpoint) is its identity: the codegen renders one
+    handler per pair, so a second same-kind vuln on the same endpoint is a dead node
+    the graph over-claims. Reject it so generation and evolution stay coherent."""
+    target_of: dict[str, str] = {}
+    for edge in graph.edges.values():
+        if edge.kind == "affects":
+            target_of.setdefault(edge.src, edge.dst)
+    seen: set[tuple[str, str]] = set()
+    issues: list[Issue] = []
+    for vuln in graph.by_kind("vulnerability"):
+        target = target_of.get(vuln.id)
+        if target is None:
+            continue
+        key = (str(vuln.attrs.get("kind")), target)
+        if key in seen:
+            issues.append(
+                Issue(
+                    "error",
+                    "duplicate_vuln_on_endpoint",
+                    f"a {key[0]} vulnerability already targets {target!r}",
+                    vuln.id,
+                )
+            )
+        seen.add(key)
+    return issues
+
+
 _CHAIN_PRODUCER_KINDS: frozenset[str] = frozenset(
     {"credential_leak", "credential_gated_relay"}
 )

--- a/packs/cyber_webapp/cyber_webapp/mutation.py
+++ b/packs/cyber_webapp/cyber_webapp/mutation.py
@@ -32,6 +32,8 @@ _APPEND_HOP_RELEVANCE = 0.9
 
 _GATE_PATH = "/internal/vault"
 _TOKEN_PARAMS: tuple[str, ...] = ("token", "api_key", "auth", "session", "key")
+# Recon that names the SSRF's internal pivot host; evolution must never drop it.
+_RECON_KIND = "config_disclosure"
 
 
 def coerce_string_list(value: object) -> list[str]:
@@ -63,6 +65,8 @@ def available_mutations(
     )
 
     for kind, node_ids in vulns_by_kind.items():
+        if kind == _RECON_KIND:
+            continue
         score = _exploitation_score(node_ids, paths_per_vuln, path_hits)
         relevance = max(score, _REMOVE_RELEVANCE_FLOOR)
         options.append(
@@ -205,6 +209,8 @@ def _diversify_swap_kind_mutations(
     existing_kinds_by_target = _existing_kinds_by_target(graph)
     mutations: list[Mutation] = []
     for kind in sorted(vulns_by_kind):
+        if kind == _RECON_KIND:
+            continue
         node_ids = sorted(vulns_by_kind[kind])
         if not node_ids:
             continue

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -23,9 +23,10 @@ from cyber_webapp import (
 )
 from cyber_webapp.codegen.seeding import project_seed
 from cyber_webapp.difficulty import world_difficulty
+from cyber_webapp.invariants import unique_vuln_per_endpoint
 from cyber_webapp.mutation import available_mutations
 from cyber_webapp.reference_solver import solve_chain
-from graphschema import Node, WorldGraph
+from graphschema import Edge, Node, Visibility, WorldGraph
 from openrange_pack_sdk import Backing, PoolableRuntime, Snapshot
 from openrange_trl import EpisodeEnv
 
@@ -665,6 +666,58 @@ def test_consequence_gate_rejects_an_unsolvable_world(tmp_path: Path) -> None:
         assert not verdict(broken.graph, base, entry).accepted
     finally:
         svc.close()
+
+
+def test_unique_vuln_invariant_flags_a_duplicate() -> None:
+    graph = _admit(_LATERAL_MANIFEST).graph
+    assert unique_vuln_per_endpoint(graph) == []
+    vuln = next(iter(graph.by_kind("vulnerability")))
+    target = next(e.dst for e in graph.out_edges(vuln.id, "affects"))
+    graph.add_node(
+        Node(
+            id="vuln_dup",
+            kind="vulnerability",
+            attrs={"kind": vuln.attrs.get("kind"), "family": "code_web", "params": {}},
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    graph.edges["e_dup"] = Edge(id="e_dup", kind="affects", src="vuln_dup", dst=target)
+    codes = [i.code for i in unique_vuln_per_endpoint(graph)]
+    assert codes == ["duplicate_vuln_on_endpoint"]
+
+
+def test_no_duplicate_same_kind_vuln_on_one_endpoint() -> None:
+    for seed in range(30):
+        for extra in ({}, {"company": True}):
+            graph = _admit({**_DEFAULT_MANIFEST, "seed": seed, **extra}).graph
+            seen: set[tuple[str, str]] = set()
+            for v in graph.by_kind("vulnerability"):
+                target = next((e.dst for e in graph.out_edges(v.id, "affects")), "")
+                key = (str(v.attrs.get("kind")), str(target))
+                assert key not in seen, f"seed={seed} {extra}: duplicate {key}"
+                seen.add(key)
+
+
+def test_evolution_never_removes_or_swaps_the_recon() -> None:
+    graph = _admit(_LATERAL_MANIFEST).graph
+    recon_ids = {
+        n.id
+        for n in graph.by_kind("vulnerability")
+        if n.attrs.get("kind") == "config_disclosure"
+    }
+    assert recon_ids
+    threatening = [
+        m
+        for m in available_mutations(graph, "webapp.pentest", [])
+        if m.direction in ("soften", "diversify")
+    ]
+    touched = {
+        nid
+        for m in threatening
+        for nid in (*m.patch.nodes_removed, *(n.id for n in m.patch.nodes_updated))
+    }
+    assert recon_ids.isdisjoint(touched)
+    assert touched
 
 
 def test_append_a_hop_deepens_the_chain_and_stays_solvable(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Closes #313 — two world-coherence bugs the generation audit found.

1. **Evolution could delete the recon.** A diversify swap or a soften remove could drop the `config_disclosure` recon that names the SSRF's internal pivot host — leaving a blind agent no way to find the pivot, yet still re-admitting (feasibility only proves a graph path exists). Fix: skip the recon kind in both operators so it always survives evolution.
2. **Dead duplicate vulns (~3/100).** Two vulnerabilities of the same kind on one endpoint render to a single handler, so the second is a dead node the graph over-claims — both the sampler's decoy pool and the SSRF re-home could create one. Fixed at the **root**: enforce `(kind, endpoint)` uniqueness as one admission invariant (`unique_vuln_per_endpoint`), so any such world — generated, networked, or evolved — is rejected and reseeded. No per-site dedups, no workaround comments.

## Verification

- New tests: the invariant flags a duplicate (and passes a clean world); no admitted world (flat + company, 30 seeds each) has two same-kind vulns on one endpoint; and evolution offers no soften/diversify mutation that touches the recon (while still mutating other vulns).
- 104 passed across `test_cyber_company` + `test_cyber_solver` + `test_cyber_staged_generation` + `test_cyber_realize_admit`; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
