### PR TITLE
cyber: score difficulty by the solve path, not the attack surface

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/difficulty.py
+++ b/packs/cyber_webapp/cyber_webapp/difficulty.py
@@ -17,7 +17,13 @@ from cyber_webapp.mutation import (
     _credential_walk,
     _oracle_path_targets,
 )
+from cyber_webapp.vulnerabilities import CATALOG
 
+# Default weights for the difficulty model. The chain-hop weight dominates, so a
+# world is ordered first by how many credential hops its solve walks and the rest
+# only break ties; a curriculum re-weights by injecting its own difficulty_fn into
+# the pool rather than editing these. Per-class exploit hardness is not here: it is
+# a property of each vuln kind, on the catalog (Vulnerability.exploit_complexity).
 _W_HOP = 10
 _W_PIVOT = 4
 _W_BOUNDARY = 3
@@ -30,22 +36,6 @@ _BODY_BUMP = 0.15
 _RECON_KIND = "config_disclosure"
 _CHAIN_KINDS = ("credential_leak", "credential_gated_relay", "credential_gated_flag")
 _OFF_PATH_EXCLUDED = {"ssrf", _RECON_KIND, "metadata_credential_leak", *_CHAIN_KINDS}
-
-_CLASS_HARDNESS = {
-    "idor": 0.2,
-    "weak_credentials": 0.3,
-    "broken_authz": 0.3,
-    "path_traversal": 0.5,
-    "ssrf": 0.5,
-    "metadata_credential_leak": 0.1,
-    "credential_leak": 0.1,
-    "credential_gated_relay": 0.1,
-    "credential_gated_flag": 0.1,
-    "sql_injection": 0.7,
-    "xxe": 0.7,
-    "ssti": 0.7,
-    "command_injection": 0.8,
-}
 
 
 def _entry_ssrf(graph: WorldGraph) -> Node | None:
@@ -89,9 +79,11 @@ def _class_weight(graph: WorldGraph, vuln: Node | None) -> float:
     if vuln is None:
         return 0.0
     kind = str(vuln.attrs.get("kind", ""))
+    spec = CATALOG.get(kind)
+    complexity = spec.exploit_complexity if spec is not None else 0.5
     endpoint = graph.nodes.get(_affects_target_id(graph, vuln.id) or "")
     body = endpoint is not None and endpoint.attrs.get("method") == "POST"
-    return _CLASS_HARDNESS.get(kind, 0.5) + (_BODY_BUMP if body else 0.0)
+    return complexity + (_BODY_BUMP if body else 0.0)
 
 
 def world_difficulty(graph: WorldGraph) -> float:

--- a/packs/cyber_webapp/cyber_webapp/difficulty.py
+++ b/packs/cyber_webapp/cyber_webapp/difficulty.py
@@ -1,21 +1,128 @@
-"""A world's difficulty as one comparable number, read from the graph.
+"""A world's difficulty, read off the path the reference solver actually walks.
 
-The chain weight must exceed the per-world vuln count (single digits) so chain
-depth always outranks vuln count, which only breaks ties between equal depths.
+Difficulty is the cost of executing the winning chain, not the size of the attack
+surface. The credential-reuse hop count dominates; the number of internal pivots, the
+dmz->internal crossing, blind recon, and the entry exploit's class are smaller
+corrections; and off-path decoys saturate at a cap so they can never out-rank a real
+hop. Every chain term is gated on a reachable public entry, so a world whose chain no
+longer has a way in scores like the flat world it has become.
 """
 
 from __future__ import annotations
 
-from graphschema import WorldGraph
+from graphschema import Node, WorldGraph
 
-_CHAIN_WEIGHT = 10
+from cyber_webapp.mutation import (
+    _affects_target_id,
+    _credential_walk,
+    _oracle_path_targets,
+)
+
+_W_HOP = 10
+_W_PIVOT = 4
+_W_BOUNDARY = 3
+_W_BLIND = 5
+_W_CLASS = 4
+_DECOY_CAP = 3.0
+_DECOY_PER = 0.3
+_BODY_BUMP = 0.15
+
+_RECON_KIND = "config_disclosure"
+_CHAIN_KINDS = ("credential_leak", "credential_gated_relay", "credential_gated_flag")
+_OFF_PATH_EXCLUDED = {"ssrf", _RECON_KIND, "metadata_credential_leak", *_CHAIN_KINDS}
+
+_CLASS_HARDNESS = {
+    "idor": 0.2,
+    "weak_credentials": 0.3,
+    "broken_authz": 0.3,
+    "path_traversal": 0.5,
+    "ssrf": 0.5,
+    "metadata_credential_leak": 0.1,
+    "credential_leak": 0.1,
+    "credential_gated_relay": 0.1,
+    "credential_gated_flag": 0.1,
+    "sql_injection": 0.7,
+    "xxe": 0.7,
+    "ssti": 0.7,
+    "command_injection": 0.8,
+}
 
 
-def world_difficulty(graph: WorldGraph) -> int:
+def _entry_ssrf(graph: WorldGraph) -> Node | None:
+    public_eps = {
+        edge.dst
+        for svc in graph.by_kind("service")
+        if svc.attrs.get("exposure") == "public"
+        for edge in graph.out_edges(svc.id, "exposes")
+    }
+    for vuln in graph.by_kind("vulnerability"):
+        if vuln.attrs.get("kind") != "ssrf":
+            continue
+        if {edge.dst for edge in graph.out_edges(vuln.id, "affects")} & public_eps:
+            return vuln
+    return None
+
+
+def _placement_index(vuln: Node) -> tuple[int, str]:
+    suffix = vuln.id.rsplit("_", 1)[-1]
+    return (int(suffix) if suffix.isdigit() else 1_000_000, vuln.id)
+
+
+def _oracle_vuln(graph: WorldGraph) -> Node | None:
+    oracle_endpoints, _ = _oracle_path_targets(graph)
+    on_oracle = [
+        vuln
+        for vuln in graph.by_kind("vulnerability")
+        if _affects_target_id(graph, vuln.id) in oracle_endpoints
+        and vuln.attrs.get("kind") != _RECON_KIND
+    ]
+    for kind in ("credential_gated_flag", "metadata_credential_leak"):
+        gated = [vuln for vuln in on_oracle if vuln.attrs.get("kind") == kind]
+        if gated:
+            return gated[0]
+    # The sampler places the flag-reading oracle first (id `vuln_<kind>_0`), so the
+    # lowest placement index is the real exploit, not an alphabetically-earlier decoy.
+    return min(on_oracle, key=_placement_index) if on_oracle else None
+
+
+def _class_weight(graph: WorldGraph, vuln: Node | None) -> float:
+    if vuln is None:
+        return 0.0
+    kind = str(vuln.attrs.get("kind", ""))
+    endpoint = graph.nodes.get(_affects_target_id(graph, vuln.id) or "")
+    body = endpoint is not None and endpoint.attrs.get("method") == "POST"
+    return _CLASS_HARDNESS.get(kind, 0.5) + (_BODY_BUMP if body else 0.0)
+
+
+def world_difficulty(graph: WorldGraph) -> float:
+    entry = _entry_ssrf(graph)
+    oracle = _oracle_vuln(graph)
     vulns = list(graph.by_kind("vulnerability"))
-    chain_depth = sum(
+
+    if entry is not None:
+        walk = _credential_walk(graph)
+        chain_hops = len(walk)
+        pivots = len({host for host, _ in walk}) if walk else 1
+        boundaries = 1
+        blind = 0 if any(v.attrs.get("kind") == _RECON_KIND for v in vulns) else 1
+    else:
+        chain_hops = pivots = boundaries = blind = 0
+
+    on_path_class = _class_weight(graph, entry) + _class_weight(graph, oracle)
+
+    oracle_id = oracle.id if oracle is not None else None
+    off_path = sum(
         1
         for vuln in vulns
-        if str(vuln.attrs.get("kind", "")).startswith("credential_gated")
+        if vuln.id != oracle_id and vuln.attrs.get("kind") not in _OFF_PATH_EXCLUDED
     )
-    return chain_depth * _CHAIN_WEIGHT + len(vulns)
+
+    return round(
+        _W_HOP * chain_hops
+        + _W_PIVOT * pivots
+        + _W_BOUNDARY * boundaries
+        + _W_BLIND * blind
+        + _W_CLASS * on_path_class
+        + min(_DECOY_CAP, _DECOY_PER * off_path),
+        2,
+    )

--- a/packs/cyber_webapp/cyber_webapp/vulnerabilities/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/vulnerabilities/__init__.py
@@ -23,6 +23,9 @@ class Vulnerability:
     # How the exploit reaches the flag; the loot stage picks a vuln whose
     # shape matches the placed loot.
     shape: str = "response_leak"
+    # CVSS-style exploit difficulty (0 trivial .. 1 hard) the difficulty metric
+    # reads to weight this class when it is the flag-reading exploit.
+    exploit_complexity: float = 0.5
     requires: frozenset[str] = frozenset()
     enables: frozenset[str] = frozenset()
     attrs_schema: Mapping[str, str] = field(default_factory=dict)
@@ -35,6 +38,7 @@ class Vulnerability:
             "target_kinds": sorted(self.target_kinds),
             "template": self.template,
             "shape": self.shape,
+            "exploit_complexity": self.exploit_complexity,
             "requires": sorted(self.requires),
             "enables": sorted(self.enables),
             "attrs_schema": dict(self.attrs_schema),
@@ -46,6 +50,7 @@ class Vulnerability:
         requires_raw = data.get("requires", ())
         enables_raw = data.get("enables", ())
         attrs_raw = data.get("attrs_schema", {})
+        complexity_raw = data.get("exploit_complexity", 0.5)
         if not isinstance(target_kinds_raw, list | tuple | frozenset | set):
             raise ValueError("target_kinds must be a sequence")
         if not isinstance(requires_raw, list | tuple | frozenset | set):
@@ -54,6 +59,8 @@ class Vulnerability:
             raise ValueError("enables must be a sequence")
         if not isinstance(attrs_raw, Mapping):
             raise ValueError("attrs_schema must be a mapping")
+        if not isinstance(complexity_raw, int | float):
+            raise ValueError("exploit_complexity must be a number")
         return cls(
             id=str(data["id"]),
             family=str(data["family"]),
@@ -61,6 +68,7 @@ class Vulnerability:
             target_kinds=frozenset(str(k) for k in target_kinds_raw),
             template=str(data["template"]),
             shape=str(data.get("shape", "response_leak")),
+            exploit_complexity=float(complexity_raw),
             requires=frozenset(str(k) for k in requires_raw),
             enables=frozenset(str(k) for k in enables_raw),
             attrs_schema={str(k): str(v) for k, v in attrs_raw.items()},
@@ -69,6 +77,7 @@ class Vulnerability:
 
 SQL_INJECTION = Vulnerability(
     id="sql_injection",
+    exploit_complexity=0.7,
     family="code_web",
     description=(
         "Endpoint that interpolates an unparameterized query parameter "
@@ -87,6 +96,7 @@ SQL_INJECTION = Vulnerability(
 
 SSRF = Vulnerability(
     id="ssrf",
+    exploit_complexity=0.5,
     family="code_web",
     description=(
         "Endpoint that fetches a URL supplied by the client without "
@@ -105,6 +115,7 @@ SSRF = Vulnerability(
 
 BROKEN_AUTHZ = Vulnerability(
     id="broken_authz",
+    exploit_complexity=0.3,
     family="code_web",
     description=(
         "Endpoint trusts a client-controlled header for the user's role "
@@ -124,6 +135,7 @@ BROKEN_AUTHZ = Vulnerability(
 
 PATH_TRAVERSAL = Vulnerability(
     id="path_traversal",
+    exploit_complexity=0.5,
     family="code_web",
     description=(
         "Endpoint serves a file named by a client parameter, joining it onto "
@@ -142,6 +154,7 @@ PATH_TRAVERSAL = Vulnerability(
 
 COMMAND_INJECTION = Vulnerability(
     id="command_injection",
+    exploit_complexity=0.8,
     family="code_web",
     description=(
         "Diagnostic endpoint concatenates a client parameter into a shell "
@@ -160,6 +173,7 @@ COMMAND_INJECTION = Vulnerability(
 
 XXE = Vulnerability(
     id="xxe",
+    exploit_complexity=0.7,
     family="code_web",
     description=(
         "Endpoint parses client XML with external entities enabled, so a "
@@ -177,6 +191,7 @@ XXE = Vulnerability(
 
 SSTI = Vulnerability(
     id="ssti",
+    exploit_complexity=0.7,
     family="code_web",
     description=(
         "Endpoint renders a client parameter as a template, so a template "
@@ -194,6 +209,7 @@ SSTI = Vulnerability(
 
 IDOR = Vulnerability(
     id="idor",
+    exploit_complexity=0.2,
     family="code_web",
     description=(
         "Endpoint returns a record by a client-supplied id with no ownership "
@@ -210,6 +226,7 @@ IDOR = Vulnerability(
 
 WEAK_CREDENTIALS = Vulnerability(
     id="weak_credentials",
+    exploit_complexity=0.3,
     family="code_web",
     description=(
         "Authentication endpoint accepts a default/weak credential pair, so "
@@ -229,6 +246,7 @@ WEAK_CREDENTIALS = Vulnerability(
 
 METADATA_CREDENTIAL_LEAK = Vulnerability(
     id="metadata_credential_leak",
+    exploit_complexity=0.1,
     family="code_web",
     description=(
         "An unauthenticated internal endpoint (cloud-metadata / admin style) returns a "
@@ -244,6 +262,7 @@ METADATA_CREDENTIAL_LEAK = Vulnerability(
 
 CONFIG_DISCLOSURE = Vulnerability(
     id="config_disclosure",
+    exploit_complexity=0.0,
     family="code_web",
     description=(
         "A public status/config endpoint over-shares internal infrastructure — it "
@@ -263,6 +282,7 @@ CONFIG_DISCLOSURE = Vulnerability(
 
 CREDENTIAL_LEAK = Vulnerability(
     id="credential_leak",
+    exploit_complexity=0.1,
     family="code_web",
     description=(
         "An unauthenticated internal endpoint hands out a service credential (a db "
@@ -284,6 +304,7 @@ CREDENTIAL_LEAK = Vulnerability(
 
 CREDENTIAL_GATED_FLAG = Vulnerability(
     id="credential_gated_flag",
+    exploit_complexity=0.1,
     family="code_web",
     description=(
         "An internal data endpoint that serves the flag only to a caller presenting "
@@ -303,6 +324,7 @@ CREDENTIAL_GATED_FLAG = Vulnerability(
 
 CREDENTIAL_GATED_RELAY = Vulnerability(
     id="credential_gated_relay",
+    exploit_complexity=0.1,
     family="code_web",
     description=(
         "An intermediate internal relay: validates the reused db token, then hands "

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -22,9 +22,9 @@ from cyber_webapp import (
     monotone_chain_gate,
 )
 from cyber_webapp.codegen.seeding import project_seed
-from cyber_webapp.difficulty import world_difficulty
+from cyber_webapp.difficulty import _DECOY_CAP, _entry_ssrf, world_difficulty
 from cyber_webapp.invariants import unique_vuln_per_endpoint
-from cyber_webapp.mutation import available_mutations
+from cyber_webapp.mutation import _oracle_path_targets, available_mutations
 from cyber_webapp.reference_solver import solve_chain
 from graphschema import Edge, Node, Visibility, WorldGraph
 from openrange_pack_sdk import Backing, PoolableRuntime, Snapshot
@@ -348,10 +348,98 @@ def test_write_exec_world_is_not_poolable() -> None:
 def test_world_difficulty_rises_with_chain_depth() -> None:
     flat = world_difficulty(_admit(_DEFAULT_MANIFEST).graph)
     company = world_difficulty(_admit(_COMPANY_MANIFEST).graph)
-    lateral = world_difficulty(
-        _admit({**_COMPANY_MANIFEST, "lateral_movement": True}).graph
-    )
+    lateral = world_difficulty(_admit(_LATERAL_MANIFEST).graph)
     assert flat < company < lateral
+
+
+def _add_off_path_vuln(graph: WorldGraph, i: int) -> None:
+    graph.add_node(
+        Node(
+            f"svc_decoy{i}",
+            "service",
+            attrs={"name": f"decoy{i}", "exposure": "internal"},
+        )
+    )
+    graph.add_node(
+        Node(f"ep_decoy{i}", "endpoint", attrs={"path": f"/d{i}", "method": "GET"})
+    )
+    graph.add_node(
+        Node(
+            f"v_decoy{i}",
+            "vulnerability",
+            attrs={"kind": "sql_injection", "params": {}},
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    graph.add_edge(Edge(f"ed{i}exp", "exposes", f"svc_decoy{i}", f"ep_decoy{i}"))
+    graph.add_edge(Edge(f"ed{i}aff", "affects", f"v_decoy{i}", f"ep_decoy{i}"))
+
+
+def _add_oracle_sibling_decoy(graph: WorldGraph) -> None:
+    service = next(iter(_oracle_path_targets(graph)[1]))
+    graph.add_node(
+        Node(
+            "ep_oracle_sibling", "endpoint", attrs={"path": "/admin", "method": "POST"}
+        )
+    )
+    graph.add_edge(Edge("e_oracle_sib_exp", "exposes", service, "ep_oracle_sibling"))
+    graph.add_node(
+        Node(
+            "vuln_command_injection_9",
+            "vulnerability",
+            attrs={"kind": "command_injection", "params": {}},
+            visibility=Visibility.HIDDEN,
+        )
+    )
+    graph.add_edge(
+        Edge(
+            "e_oracle_sib_aff",
+            "affects",
+            "vuln_command_injection_9",
+            "ep_oracle_sibling",
+        )
+    )
+
+
+def test_off_path_decoys_cannot_outrank_a_real_hop() -> None:
+    graph = _admit(_LATERAL_MANIFEST).graph
+    base = world_difficulty(graph)
+    for i in range(20):
+        _add_off_path_vuln(graph, i)
+    assert world_difficulty(graph) - base <= _DECOY_CAP
+
+
+def test_an_oracle_sibling_decoy_is_never_scored_on_path() -> None:
+    for manifest in (_DEFAULT_MANIFEST, _LATERAL_MANIFEST):
+        graph = _admit(manifest).graph
+        base = world_difficulty(graph)
+        _add_oracle_sibling_decoy(graph)
+        assert world_difficulty(graph) - base < 1
+
+
+def test_a_chain_with_no_way_in_scores_like_a_flat_world() -> None:
+    graph = _admit(_LATERAL_MANIFEST).graph
+    flat = world_difficulty(_admit(_DEFAULT_MANIFEST).graph)
+    ssrf = _entry_ssrf(graph)
+    assert ssrf is not None
+    internal_ep = next(
+        edge.dst
+        for svc in graph.by_kind("service")
+        if svc.attrs.get("exposure") != "public"
+        for edge in graph.out_edges(svc.id, "exposes")
+    )
+    for affects in graph.out_edges(ssrf.id, "affects"):
+        affects.dst = internal_ep
+    assert _entry_ssrf(graph) is None
+    assert world_difficulty(graph) <= flat
+
+
+def test_blind_recon_is_harder_than_recon_given() -> None:
+    given = world_difficulty(_admit(_COMPANY_MANIFEST).graph)
+    blind = world_difficulty(
+        _admit({**_COMPANY_MANIFEST, "recon_disclosure": "none"}).graph
+    )
+    assert blind > given
 
 
 def test_warm_cache_is_a_bounded_lru(tmp_path: Path) -> None:
@@ -730,7 +818,7 @@ def test_append_a_hop_deepens_the_chain_and_stays_solvable(tmp_path: Path) -> No
         parent, report, pack=pack, gate=monotone_chain_gate(parent), max_repairs=3
     )
     assert child is not None
-    # +10 is the chain-depth weight: a hop was appended, not an off-path decoy (+1).
+    # A real appended hop adds the full chain-hop weight, far above any off-path decoy.
     assert world_difficulty(child.graph) - parent_diff >= 10
     assert _breach_report(pack, tmp_path / "child", child).passed
 

--- a/tests/test_cyber_vulnerabilities.py
+++ b/tests/test_cyber_vulnerabilities.py
@@ -93,6 +93,7 @@ def test_catalog_yaml_round_trip() -> None:
         assert rt.family == v.family
         assert rt.target_kinds == v.target_kinds
         assert rt.template == v.template
+        assert rt.exploit_complexity == v.exploit_complexity
         assert rt.requires == v.requires
         assert rt.enables == v.enables
 


### PR DESCRIPTION
## What

`world_difficulty` was `chain_depth*10 + vuln_count`, with `chain_depth` counting any node whose kind started with `credential_gated`. That measured the **attack surface**, and it was gameable:

- an off-path inert `credential_gated_flag` added **+11** without making the world harder,
- every decoy added **+1**, unboundedly,
- a one-pivot company world and a four-hop lateral chain both read as depth-1,
- it missed the leak hop that *starts* a chain, and never saw recon, pivots, or the dmz→internal boundary.

This rewrites it to measure the **cost of executing the reference solver's winning chain** instead — grounded in the attack-graph difficulty literature (shortest-path / kill-chain length, CVSS exploit class) and the UED constraint that difficulty must stay monotone in real solve effort:

```
world_difficulty =
  10 · chain_hops          # credential leak->relay*->flag walk — DOMINANT
+  4 · pivots              # distinct internal services the chain lands on
+  3 · boundaries_crossed  # the dmz->internal trust-boundary crossing
+  5 · blind_recon         # the agent must enumerate internal hosts (no config_disclosure)
+  4 · on_path_class       # CVSS-style hardness of the entry + the one flag-leaking exploit
+  min(3, 0.3 · off_path)  # decoys saturate — can never out-rank one real hop
```

Every chain term is **gated on a reachable public entry** (the SSRF the solver enters through), so a world whose chain has lost its way in scores like the flat world it has become.

## Verified on the seed-3 worlds

| world | difficulty | |
|---|---|---|
| flat | 2.8 | |
| company (1-pivot SSRF) | 10.0 | strict flat < company < lateral |
| lateral (4-hop chain) | 48.0 | |

- **Append a hop** → ≥ +10 (the existing contract holds).
- **Off-path decoy** → +0.3; **20 decoys** saturate at +2.4; **a hard `command_injection` on a sibling endpoint of the oracle service** → +0.3 (not +3.4 — the on-path class now reads only the single flag-leaking vuln plus the entry, not the whole service); **inert `credential_gated_flag`** → +0.0.
- **Strip the only SSRF from a lateral world** (unsolvable) → collapses 48 → 1.0, below flat.
- **Blind recon** → +5.0.

## Relation to the pool's behavioural signal

This is a **static prior** — a cheap, rollout-free ordering that seeds pool priority and gates admission. It does not replace the pool's live `p(1-p)` / regret signal; the two compose (static orders and gates, behavioural has the final say on what to replay).

## Tests

Existing contracts (`test_world_difficulty_rises_with_chain_depth`, `test_append_a_hop_deepens_the_chain_and_stays_solvable`, the three performance-driven evolution tests) still pass, plus four new regression tests pinning the gameability, oracle-sibling, solvability-gating, and blind-recon behaviour. Full `test_cyber_company.py` green (42), ruff + mypy clean.

Decoupled from `BODY_SHAPED_KINDS` (#320, not yet on main): the body-shaped signal is read as `method == "POST"`, so this works on main today (GET-only → no bump) and activates automatically once #320 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
