### PR TITLE
cyber: exclude internal-only chain kinds from curriculum mutation

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/mutation.py
+++ b/packs/cyber_webapp/cyber_webapp/mutation.py
@@ -9,6 +9,7 @@ from graphschema import Edge, GraphPatch, Node, Visibility, WorldGraph
 from openrange_pack_sdk import EpisodeReportLike, Mutation, Snapshot
 
 from cyber_webapp.ontology import ONTOLOGY_ID
+from cyber_webapp.sampling import _INTERNAL_ONLY_KINDS
 from cyber_webapp.vulnerabilities import CATALOG as VULN_CATALOG
 
 # Keep the import alive even though only the validator reads ONTOLOGY_ID.
@@ -32,9 +33,9 @@ _APPEND_HOP_RELEVANCE = 0.9
 
 _GATE_PATH = "/internal/vault"
 _TOKEN_PARAMS: tuple[str, ...] = ("token", "api_key", "auth", "session", "key")
-# Structural recon owned by the recon_disclosure knob (graph-derived params):
-# evolution must neither drop it (soften/diversify) nor add a generic one (harden).
-_RECON_KIND = "config_disclosure"
+# Internal-only kinds are graph-synthesized (the credential-reuse chain) or owned
+# by the recon_disclosure knob: a soften/diversify/harden move on one is always
+# rejected by admission, so exclude them up front instead of wasting the budget.
 
 
 def coerce_string_list(value: object) -> list[str]:
@@ -66,7 +67,7 @@ def available_mutations(
     )
 
     for kind, node_ids in vulns_by_kind.items():
-        if kind == _RECON_KIND:
+        if kind in _INTERNAL_ONLY_KINDS:
             continue
         score = _exploitation_score(node_ids, paths_per_vuln, path_hits)
         relevance = max(score, _REMOVE_RELEVANCE_FLOOR)
@@ -115,7 +116,7 @@ def _harden_add_absent_mutations(
 
     mutations: list[Mutation] = []
     for kind in sorted(VULN_CATALOG):
-        if kind in vulns_by_kind or kind == _RECON_KIND:
+        if kind in vulns_by_kind or kind in _INTERNAL_ONLY_KINDS:
             continue
         catalog_entry = VULN_CATALOG[kind]
         target_kinds = catalog_entry.target_kinds
@@ -210,7 +211,7 @@ def _diversify_swap_kind_mutations(
     existing_kinds_by_target = _existing_kinds_by_target(graph)
     mutations: list[Mutation] = []
     for kind in sorted(vulns_by_kind):
-        if kind == _RECON_KIND:
+        if kind in _INTERNAL_ONLY_KINDS:
             continue
         node_ids = sorted(vulns_by_kind[kind])
         if not node_ids:
@@ -606,7 +607,7 @@ def _pick_alt_kind(
 ) -> str | None:
     target_node_kind = target.kind
     for alt in sorted(VULN_CATALOG):
-        if alt == current_kind:
+        if alt == current_kind or alt in _INTERNAL_ONLY_KINDS:
             continue
         if (alt, target.id) in existing_kinds_by_target:
             continue

--- a/tests/test_cyber_auto_curriculum.py
+++ b/tests/test_cyber_auto_curriculum.py
@@ -15,10 +15,10 @@ from typing import Any
 
 from cyber_webapp import WebappPack, WebappPentest
 from cyber_webapp.mutation import (
-    _RECON_KIND,
     _oracle_path_targets,
     available_mutations,
 )
+from cyber_webapp.sampling import _INTERNAL_ONLY_KINDS
 from cyber_webapp.vulnerabilities import CATALOG as VULN_CATALOG
 from graphschema import GraphPatch, WorldGraph, apply_patch
 from openrange_pack_sdk import EpisodeReportLike, Mutation, Snapshot
@@ -115,9 +115,10 @@ def test_available_mutations_covers_every_catalog_kind() -> None:
     """Across the option list, every mutation-introducible catalog kind shows up.
 
     A `harden` proposes an absent kind, `soften`/`diversify` operate on present
-    kinds; together they exhaust the catalog except `config_disclosure`, which the
-    sampler plants from the world's own internal estate (graph-derived params the
-    recon_disclosure knob owns), so the operators never introduce a generic one.
+    kinds; together they exhaust the catalog except the internal-only kinds, which
+    the sampler plants from the world's own internal estate (the recon knob's
+    graph-derived params and the synthesized credential-reuse chain), so the
+    operators never introduce or drop one.
     """
     snap = _build_snapshot()
     options = available_mutations(snap.graph, "webapp.pentest", ())
@@ -135,7 +136,7 @@ def test_available_mutations_covers_every_catalog_kind() -> None:
         for kind in VULN_CATALOG:
             if kind in opt.note:
                 kinds_seen.add(kind)
-    assert (set(VULN_CATALOG) - {_RECON_KIND}).issubset(kinds_seen)
+    assert (set(VULN_CATALOG) - _INTERNAL_ONLY_KINDS).issubset(kinds_seen)
 
 
 def test_directions_produce_different_patch_shapes() -> None:

--- a/tests/test_cyber_recon.py
+++ b/tests/test_cyber_recon.py
@@ -182,6 +182,38 @@ def test_evolution_does_not_re_add_recon_to_a_blind_world() -> None:
     assert "config_disclosure" not in added
 
 
+def test_evolution_leaves_the_credential_chain_intact_but_still_deepens_it() -> None:
+    # Internal-only kinds (recon + the synthesized credential-reuse chain) must never
+    # be dropped, swapped, or added as a decoy -- only the append-hop may extend the
+    # chain. Without this, admission rejects the move after the fact, wasting budget.
+    internal_only = {
+        "config_disclosure",
+        "metadata_credential_leak",
+        "credential_leak",
+        "credential_gated_relay",
+        "credential_gated_flag",
+    }
+    chain_kinds = {"credential_leak", "credential_gated_relay", "credential_gated_flag"}
+    graph = _admit({**_COMPANY, "lateral_movement": True}).graph
+    moves = available_mutations(graph, "webapp.pentest", [])
+
+    for move in moves:
+        if move.direction in ("soften", "diversify"):
+            assert not any(ck in move.note for ck in chain_kinds), move.note
+
+    appended = False
+    for move in moves:
+        if move.direction != "harden":
+            continue
+        if move.note.startswith("append a credential hop"):
+            appended = True
+            continue
+        for node in move.patch.nodes_added:
+            if node.kind == "vulnerability":
+                assert node.attrs.get("kind") not in internal_only, move.note
+    assert appended  # the legitimate chain-deepening frontier move is still offered
+
+
 @pytest.mark.parametrize("seed", [1, 2, 3, 5, 7])
 def test_a_blind_world_always_names_the_flag_host_in_the_ssrf_pool(seed: int) -> None:
     graph = _admit({**_NONE, "seed": seed}).graph


### PR DESCRIPTION
## What

Curriculum mutation (`available_mutations`) only skipped the recon kind (`config_disclosure`) when proposing soften/diversify/harden moves. So on a credential-reuse chain world it offered moves that **drop, swap, or add** the synthesized chain kinds (`credential_leak` / `credential_gated_relay` / `credential_gated_flag`) and `metadata_credential_leak`. Every such move is rejected by `credential_reuse_binding` at admission — wasted evolution budget (a live probe showed ~7 of ~19 moves on a seed-3 lateral world were dead).

## Change

- `mutation.py`: import the shared `_INTERNAL_ONLY_KINDS` set (from `sampling.py`) and drive all three kind-selection loops (soften, harden-add-absent, diversify) plus the diversify swap-*target* (`_pick_alt_kind`) off it. This **subsumes** the old `_RECON_KIND` guard (config_disclosure is in the set) and adds the chain + metadata exclusion — one source of truth, no third copy. Removed the now-dead `_RECON_KIND` constant.
- The legitimate chain-deepening move (`_harden_append_hop_mutation`, "append a credential hop") is deliberately untouched and still offered.
- Tests: new `test_evolution_leaves_the_credential_chain_intact_but_still_deepens_it` (independent oracle — hardcodes the excluded set) asserting no soften/diversify/harden-decoy touches an internal-only kind while the append-hop stays; updated `test_available_mutations_covers_every_catalog_kind` to the broader exclusion.

## Verification

- Full cyber suite: **501 passed, 5 skipped** (stable order).
- Adversarial workflow audit: clean (`confirmed: 0`). Verified the four generators are exhaustive (no bypass path; the LLM enrich path cannot invent patches), the append-hop survives on all 22 lateral configs, `_pick_alt_kind` exclusion suppresses nothing legitimate (internal-only kinds have empty default params, never valid swap targets), no import cycle, ruff clean. The audit reverted the guard and confirmed the new test fails with the exact `remove credential_leak` leak, then restored.

First of a stacked series toward making the credential-reuse chain first-class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
