### PR TITLE
cyber: close GRPO rollout envs so CONTAINER worlds don't leak

### DIFF
--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -171,6 +171,13 @@ class EpisodeEnv:
         self._finalized = False
         return self._initial_observation()
 
+    def close(self) -> None:
+        """Release the env's resources: tear down any sandbox and close the underlying
+        ``EpisodeService`` (stopping live episodes and warm-pooled worlds). TRL never
+        closes the envs it builds from a factory, so the factory's owner must."""
+        self._teardown_sandbox()
+        self.service.close()
+
     def _initial_observation(self) -> str:
         surface = self._surface or {}
         base_url = surface.get("base_url")
@@ -477,9 +484,15 @@ def make_grpo_rounds(
             environment_factory=factory,
             peft_config=holder["peft"],
         )
-        trainer.train()
-        if update:
-            holder["model"], holder["peft"] = trainer.model, None
+        try:
+            trainer.train()
+            if update:
+                holder["model"], holder["peft"] = trainer.model, None
+        finally:
+            # TRL builds one env per batch slot and never closes them; without this
+            # each round's CONTAINER worlds (a per-service container stack) leak.
+            for env in getattr(trainer, "environments", None) or []:
+                env.close()
         return collector
 
     def train_round(rows: list[PromptRow], snapshots: list[Snapshot]) -> RoundReports:

--- a/tests/test_trl_adapter.py
+++ b/tests/test_trl_adapter.py
@@ -186,6 +186,20 @@ def test_base_env_resets_with_no_tools(tmp_path: Path) -> None:
         service.close()
 
 
+def test_env_close_releases_the_service(tmp_path: Path) -> None:
+    # TRL builds envs from a factory and never closes them, so env.close() is the
+    # only hook to stop the live episode + warm worlds. Without it, CONTAINER rollouts
+    # leak a container stack per env. close() is idempotent and safe before any reset.
+    snapshot = _admit("calc_sum")
+    service = EpisodeService(SwePack(), tmp_path / "close")
+    env = EpisodeEnv(service=service, snapshots={snapshot.snapshot_id: snapshot})
+    env.reset(snapshot_id=snapshot.snapshot_id)
+    assert service._episodes  # a live episode is registered
+    env.close()
+    assert not service._episodes  # closed: nothing left running
+    env.close()  # idempotent
+
+
 class TestBuildDataset:
     def test_rows_carry_prompt_and_tags(self) -> None:
         snapshot = _admit("calc_sum")


### PR DESCRIPTION
## Problem

TRL's `GRPOTrainer` builds one environment per batch slot from the `environment_factory` and never closes them (the env protocol is `reset`-only). `EpisodeEnv` had no `close()` either, and it owns its `EpisodeService`. So every `make_grpo_rounds` round leaked the rollout `EpisodeService`s — and under `Backing.CONTAINER` each service is a per-service container stack. Running the tutorial notebook under docker left **~26 containers + 4 networks** still `Up` after it finished.

## Fix

- `EpisodeEnv.close()` — tear down any sandbox and close the underlying `EpisodeService` (which stops live episodes and warm-pooled worlds). Idempotent; safe before any `reset`.
- `make_grpo_rounds._round` now closes `trainer.environments` in a `finally` after `trainer.train()`, so the rollout worlds are released even if training raises.

This fixes the leak for every consumer of `make_grpo_rounds`, not just the notebook — so no notebook cleanup cell is needed.

## Verification

- New unit test `test_env_close_releases_the_service` pins `env.close()` clearing the service's live episodes (and being idempotent).
- Integration proof: one real GRPO round under `Backing.CONTAINER` (the model actually invoked tools) ends at **0 leaked containers / 0 networks** (baseline `(0,0)` → after `(0,0)`); the same path left 4 networks before the fix.
- `ruff`, `mypy` (CI command), and the core/pack boundary check are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)