### PR TITLE
cyber: make the curriculum self-verifying by default

### DIFF
--- a/examples/trl_grpo_cyber.ipynb
+++ b/examples/trl_grpo_cyber.ipynb
@@ -54,10 +54,10 @@
    "id": "3900e6b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T02:09:06.985308Z",
-     "iopub.status.busy": "2026-06-20T02:09:06.985148Z",
-     "iopub.status.idle": "2026-06-20T02:09:07.321393Z",
-     "shell.execute_reply": "2026-06-20T02:09:07.320684Z"
+     "iopub.execute_input": "2026-06-20T18:42:09.101664Z",
+     "iopub.status.busy": "2026-06-20T18:42:09.101510Z",
+     "iopub.status.idle": "2026-06-20T18:42:09.439566Z",
+     "shell.execute_reply": "2026-06-20T18:42:09.439124Z"
     }
    },
    "outputs": [
@@ -134,10 +134,10 @@
    "id": "0bf8859e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T02:09:07.322860Z",
-     "iopub.status.busy": "2026-06-20T02:09:07.322717Z",
-     "iopub.status.idle": "2026-06-20T02:09:07.325795Z",
-     "shell.execute_reply": "2026-06-20T02:09:07.325438Z"
+     "iopub.execute_input": "2026-06-20T18:42:09.441055Z",
+     "iopub.status.busy": "2026-06-20T18:42:09.440906Z",
+     "iopub.status.idle": "2026-06-20T18:42:09.443883Z",
+     "shell.execute_reply": "2026-06-20T18:42:09.443496Z"
     }
    },
    "outputs": [
@@ -207,10 +207,10 @@
    "id": "eda_provenance_code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T02:09:07.326719Z",
-     "iopub.status.busy": "2026-06-20T02:09:07.326665Z",
-     "iopub.status.idle": "2026-06-20T02:09:21.198471Z",
-     "shell.execute_reply": "2026-06-20T02:09:21.197638Z"
+     "iopub.execute_input": "2026-06-20T18:42:09.444909Z",
+     "iopub.status.busy": "2026-06-20T18:42:09.444836Z",
+     "iopub.status.idle": "2026-06-20T18:43:03.550415Z",
+     "shell.execute_reply": "2026-06-20T18:43:03.549256Z"
     }
    },
    "outputs": [
@@ -248,15 +248,18 @@
       "    key_column = state['schema']['key_column']\n",
       "    terms = query.get('term') or ['']\n",
       "    term = terms[0]\n",
-      "    sql = \"SELECT \" + key_column + \", secret FROM records WHERE \" + key_column + \" = \" + term\n",
+      "    # Intentionally vulnerable (training gym): term is concatenated straight\n",
+      "    # into the WHERE clause, unquoted and unparameterized, so a UNION payload\n",
+      "    # like \"0 UNION SELECT key, secret FROM records -- \" surfaces every row.\n",
+      "    sql = \"SELECT * FROM records WHERE \" + key_column + \" = \" + term\n",
       "    try:\n",
       "        cur = db.execute(sql)\n",
       "        rows = [dict(r) for r in cur.fetchall()]\n",
       "    except Exception as exc:\n",
       "        body = json.dumps({\"error\": str(exc)}).encode(\"utf-8\")\n",
-      "        return 400, {\"Content-Type\": \"application/json\"}, body\n",
+      "        return (400, {\"Content-Type\": \"application/json\"}, body)\n",
       "    body = json.dumps({\"results\": rows}).encode(\"utf-8\")\n",
-      "    return 200, {\"Content-Type\": \"application/json\"}, body\n"
+      "    return (200, {\"Content-Type\": \"application/json\"}, body)\n"
      ]
     }
    ],
@@ -327,10 +330,10 @@
    "id": "93f9fe0f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T02:09:21.200451Z",
-     "iopub.status.busy": "2026-06-20T02:09:21.200294Z",
-     "iopub.status.idle": "2026-06-20T02:09:37.510444Z",
-     "shell.execute_reply": "2026-06-20T02:09:37.509271Z"
+     "iopub.execute_input": "2026-06-20T18:43:03.554089Z",
+     "iopub.status.busy": "2026-06-20T18:43:03.553915Z",
+     "iopub.status.idle": "2026-06-20T18:43:23.088593Z",
+     "shell.execute_reply": "2026-06-20T18:43:23.087172Z"
     }
    },
    "outputs": [
@@ -489,10 +492,10 @@
    "id": "972058b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T02:09:37.513902Z",
-     "iopub.status.busy": "2026-06-20T02:09:37.513708Z",
-     "iopub.status.idle": "2026-06-20T02:09:38.194284Z",
-     "shell.execute_reply": "2026-06-20T02:09:38.193793Z"
+     "iopub.execute_input": "2026-06-20T18:43:23.092977Z",
+     "iopub.status.busy": "2026-06-20T18:43:23.092743Z",
+     "iopub.status.idle": "2026-06-20T18:43:24.104537Z",
+     "shell.execute_reply": "2026-06-20T18:43:24.104088Z"
     }
    },
    "outputs": [],
@@ -539,10 +542,10 @@
    "id": "a754841e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T02:09:38.195438Z",
-     "iopub.status.busy": "2026-06-20T02:09:38.195367Z",
-     "iopub.status.idle": "2026-06-20T02:09:40.824186Z",
-     "shell.execute_reply": "2026-06-20T02:09:40.823596Z"
+     "iopub.execute_input": "2026-06-20T18:43:24.105584Z",
+     "iopub.status.busy": "2026-06-20T18:43:24.105525Z",
+     "iopub.status.idle": "2026-06-20T18:43:27.125140Z",
+     "shell.execute_reply": "2026-06-20T18:43:27.124536Z"
     }
    },
    "outputs": [
@@ -559,7 +562,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Loading weights: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 290/290 [00:00<00:00, 11137.60it/s]"
+      "Loading weights: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 290/290 [00:00<00:00, 9976.28it/s]"
      ]
     }
    ],
@@ -603,10 +606,10 @@
    "id": "ec5ea299",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T02:09:40.825666Z",
-     "iopub.status.busy": "2026-06-20T02:09:40.825338Z",
-     "iopub.status.idle": "2026-06-20T02:09:40.934154Z",
-     "shell.execute_reply": "2026-06-20T02:09:40.933703Z"
+     "iopub.execute_input": "2026-06-20T18:43:27.126879Z",
+     "iopub.status.busy": "2026-06-20T18:43:27.126531Z",
+     "iopub.status.idle": "2026-06-20T18:43:27.235307Z",
+     "shell.execute_reply": "2026-06-20T18:43:27.234852Z"
     }
    },
    "outputs": [],
@@ -645,6 +648,8 @@
     "\n",
     "Training runs over a *pool* of worlds, not one. Each round samples a spread from the pool \u2014 a **mix floor** always keeps an easy one in \u2014 trains a GRPO pass, then evolves the worlds the model learns most from into harder admitted children, keeping the parents. The pool is the curriculum, and it sharpens as the model improves.\n",
     "\n",
+    "Every evolved world is gated by the **consequence verifier** (`consequence_gate`): the reference breach must still leak the flag \u2014 and a benign request must not \u2014 or the candidate is rejected. So the curriculum can harden without ever shipping a world the agent (or the grader) can't actually solve. This is *self-verifying generation*: the verifier, not the generator, decides what counts as a real world. (It checks under the cheap PROCESS backing \u2014 faithful to CONTAINER, since the reference breach grades identically on both.)\n",
+    "\n",
     "`run_pool_curriculum` drives the loop; `make_grpo_rounds` returns the `(train_round, eval_round)` pair. `eval_round` scores a **fenced held-out** pool under a frozen update \u2014 no learning \u2014 so the train-vs-held-out gap measures generalization, not memorization. One real round:"
    ]
   },
@@ -654,10 +659,10 @@
    "id": "9277400c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T02:09:40.935265Z",
-     "iopub.status.busy": "2026-06-20T02:09:40.935205Z",
-     "iopub.status.idle": "2026-06-20T02:10:16.469262Z",
-     "shell.execute_reply": "2026-06-20T02:10:16.468719Z"
+     "iopub.execute_input": "2026-06-20T18:43:27.236425Z",
+     "iopub.status.busy": "2026-06-20T18:43:27.236364Z",
+     "iopub.status.idle": "2026-06-20T18:44:18.549098Z",
+     "shell.execute_reply": "2026-06-20T18:44:18.548541Z"
     }
    },
    "outputs": [
@@ -665,16 +670,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '0.0001', 'num_tokens': '1038', 'completions/mean_length': '177', 'completions/min_length': '98', 'completions/max_length': '256', 'completions/clipped_ratio': '0.5', 'completions/mean_terminated_length': '98', 'completions/min_terminated_length': '98', 'completions/max_terminated_length': '98', 'tools/call_frequency': '0.5', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.3333', 'rewards/reward_func/std': '0', 'reward': '0.3333', 'reward_std': '0', 'frac_reward_zero_std': '1', 'entropy': '4.339', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '16.27', 'epoch': '0.5'}\n",
-      "{'train_runtime': '16.42', 'train_samples_per_second': '0.122', 'train_steps_per_second': '0.061', 'train_loss': '0', 'epoch': '0.5'}\n"
+      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '0.0001', 'num_tokens': '1298', 'completions/mean_length': '212', 'completions/min_length': '168', 'completions/max_length': '256', 'completions/clipped_ratio': '0.5', 'completions/mean_terminated_length': '168', 'completions/min_terminated_length': '168', 'completions/max_terminated_length': '168', 'tools/call_frequency': '0.5', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.3333', 'rewards/reward_func/std': '0', 'reward': '0.3333', 'reward_std': '0', 'frac_reward_zero_std': '1', 'entropy': '4.208', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '19.68', 'epoch': '0.5'}\n",
+      "{'train_runtime': '19.86', 'train_samples_per_second': '0.101', 'train_steps_per_second': '0.05', 'train_loss': '0', 'epoch': '0.5'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '0', 'num_tokens': '1059', 'completions/mean_length': '187.5', 'completions/min_length': '119', 'completions/max_length': '256', 'completions/clipped_ratio': '0.5', 'completions/mean_terminated_length': '119', 'completions/min_terminated_length': '119', 'completions/max_terminated_length': '119', 'tools/call_frequency': '0.5', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.3333', 'rewards/reward_func/std': '0', 'reward': '0.3333', 'reward_std': '0', 'frac_reward_zero_std': '1', 'entropy': '6.357', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '15.57', 'epoch': '0.25'}\n",
-      "{'train_runtime': '15.74', 'train_samples_per_second': '0.127', 'train_steps_per_second': '0.064', 'train_loss': '0', 'epoch': '0.25'}\n"
+      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '0', 'num_tokens': '1198', 'completions/mean_length': '162', 'completions/min_length': '68', 'completions/max_length': '256', 'completions/clipped_ratio': '0.5', 'completions/mean_terminated_length': '68', 'completions/min_terminated_length': '68', 'completions/max_terminated_length': '68', 'tools/call_frequency': '0.5', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.3333', 'rewards/reward_func/std': '0', 'reward': '0.3333', 'reward_std': '0', 'frac_reward_zero_std': '1', 'entropy': '6.963', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '15.23', 'epoch': '0.25'}\n",
+      "{'train_runtime': '15.39', 'train_samples_per_second': '0.13', 'train_steps_per_second': '0.065', 'train_loss': '0', 'epoch': '0.25'}\n"
      ]
     },
     {
@@ -687,8 +692,10 @@
    ],
    "source": [
     "from cyber_webapp.difficulty import world_difficulty\n",
+    "from cyber_webapp.verify import accepts\n",
     "from openrange_trl import make_grpo_rounds\n",
     "\n",
+    "from openrange.core import consequence_gate\n",
     "from openrange.pool import EvalPool, WorldPool, run_pool_curriculum\n",
     "\n",
     "\n",
@@ -727,6 +734,14 @@
     "    backing=BACKING,\n",
     "    sandbox=True,\n",
     ")\n",
+    "verify_gate = consequence_gate(pack, \"or-runs/cyber/gate\", accepts)\n",
+    "\n",
+    "\n",
+    "def verified_pentest(snap, mut):\n",
+    "    # keep a pentest-family child only if its reference breach still leaks\n",
+    "    return mut.family == \"webapp.pentest\" and verify_gate(snap, mut)\n",
+    "\n",
+    "\n",
     "metrics = run_pool_curriculum(\n",
     "    pool,\n",
     "    train_round,\n",
@@ -734,7 +749,7 @@
     "    pack=pack,\n",
     "    groups=1,\n",
     "    num_generations=num_generations,\n",
-    "    gate=lambda _snap, mut: mut.family == \"webapp.pentest\",\n",
+    "    gate=verified_pentest,\n",
     "    eval_pool=held_out,\n",
     "    eval_round=eval_round,\n",
     ")\n",
@@ -752,7 +767,7 @@
    "source": [
     "The round trained, but the 0.5B can't pivot \u2014 its train and held-out **solve-rates are both 0.000** (no rollout submitted the right flag). Every rollout earns the same **free `0.333`** reward the storefront answers before the agent acts (just `reached_endpoint`), so with zero reward spread GRPO has no gradient. A real climb needs a bigger model on a GPU; on a laptop we script the agent's performance with the \u00a75 reference breach to watch the **loop** itself.\n",
     "\n",
-    "The pool *follows performance*. Run the **same three seeds twice** \u2014 once with a solving agent, once with a stuck one. Solving **hardens** the frontier; getting stuck **softens** it. (The default policy decides direction from the round's solve-rate; the gate just keeps children on the pentest family.)"
+    "The pool *follows performance*. Run the **same three seeds twice** \u2014 once with a solving agent, once with a stuck one. Solving **hardens** the frontier; getting stuck **softens** it. The default policy decides the *direction* from the round's solve-rate, and the same `consequence_gate` from \u00a79 keeps every child breach-verified \u2014 a softened world still has to leak the flag, or it's rejected."
    ]
   },
   {
@@ -761,10 +776,10 @@
    "id": "1ee78765",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T02:10:16.471049Z",
-     "iopub.status.busy": "2026-06-20T02:10:16.470951Z",
-     "iopub.status.idle": "2026-06-20T02:11:52.680404Z",
-     "shell.execute_reply": "2026-06-20T02:11:52.679813Z"
+     "iopub.execute_input": "2026-06-20T18:44:18.550638Z",
+     "iopub.status.busy": "2026-06-20T18:44:18.550556Z",
+     "iopub.status.idle": "2026-06-20T18:46:03.536142Z",
+     "shell.execute_reply": "2026-06-20T18:46:03.535605Z"
     }
    },
    "outputs": [
@@ -779,7 +794,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "agent stuck  : seeded [9.7, 10.0, 10.3]  ->  [1.3, 9.7, 10.0, 10.3]\n"
+      "agent stuck  : seeded [9.7, 10.0, 10.3]  ->  [9.4, 9.7, 9.7, 10.0, 10.3]\n"
      ]
     }
    ],
@@ -831,7 +846,7 @@
     "        pack=pack,\n",
     "        groups=len(p),\n",
     "        num_generations=1,\n",
-    "        gate=lambda _snap, mut: mut.family == \"webapp.pentest\",\n",
+    "        gate=verified_pentest,\n",
     "    )\n",
     "    runs[label] = p\n",
     "    print(f\"agent {label:6} : seeded {seeded}  ->  {diff_band(p)}\")\n",
@@ -846,7 +861,7 @@
    "source": [
     "## 10. The pool tracks the agent\n",
     "\n",
-    "Same seeds, opposite outcomes: under a solving agent the band extended **up** (a harder child each round); under a stuck one a **softer** world joined it \u2014 the curriculum follows performance, it doesn't just ratchet harder. Each evolved world is an **admission-checked** child that records its parent *and* its direction (`auto_evolve` re-admits it, so a harder child is still provably solvable \u2014 and a softer one too), while the easy seeds stay in under the mix floor. Here's the solving run's lineage:"
+    "Same seeds, opposite outcomes: under a solving agent the band extended **up** (a harder child each round); under a stuck one a **softer** world joined it \u2014 the curriculum follows performance, it doesn't just ratchet harder. Each evolved world is a **breach-verified** child that records its parent *and* its direction: `auto_evolve` re-admits it and the consequence gate confirms the reference breach still leaks, so a harder child is provably solvable \u2014 and a softer one too. The easy seeds stay in under the mix floor. Here's the solving run's lineage:"
    ]
   },
   {
@@ -855,10 +870,10 @@
    "id": "0e168699",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T02:11:52.682206Z",
-     "iopub.status.busy": "2026-06-20T02:11:52.682098Z",
-     "iopub.status.idle": "2026-06-20T02:11:52.684355Z",
-     "shell.execute_reply": "2026-06-20T02:11:52.684030Z"
+     "iopub.execute_input": "2026-06-20T18:46:03.537869Z",
+     "iopub.status.busy": "2026-06-20T18:46:03.537777Z",
+     "iopub.status.idle": "2026-06-20T18:46:03.540129Z",
+     "shell.execute_reply": "2026-06-20T18:46:03.539807Z"
     }
    },
    "outputs": [
@@ -905,10 +920,10 @@
    "id": "5646d2d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T02:11:52.685301Z",
-     "iopub.status.busy": "2026-06-20T02:11:52.685236Z",
-     "iopub.status.idle": "2026-06-20T02:11:52.687602Z",
-     "shell.execute_reply": "2026-06-20T02:11:52.687290Z"
+     "iopub.execute_input": "2026-06-20T18:46:03.541095Z",
+     "iopub.status.busy": "2026-06-20T18:46:03.541035Z",
+     "iopub.status.idle": "2026-06-20T18:46:03.543262Z",
+     "shell.execute_reply": "2026-06-20T18:46:03.542999Z"
     }
    },
    "outputs": [

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -761,6 +761,58 @@ def test_consequence_gate_rejects_an_unsolvable_world(tmp_path: Path) -> None:
         svc.close()
 
 
+def test_pool_curriculum_only_evolves_breach_verified_worlds(tmp_path: Path) -> None:
+    # Brick 1 -- self-verifying by default: with the consequence gate wired into the
+    # curriculum, every world the pool evolves into must still leak via the reference
+    # breach, so training never inherits a world that hardened its way to unsolvable.
+    pack = WebappPack()
+    seeds = [{**_COMPANY_MANIFEST, "seed": s} for s in range(3)]
+    pool = WorldPool.seed(
+        pack,
+        seeds,
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=8,
+    )
+    seed_ids = {m.snapshot.snapshot_id for m in pool._members.values()}
+    round_no = [0]
+
+    def run_round(
+        rows: list[dict[str, object]], snapshots: list[Snapshot]
+    ) -> dict[tuple[str, str], list[EpisodeReport]]:
+        round_no[0] += 1
+        return _solve_round(pack, tmp_path / f"r{round_no[0]}", rows, snapshots)
+
+    verify = consequence_gate(pack, tmp_path / "gate", accepts)
+    run_pool_curriculum(
+        pool,
+        run_round,
+        rounds=2,
+        pack=pack,
+        groups=3,
+        num_generations=2,
+        gate=lambda snap, mut: _pentest_only(snap, mut) and verify(snap, mut),
+    )
+
+    final_ids = {m.snapshot.snapshot_id for m in pool._members.values()}
+    assert final_ids - seed_ids, "the gate rejected every evolution; nothing to verify"
+
+    svc = EpisodeService(pack, tmp_path / "check")
+    try:
+        for member in pool._members.values():
+            task = next(
+                t
+                for t in member.snapshot.tasks
+                if t.meta.get("family") == "webapp.pentest"
+            )
+            handle = svc.start_episode(member.snapshot, task.id)
+            verified = accepts(member.snapshot, svc.base_url(handle))
+            svc.stop_episode(handle)
+            assert verified, f"unverified world in pool: {member.snapshot.snapshot_id}"
+    finally:
+        svc.close()
+
+
 def test_unique_vuln_invariant_flags_a_duplicate() -> None:
     graph = _admit(_LATERAL_MANIFEST).graph
     assert unique_vuln_per_endpoint(graph) == []


### PR DESCRIPTION
## What

Makes the cyber curriculum **self-verifying by default**: wire `consequence_gate` into the training/evolve loop so every evolved world must still leak via the reference breach (and a benign request must not), or it is rejected. Until now the loop gated only on the mutation's *family* — a structural check — so a "harden" that broke solvability, or an over-softened world, could enter training.

## Why

This is "the verifier is the ceiling" thesis as the system's actual default behavior, and it closes the world-generation audit's open gap: *the consequence-verifier was not run on evolve re-admit*. Builds on #324 (now merged) — the loop re-realizes worlds every evolve step.

## Changes

- The notebook's GRPO loop and the adaptive-direction demo compose `consequence_gate(pack, …, accepts)` into the pool gate (a shared `verified_pentest`). It verifies under the cheap PROCESS backing — faithful to CONTAINER, since the reference breach grades identically on both, so there is no per-candidate container cost.
- Pool-level test `test_pool_curriculum_only_evolves_breach_verified_worlds`: `run_pool_curriculum` with the gate evolves the pool **and** every resulting member is breach-verified (mirrors the existing real-`run_round` tests — no mocks).

## Live evidence (full notebook re-run on real Docker)

- 0 errors, all cells populated, 0 warnings.
- §9-adaptive **stuck** run now softens to breach-verified worlds (`[9.4, 9.7, 9.7, 10.0, 10.3]`) instead of the degenerate `1.3` the family-only gate let through — the verifier shaping the soften, live.
- §9 GRPO and §10 lineage unchanged.

Next on the path: this is the foundation; #261 → #317 (LLM synthesizes novel-shape worlds and proves them) extend the same gate seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
