### PR TITLE
cyber: stop the sampler placing two same-kind vulns on one endpoint

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -798,6 +798,7 @@ def _sample_vulnerabilities(
         rng, oracle_shapes, pool, oracle_endpoints, graph, db_backed_services
     )
 
+    placed_pairs: set[tuple[str, str]] = set()
     placed_vulns: list[Node] = []
     for i in range(count):
         target_node: Node | None = None
@@ -808,17 +809,22 @@ def _sample_vulnerabilities(
             if kind not in VULN_CATALOG:
                 continue
             target_kinds = VULN_CATALOG[kind].target_kinds
-            eligible_endpoints = _eligible_endpoints_for(
-                kind, endpoints, graph, db_backed_services
-            )
             if "endpoint" in target_kinds:
-                if not eligible_endpoints:
-                    continue
-                target_node = eligible_endpoints[i % len(eligible_endpoints)]
-            elif "service" in target_kinds and services:
-                target_node = services[i % len(services)]
+                candidates = _eligible_endpoints_for(
+                    kind, endpoints, graph, db_backed_services
+                )
+            elif "service" in target_kinds:
+                candidates = services
             else:
                 continue
+            if not candidates:
+                continue
+            target_node = candidates[i % len(candidates)]
+        # The codegen renders one handler per (kind, endpoint), so a second vuln on
+        # the pair is a dead node the uniqueness invariant rejects.
+        if (kind, target_node.id) in placed_pairs:
+            continue
+        placed_pairs.add((kind, target_node.id))
         catalog_entry = VULN_CATALOG[kind]
         vuln_id = f"vuln_{kind}_{i}"
         vuln_node = Node(


### PR DESCRIPTION
## What

A `main` regression surfaced by CI on #310 — the failing check is `tests/test_trl_cyber.py`, not the notebook.

A world that pins a single vuln kind — e.g. `vuln_kinds={"sql_injection": 1}` — with more vuln slots than endpoints eligible for that kind placed the kind on the same endpoint repeatedly (round-robin by index), stacking two or three same-kind vulns on one endpoint. The uniqueness invariant from #318 correctly rejects that (a second same-kind vuln renders to one handler — a dead node), **but a pinned kind can't escape it by reseeding**, so admission failed outright. `tests/test_trl_cyber.py` forces exactly such a world (`sql_injection`-only, seed 0), so it — and any branch merging with `main` — went red.

## Fix

The sampler skips a decoy whose `(kind, target)` is already placed — one guard, so it never generates the dead node the invariant forbids. The #318 invariant stays as the guard for evolution and externally-built graphs.

## No change to admitting worlds

A world that already admitted has no duplicate (the invariant would have rejected it), so the guard never fires for it and its placement and snapshot are untouched — verified: company seed 3 still hashes to `…ce3e3fcec648`. Only the previously-unadmittable worlds change (they now admit). `tests/test_trl_cyber.py` is green (16/16) and the full cyber suite passes; `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
