### PR TITLE
cyber: make the credential-reuse chain the notebook's flagship

### DIFF
--- a/examples/trl_grpo_cyber.ipynb
+++ b/examples/trl_grpo_cyber.ipynb
@@ -10,10 +10,11 @@
     "OpenRange admits **content-addressed, evolving** agent-training worlds. This notebook\n",
     "trains a small model on the *cyber* pack's flagship: a **believable company** — a public\n",
     "storefront in a dmz, plus internal APIs and databases on a segmented network. The flag is\n",
-    "a production-style credential **confined to an internal service**, with no front door. To\n",
-    "get it, the agent must **recon the estate, find a foothold (an SSRF on the storefront),\n",
-    "and pivot dmz→internal** over the network — graded by the world itself, no static dataset\n",
-    "of \"correct\" attacks.\n",
+    "a production-style credential **confined to the deepest internal service**, with no\n",
+    "front door. To get it, the agent must **recon the estate, get a foothold (an SSRF on the\n",
+    "storefront), then loot a credential and replay it hop-by-hop through gated internal\n",
+    "services** — a *credential-reuse chain* — graded by the world itself, no static dataset of\n",
+    "\"correct\" attacks.\n",
     "\n",
     "It runs on **real Docker**: each rollout boots **one container per service** on a real\n",
     "segmented network, and the agent gets its **own** hardened container with a shell — it\n",
@@ -45,7 +46,7 @@
    "source": [
     "## 2. Admit the company world\n",
     "\n",
-    "`company: True` builds a segmented 6–8-service estate instead of a single service — deterministic and LLM-free, so this snapshot is byte-identical on every machine. We also pick the backing: real Docker if it's running, else the in-process emulation."
+    "`company: True` builds a segmented 6–8-service estate instead of a single service — deterministic and LLM-free, so this snapshot is byte-identical on every machine. `lateral_movement: True` then puts the flag behind a **credential-reuse chain** — loot a token from one internal service, replay it to reach the next. We also pick the backing: real Docker if it's running, else the in-process emulation."
    ]
   },
   {
@@ -54,10 +55,10 @@
    "id": "3900e6b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-21T00:57:11.713677Z",
-     "iopub.status.busy": "2026-06-21T00:57:11.713491Z",
-     "iopub.status.idle": "2026-06-21T00:57:12.062322Z",
-     "shell.execute_reply": "2026-06-21T00:57:12.061958Z"
+     "iopub.execute_input": "2026-06-21T08:35:05.975015Z",
+     "iopub.status.busy": "2026-06-21T08:35:05.974823Z",
+     "iopub.status.idle": "2026-06-21T08:35:06.383240Z",
+     "shell.execute_reply": "2026-06-21T08:35:06.382803Z"
     }
    },
    "outputs": [
@@ -65,7 +66,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "world 9eb5218387c6   backing=CONTAINER\n"
+      "world bf6a2e8c09bf   backing=CONTAINER\n"
      ]
     }
    ],
@@ -96,6 +97,7 @@
     "        \"npc\": [],\n",
     "        \"seed\": 3,\n",
     "        \"company\": True,\n",
+    "        \"lateral_movement\": True,\n",
     "    },\n",
     "    max_repairs=3,\n",
     ")\n",
@@ -125,7 +127,7 @@
    "source": [
     "## 3. The estate\n",
     "\n",
-    "Print the world's layout — just the graph, nothing running yet. One public **storefront** sits in the `dmz`; the other services (databases, internal APIs) are on an isolated **internal** network. The flag is a credential on one of those internal databases — so the storefront is the only way in, and the dmz→internal **pivot** is mandatory."
+    "Print the world's layout — just the graph, nothing running yet. One public **storefront** sits in the `dmz`; the other services (internal APIs and databases) are on an isolated **internal** network. The flag sits at the end of a **credential-reuse chain**: the storefront SSRF is the only way in, and from there each internal hop hands over a credential that unlocks the next — until the last one yields the flag. No single bug reaches it."
    ]
   },
   {
@@ -134,10 +136,10 @@
    "id": "0bf8859e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-21T00:57:12.063829Z",
-     "iopub.status.busy": "2026-06-21T00:57:12.063681Z",
-     "iopub.status.idle": "2026-06-21T00:57:12.066807Z",
-     "shell.execute_reply": "2026-06-21T00:57:12.066475Z"
+     "iopub.execute_input": "2026-06-21T08:35:06.384866Z",
+     "iopub.status.busy": "2026-06-21T08:35:06.384709Z",
+     "iopub.status.idle": "2026-06-21T08:35:06.388337Z",
+     "shell.execute_reply": "2026-06-21T08:35:06.387963Z"
     }
    },
    "outputs": [
@@ -145,19 +147,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "8 services across networks ['dmz', 'internal']\n",
+      "8 services; the flag sits behind a 4-hop chain\n",
       "\n",
-      "  orders-db        internal  internal   <- holds the flag\n",
-      "  orders-api       internal  internal \n",
-      "  users-db         internal  internal \n",
-      "  billing-db       internal  internal \n",
-      "  catalog-api      internal  internal \n",
-      "  payments-api     internal  internal \n",
-      "  ledger-db        internal  internal \n",
-      "  storefront       public    dmz        <- public entry (the only way in)\n",
-      "\n",
-      "flag: a hidden credential on 'orders-db' (internal) — reachable only by\n",
-      "pivoting from 'storefront' via the SSRF on its endpoint.\n"
+      "  storefront     public    foothold: an SSRF on its endpoint\n",
+      "  catalog-api    internal  loot the first token\n",
+      "  orders-api     internal  replay it -> the next token\n",
+      "  payments-api   internal  replay it -> the next token\n",
+      "  orders-db      internal  replay it -> the flag\n"
      ]
     }
    ],
@@ -165,28 +161,42 @@
     "g = snapshot.graph\n",
     "services = list(g.by_kind(\"service\"))\n",
     "public = next(s for s in services if s.attrs.get(\"exposure\") == \"public\")\n",
-    "ssrf = next(v for v in g.by_kind(\"vulnerability\") if v.attrs.get(\"kind\") == \"ssrf\")\n",
-    "flag_host = ssrf.attrs[\"params\"][\"internal_host\"]\n",
     "\n",
     "\n",
-    "def network_of(svc):\n",
-    "    edge = next(e for e in g.out_edges(svc.id, \"connected_to\"))\n",
-    "    return g.nodes[edge.dst].attrs[\"name\"]\n",
+    "def host_of(vuln):\n",
+    "    ep = next((g.nodes[e.dst] for e in g.out_edges(vuln.id, \"affects\")), None)\n",
+    "    if ep is None:\n",
+    "        return \"?\"\n",
+    "    svc = next((g.nodes[e.src] for e in g.in_edges(ep.id, \"exposes\")), None)\n",
+    "    return svc.attrs[\"name\"] if svc else \"?\"\n",
     "\n",
     "\n",
-    "nets = sorted({network_of(s) for s in services})\n",
-    "print(f\"{len(services)} services across networks {nets}\\n\")\n",
-    "for s in sorted(services, key=lambda s: s.attrs.get(\"exposure\")):\n",
-    "    tag = \"\"\n",
-    "    if s.attrs.get(\"exposure\") == \"public\":\n",
-    "        tag = \"  <- public entry (the only way in)\"\n",
-    "    elif s.attrs[\"name\"] == flag_host:\n",
-    "        tag = \"  <- holds the flag\"\n",
-    "    print(\n",
-    "        f\"  {s.attrs['name']:<16} {s.attrs.get('exposure'):<9} {network_of(s):<9}{tag}\"\n",
-    "    )\n",
-    "print(f\"\\nflag: a hidden credential on '{flag_host}' (internal) — reachable only by\")\n",
-    "print(f\"pivoting from '{public.attrs['name']}' via the SSRF on its endpoint.\")"
+    "vulns = list(g.by_kind(\"vulnerability\"))\n",
+    "req_ep = {e.dst: e.src for e in g.edges.values() if e.kind == \"requires_credential\"}\n",
+    "vuln_of_ep = {\n",
+    "    next((e.dst for e in g.out_edges(v.id, \"affects\")), None): v for v in vulns\n",
+    "}\n",
+    "\n",
+    "# Walk leak -> relay(s) -> gated flag, following each produced token to the hop\n",
+    "# that requires it next.\n",
+    "leak = next(v for v in vulns if v.attrs.get(\"kind\") == \"credential_leak\")\n",
+    "chain, cur = [(leak, \"loot the first token\")], leak\n",
+    "while True:\n",
+    "    cred = next((e.dst for e in g.out_edges(cur.id, \"produces\")), None)\n",
+    "    nxt = vuln_of_ep.get(req_ep.get(cred)) if cred else None\n",
+    "    if nxt is None:\n",
+    "        break\n",
+    "    last = nxt.attrs.get(\"kind\") == \"credential_gated_flag\"\n",
+    "    step = \"replay it -> the flag\" if last else \"replay it -> the next token\"\n",
+    "    chain.append((nxt, step))\n",
+    "    if last:\n",
+    "        break\n",
+    "    cur = nxt\n",
+    "\n",
+    "print(f\"{len(services)} services; the flag sits behind a {len(chain)}-hop chain\\n\")\n",
+    "print(f\"  {public.attrs['name']:<14} public    foothold: an SSRF on its endpoint\")\n",
+    "for vuln, step in chain:\n",
+    "    print(f\"  {host_of(vuln):<14} internal  {step}\")"
    ]
   },
   {
@@ -207,10 +217,10 @@
    "id": "eda_provenance_code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-21T00:57:12.067791Z",
-     "iopub.status.busy": "2026-06-21T00:57:12.067735Z",
-     "iopub.status.idle": "2026-06-21T00:58:04.357885Z",
-     "shell.execute_reply": "2026-06-21T00:58:04.356771Z"
+     "iopub.execute_input": "2026-06-21T08:35:06.389345Z",
+     "iopub.status.busy": "2026-06-21T08:35:06.389283Z",
+     "iopub.status.idle": "2026-06-21T08:35:19.561181Z",
+     "shell.execute_reply": "2026-06-21T08:35:19.560560Z"
     }
    },
    "outputs": [
@@ -219,14 +229,14 @@
      "output_type": "stream",
      "text": [
       "same seed -> same id: True\n",
-      "seed 3: {'id': '9eb5218387c6', 'nets': ['dmz', 'internal'], 'services': 8, 'vulns': ['config_disclosure', 'metadata_credential_leak', 'ssrf', 'xxe', 'xxe'], 'flag': 'ghp_sC3VUX9I53YY', 'llm_handlers': 0}\n"
+      "seed 3: {'id': 'bf6a2e8c09bf', 'nets': ['dmz', 'internal'], 'services': 8, 'vulns': ['config_disclosure', 'credential_gated_flag', 'credential_gated_relay', 'credential_gated_relay', 'credential_leak', 'ssrf', 'xxe', 'xxe'], 'flag': 'ghp_sC3VUX9I53YY', 'llm_handlers': 0}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "seed 4: {'id': 'c0a6db8c86a0', 'nets': ['dmz', 'internal'], 'services': 7, 'vulns': ['config_disclosure', 'metadata_credential_leak', 'path_traversal', 'ssrf', 'xxe'], 'flag': '29a0a9a4d296e948', 'llm_handlers': 0}\n"
+      "seed 4: {'id': 'f28be3f2e24a', 'nets': ['dmz', 'internal'], 'services': 7, 'vulns': ['config_disclosure', 'credential_gated_flag', 'credential_gated_relay', 'credential_gated_relay', 'credential_leak', 'path_traversal', 'ssrf', 'xxe'], 'flag': '29a0a9a4d296e948', 'llm_handlers': 0}\n"
      ]
     },
     {
@@ -243,21 +253,27 @@
      "output_type": "stream",
      "text": [
       "def handle(query, state):\n",
-      "    key = state['schema']['key_column']\n",
+      "    import json\n",
+      "    db = state['db']\n",
+      "    key_column = state['schema']['key_column']\n",
       "    terms = query.get('term') or ['']\n",
       "    term = terms[0]\n",
-      "    db = state['db']\n",
-      "    sql = \"SELECT {key}, secret FROM records WHERE {key} = {term}\".format(\n",
-      "        key=key, term=term)\n",
-      "    rows = []\n",
+      "    # Vulnerable on purpose (training gym): the term is concatenated straight\n",
+      "    # into the WHERE clause in an unquoted context, with no parameterization,\n",
+      "    # so a payload like  0 UNION SELECT key, secret FROM records --  surfaces\n",
+      "    # every row including the secret flag.\n",
+      "    sql = (\n",
+      "        \"SELECT \" + key_column + \" AS key, secret FROM records WHERE \"\n",
+      "        + key_column + \" = \" + term\n",
+      "    )\n",
       "    try:\n",
-      "        cursor = db.execute(sql)\n",
-      "        for row in cursor:\n",
-      "            rows.append({col: row[col] for col in row.keys()})\n",
+      "        cur = db.execute(sql)\n",
+      "        rows = [dict(r) for r in cur.fetchall()]\n",
       "    except Exception as exc:\n",
       "        body = json.dumps({\"error\": str(exc)}).encode(\"utf-8\")\n",
       "        return 400, {\"Content-Type\": \"application/json\"}, body\n",
-      "    body = json.dumps({\"results\": rows}).encode(\"utf-8\")\n",
+      "    results = [{\"key\": r[\"key\"], \"secret\": r[\"secret\"]} for r in rows]\n",
+      "    body = json.dumps({\"results\": results}).encode(\"utf-8\")\n",
       "    return 200, {\"Content-Type\": \"application/json\"}, body\n"
      ]
     }
@@ -273,6 +289,7 @@
     "    \"runtime\": {\"tick\": {\"mode\": \"off\"}},\n",
     "    \"npc\": [],\n",
     "    \"company\": True,\n",
+    "    \"lateral_movement\": True,\n",
     "}\n",
     "\n",
     "\n",
@@ -327,10 +344,10 @@
    "id": "99a66a7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-21T00:58:04.361331Z",
-     "iopub.status.busy": "2026-06-21T00:58:04.361155Z",
-     "iopub.status.idle": "2026-06-21T00:58:22.892943Z",
-     "shell.execute_reply": "2026-06-21T00:58:22.892085Z"
+     "iopub.execute_input": "2026-06-21T08:35:19.563580Z",
+     "iopub.status.busy": "2026-06-21T08:35:19.563422Z",
+     "iopub.status.idle": "2026-06-21T08:35:32.160621Z",
+     "shell.execute_reply": "2026-06-21T08:35:32.159422Z"
     }
    },
    "outputs": [
@@ -425,7 +442,7 @@
    "source": [
     "## 5. See the reward before you train\n",
     "\n",
-    "The reward grades the **HTTP path** against three subgoals: reach the entry, extract *something*, submit the *right* flag. Driving the agent's shell (`curl`) by hand maps three behaviors onto it (no model, no GPU — but a Docker engine, since the agent acts from its own sandbox). The richest is the **full breach**: reach the storefront, **SSRF-pivot into the internal service, and exfiltrate the credential** — every coordinate read from the world graph (no hardcoded secrets) via the pack's reference solver, run as the agent's own `curl`."
+    "The reward grades the **HTTP path** against three subgoals: reach the entry, extract *something*, submit the *right* flag. Driving the agent's shell (`curl`) by hand maps three behaviors onto it (no model, no GPU — but a Docker engine, since the agent acts from its own sandbox). The richest is the **full breach**: reach the storefront, get the SSRF foothold, then **walk the credential-reuse chain** — loot a token, replay it to the next hop, repeat — and exfiltrate the final credential, every coordinate read from the world graph (no hardcoded secrets) via the pack's reference solver, run as the agent's own `curl`."
    ]
   },
   {
@@ -434,10 +451,10 @@
    "id": "93f9fe0f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-21T00:58:22.896710Z",
-     "iopub.status.busy": "2026-06-21T00:58:22.896502Z",
-     "iopub.status.idle": "2026-06-21T00:58:38.855472Z",
-     "shell.execute_reply": "2026-06-21T00:58:38.854367Z"
+     "iopub.execute_input": "2026-06-21T08:35:32.163141Z",
+     "iopub.status.busy": "2026-06-21T08:35:32.162908Z",
+     "iopub.status.idle": "2026-06-21T08:35:55.305655Z",
+     "shell.execute_reply": "2026-06-21T08:35:55.304172Z"
     }
    },
    "outputs": [
@@ -459,7 +476,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "recon + pivot + breach     reward=1.000  resolved=True\n"
+      "recon + chain + breach     reward=1.000  resolved=True\n"
      ]
     }
    ],
@@ -551,7 +568,7 @@
     "    \"reach + wrong flag\",\n",
     "    lambda e: (e.shell(curl(entry)), e.submit(json.dumps({\"flag\": \"guess\"}))),\n",
     ")\n",
-    "grade(\"recon + pivot + breach\", lambda e: breach(e, snapshot))"
+    "grade(\"recon + chain + breach\", lambda e: breach(e, snapshot))"
    ]
   },
   {
@@ -565,11 +582,11 @@
     "|------|--------|-----|\n",
     "| reach the storefront | **0.333** | `reached_endpoint` only |\n",
     "| reach + wrong flag | **0.667** | `+ extracted_anything`, but wrong |\n",
-    "| recon + pivot + breach | **1.0** | breached: pivoted dmz→internal, exfiltrated the credential |\n",
+    "| recon + chain + breach | **1.0** | breached: walked the credential-reuse chain, exfiltrated the final credential |\n",
     "\n",
     "That `0.333 → 1.0` spread is what GRPO turns into a gradient. `matched_flag == success` — the\n",
-    "agent has to actually **submit the right credential**, which it can only get by pivoting,\n",
-    "not by poking the storefront. (This surface is asserted in `tests/test_cyber_company.py`.)"
+    "agent has to actually **submit the right credential**, which it can only get by walking\n",
+    "the chain, not by poking the storefront. (This surface is asserted in `tests/test_cyber_company.py`.)"
    ]
   },
   {
@@ -596,10 +613,10 @@
    "id": "972058b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-21T00:58:38.857996Z",
-     "iopub.status.busy": "2026-06-21T00:58:38.857838Z",
-     "iopub.status.idle": "2026-06-21T00:58:40.007126Z",
-     "shell.execute_reply": "2026-06-21T00:58:40.006676Z"
+     "iopub.execute_input": "2026-06-21T08:35:55.309150Z",
+     "iopub.status.busy": "2026-06-21T08:35:55.308952Z",
+     "iopub.status.idle": "2026-06-21T08:35:56.711594Z",
+     "shell.execute_reply": "2026-06-21T08:35:56.711170Z"
     }
    },
    "outputs": [],
@@ -646,10 +663,10 @@
    "id": "a754841e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-21T00:58:40.008171Z",
-     "iopub.status.busy": "2026-06-21T00:58:40.008113Z",
-     "iopub.status.idle": "2026-06-21T00:58:43.074123Z",
-     "shell.execute_reply": "2026-06-21T00:58:43.073678Z"
+     "iopub.execute_input": "2026-06-21T08:35:56.713747Z",
+     "iopub.status.busy": "2026-06-21T08:35:56.713658Z",
+     "iopub.status.idle": "2026-06-21T08:35:59.730030Z",
+     "shell.execute_reply": "2026-06-21T08:35:59.729506Z"
     }
    },
    "outputs": [
@@ -673,7 +690,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Loading weights: 100%|██████████| 290/290 [00:00<00:00, 10281.81it/s]"
+      "Loading weights: 100%|██████████| 290/290 [00:00<00:00, 8572.77it/s]"
      ]
     },
     {
@@ -724,10 +741,10 @@
    "id": "ec5ea299",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-21T00:58:43.075998Z",
-     "iopub.status.busy": "2026-06-21T00:58:43.075636Z",
-     "iopub.status.idle": "2026-06-21T00:58:43.187686Z",
-     "shell.execute_reply": "2026-06-21T00:58:43.187220Z"
+     "iopub.execute_input": "2026-06-21T08:35:59.731817Z",
+     "iopub.status.busy": "2026-06-21T08:35:59.731537Z",
+     "iopub.status.idle": "2026-06-21T08:35:59.847424Z",
+     "shell.execute_reply": "2026-06-21T08:35:59.847063Z"
     }
    },
    "outputs": [],
@@ -777,10 +794,10 @@
    "id": "9277400c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-21T00:58:43.188836Z",
-     "iopub.status.busy": "2026-06-21T00:58:43.188777Z",
-     "iopub.status.idle": "2026-06-21T00:59:32.321060Z",
-     "shell.execute_reply": "2026-06-21T00:59:32.320677Z"
+     "iopub.execute_input": "2026-06-21T08:35:59.848668Z",
+     "iopub.status.busy": "2026-06-21T08:35:59.848615Z",
+     "iopub.status.idle": "2026-06-21T08:36:54.269262Z",
+     "shell.execute_reply": "2026-06-21T08:36:54.268839Z"
     }
    },
    "outputs": [
@@ -788,16 +805,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '0.0001', 'num_tokens': '1298', 'completions/mean_length': '212', 'completions/min_length': '168', 'completions/max_length': '256', 'completions/clipped_ratio': '0.5', 'completions/mean_terminated_length': '168', 'completions/min_terminated_length': '168', 'completions/max_terminated_length': '168', 'tools/call_frequency': '0.5', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.3333', 'rewards/reward_func/std': '0', 'reward': '0.3333', 'reward_std': '0', 'frac_reward_zero_std': '1', 'entropy': '4.208', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '19.11', 'epoch': '0.5'}\n",
-      "{'train_runtime': '19.28', 'train_samples_per_second': '0.104', 'train_steps_per_second': '0.052', 'train_loss': '0', 'epoch': '0.5'}\n"
+      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '0.0001', 'num_tokens': '1185', 'completions/mean_length': '155.5', 'completions/min_length': '55', 'completions/max_length': '256', 'completions/clipped_ratio': '0.5', 'completions/mean_terminated_length': '55', 'completions/min_terminated_length': '55', 'completions/max_terminated_length': '55', 'tools/call_frequency': '0.5', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.3333', 'rewards/reward_func/std': '0', 'reward': '0.3333', 'reward_std': '0', 'frac_reward_zero_std': '1', 'entropy': '4.656', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '19.97', 'epoch': '0.5'}\n",
+      "{'train_runtime': '20.16', 'train_samples_per_second': '0.099', 'train_steps_per_second': '0.05', 'train_loss': '0', 'epoch': '0.5'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '0', 'num_tokens': '1198', 'completions/mean_length': '162', 'completions/min_length': '68', 'completions/max_length': '256', 'completions/clipped_ratio': '0.5', 'completions/mean_terminated_length': '68', 'completions/min_terminated_length': '68', 'completions/max_terminated_length': '68', 'tools/call_frequency': '0.5', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.3333', 'rewards/reward_func/std': '0', 'reward': '0.3333', 'reward_std': '0', 'frac_reward_zero_std': '1', 'entropy': '6.667', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '14.01', 'epoch': '0.25'}\n",
-      "{'train_runtime': '14.19', 'train_samples_per_second': '0.141', 'train_steps_per_second': '0.07', 'train_loss': '0', 'epoch': '0.25'}\n"
+      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '0', 'num_tokens': '1198', 'completions/mean_length': '162', 'completions/min_length': '68', 'completions/max_length': '256', 'completions/clipped_ratio': '0.5', 'completions/mean_terminated_length': '68', 'completions/min_terminated_length': '68', 'completions/max_terminated_length': '68', 'tools/call_frequency': '0.5', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.3333', 'rewards/reward_func/std': '0', 'reward': '0.3333', 'reward_std': '0', 'frac_reward_zero_std': '1', 'entropy': '6.963', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '18.42', 'epoch': '0.25'}\n",
+      "{'train_runtime': '18.6', 'train_samples_per_second': '0.108', 'train_steps_per_second': '0.054', 'train_loss': '0', 'epoch': '0.25'}\n"
      ]
     },
     {
@@ -825,6 +842,7 @@
     "        \"npc\": [],\n",
     "        \"seed\": seed,\n",
     "        \"company\": True,\n",
+    "        \"lateral_movement\": True,\n",
     "    }\n",
     "\n",
     "\n",
@@ -883,7 +901,7 @@
    "id": "984b4f68",
    "metadata": {},
    "source": [
-    "The round trained, but the 0.5B can't pivot — its train and held-out **solve-rates are both 0.000** (no rollout submitted the right flag). Every rollout earns the same **free `0.333`** reward the storefront answers before the agent acts (just `reached_endpoint`), so with zero reward spread GRPO has no gradient. A real climb needs a bigger model on a GPU; on a laptop we script the agent's performance with the §5 reference breach to watch the **loop** itself.\n",
+    "The round trained, but the 0.5B can't walk the chain — its train and held-out **solve-rates are both 0.000** (no rollout submitted the right flag). Every rollout earns the same **free `0.333`** reward the storefront answers before the agent acts (just `reached_endpoint`), so with zero reward spread GRPO has no gradient. A real climb needs a bigger model on a GPU; on a laptop we script the agent's performance with the §5 reference breach to watch the **loop** itself.\n",
     "\n",
     "The pool *follows performance*. Run the **same three seeds twice** — once with a solving agent, once with a stuck one. Solving **hardens** the frontier; getting stuck **softens** it. The default policy decides the *direction* from the round's solve-rate, and the same `consequence_gate` from §9 keeps every child breach-verified — a softened world still has to leak the flag, or it's rejected."
    ]
@@ -894,10 +912,10 @@
    "id": "1ee78765",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-21T00:59:32.322543Z",
-     "iopub.status.busy": "2026-06-21T00:59:32.322459Z",
-     "iopub.status.idle": "2026-06-21T01:01:10.523843Z",
-     "shell.execute_reply": "2026-06-21T01:01:10.523253Z"
+     "iopub.execute_input": "2026-06-21T08:36:54.271146Z",
+     "iopub.status.busy": "2026-06-21T08:36:54.271050Z",
+     "iopub.status.idle": "2026-06-21T08:38:40.845185Z",
+     "shell.execute_reply": "2026-06-21T08:38:40.844658Z"
     }
    },
    "outputs": [
@@ -905,14 +923,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "agent solves : seeded [9.7, 10.0, 10.3]  ->  [9.7, 10.0, 10.3, 10.6]\n"
+      "agent solves : seeded [20.0, 33.7, 34.3]  ->  [20.0, 33.7, 34.3, 47.7]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "agent stuck  : seeded [9.7, 10.0, 10.3]  ->  [9.4, 9.7, 9.7, 10.0, 10.3]\n"
+      "agent stuck  : seeded [20.0, 33.7, 34.3]  ->  [20.0, 33.4, 33.7, 34.3]\n"
      ]
     }
    ],
@@ -988,10 +1006,10 @@
    "id": "0e168699",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-21T01:01:10.525572Z",
-     "iopub.status.busy": "2026-06-21T01:01:10.525481Z",
-     "iopub.status.idle": "2026-06-21T01:01:10.527732Z",
-     "shell.execute_reply": "2026-06-21T01:01:10.527441Z"
+     "iopub.execute_input": "2026-06-21T08:38:40.846915Z",
+     "iopub.status.busy": "2026-06-21T08:38:40.846832Z",
+     "iopub.status.idle": "2026-06-21T08:38:40.849334Z",
+     "shell.execute_reply": "2026-06-21T08:38:40.848991Z"
     }
    },
    "outputs": [
@@ -999,10 +1017,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2919c80c8eaf  difficulty=9.7 seed    parent=root\n",
-      "c22493366fa7  difficulty=10.0 seed    parent=root\n",
-      "7b30f94fcfe5  difficulty=10.3 seed    parent=root\n",
-      "9c58b496c0b0  difficulty=10.6 harden  parent=7b30f94fcfe5\n"
+      "cd59d8316ba6  difficulty=20.0 seed    parent=root\n",
+      "3353103c5711  difficulty=33.7 seed    parent=root\n",
+      "8d2d6768942e  difficulty=34.3 seed    parent=root\n",
+      "c2af58b1e870  difficulty=47.7 harden  parent=3353103c5711\n"
      ]
     }
    ],
@@ -1038,10 +1056,10 @@
    "id": "5646d2d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-21T01:01:10.528645Z",
-     "iopub.status.busy": "2026-06-21T01:01:10.528580Z",
-     "iopub.status.idle": "2026-06-21T01:01:10.531109Z",
-     "shell.execute_reply": "2026-06-21T01:01:10.530771Z"
+     "iopub.execute_input": "2026-06-21T08:38:40.850272Z",
+     "iopub.status.busy": "2026-06-21T08:38:40.850222Z",
+     "iopub.status.idle": "2026-06-21T08:38:40.852770Z",
+     "shell.execute_reply": "2026-06-21T08:38:40.852469Z"
     }
    },
    "outputs": [

--- a/examples/trl_grpo_cyber.ipynb
+++ b/examples/trl_grpo_cyber.ipynb
@@ -654,7 +654,7 @@
     "\n",
     "LoRA on a small instruct model — the base stays frozen (fits a laptop), GRPO updates only\n",
     "the low-rank adapters. Bump `model_name` to a larger instruct model for rollouts strong\n",
-    "enough to actually land the pivot."
+    "enough to actually walk the chain."
    ]
   },
   {
@@ -730,7 +730,7 @@
     "\n",
     "`num_generations` completions of the same prompt, each against its own freshly booted\n",
     "company. `beta=0` drops the reference model; `use_vllm=False` generates through\n",
-    "transformers; `max_tool_calling_iterations` is raised to **8** because recon → pivot →\n",
+    "transformers; `max_tool_calling_iterations` is raised to **8** because recon → walk the chain →\n",
     "submit is several turns, not the one-shot of a single-service bug. `max_steps=1` makes one\n",
     "call here **one training round** — §9 wraps rounds into the curriculum."
    ]
@@ -997,7 +997,7 @@
    "source": [
     "## 10. The pool tracks the agent\n",
     "\n",
-    "Same seeds, opposite outcomes: under a solving agent the band extended **up** (a harder child each round); under a stuck one a **softer** world joined it — the curriculum follows performance, it doesn't just ratchet harder. Each evolved world is a **breach-verified** child that records its parent *and* its direction: `auto_evolve` re-admits it and the consequence gate confirms the reference breach still leaks, so a harder child is provably solvable — and a softer one too. The easy seeds stay in under the mix floor. Here's the solving run's lineage:"
+    "Same seeds, opposite outcomes: under a solving agent the band extended **up** (a harder, breach-verified child appeared); under a stuck one a **softer** world joined it — the curriculum follows performance, it doesn't just ratchet harder. Each evolved world is a **breach-verified** child that records its parent *and* its direction: `auto_evolve` re-admits it and the consequence gate confirms the reference breach still leaks, so a harder child is provably solvable — and a softer one too. The easy seeds stay in under the mix floor. Here's the solving run's lineage:"
    ]
   },
   {
@@ -1047,7 +1047,7 @@
     "surface (it composes `curl` itself). Here's the company breached by a\n",
     "[Strands](https://strandsagents.com) agent against any OpenAI-compatible endpoint:\n",
     "`pip install strands-agents openai`, set `OPENAI_BASE_URL` (and optionally `OPENAI_MODEL`),\n",
-    "and a capable model lands the pivot in a handful of calls."
+    "and a capable model walks the credential-reuse chain in a handful of calls."
    ]
   },
   {
@@ -1119,8 +1119,9 @@
    "source": [
     "## Where this goes\n",
     "\n",
-    "You watched an agent breach a **real, multi-service company** — recon the estate, pivot\n",
-    "dmz→internal over the network, exfiltrate a confined credential — and the gym **harden** in\n",
+    "You watched an agent breach a **real, multi-service company** — recon the estate, get an SSRF foothold on the\n",
+    "storefront, then loot a credential and replay it hop-by-hop through the gated internal\n",
+    "services to exfiltrate the confined flag — a credential-reuse chain — and the gym **harden** in\n",
     "response. Two things take it past a laptop:\n",
     "\n",
     "- **A real climb.** Swap the reference breach for `make_grpo_run_round` + a larger instruct\n",
@@ -1130,7 +1131,7 @@
     "  serially, so a pooled / fast world realization is the gym-side lever that keeps a big batch\n",
     "  from stalling on container boots (#294).\n",
     "\n",
-    "Honest scope: a laptop-scale model doesn't complete the pivot — the reward surface and the\n",
+    "Honest scope: a laptop-scale model can't walk the credential-reuse chain — the reward surface and the\n",
     "breach are real and proven (§5), but mastery needs GPU-scale compute. The deterministic\n",
     "world + reward tests live in `packs/cyber_webapp` + `tests/test_cyber_company.py`."
    ]


### PR DESCRIPTION
## What

The credential-reuse chain (`lateral_movement: True`) was fully built, admission-verified (`credential_reuse_binding`), solved (`_walk_credential_chain`), and gate-graded — but **invisible**: the training notebook only ever admitted `company: True` (the single SSRF→internal pivot, difficulty 10). No trainer or reader knew the chain existed.

This flips the notebook's flagship to the chain so it's the world the tutorial **shows and trains on**.

## Change (`examples/trl_grpo_cyber.ipynb`)

- §2 admits with `lateral_movement: True`; §4's determinism demo uses the same flagship (seed-3 id `bf6a2e8c09bf` matches §2).
- §3 now **walks and prints the chain**: storefront (SSRF foothold) → catalog-api (loot the first token) → orders-api → payments-api (replay it → the next token) → orders-db (replay it → the flag).
- §9 / §10 pools train and evolve on chain worlds (the `company(seed)` helper carries `lateral_movement`).
- Prose across the intro, §2, §3, §5, §10 names the credential-reuse chain instead of the bare dmz→internal pivot; the §5 breach label is now "recon + chain + breach".

## Verification (end-to-end, the eval loop)

Re-ran the whole notebook on **CONTAINER**, 0 errors:
- §3 prints a 4-hop chain; §5 reward surface holds — `0.333 / 0.667 / 1.000`, breach **resolved=True** (the agent walks the chain over real `curl`).
- §9 GRPO round runs on the chain pool; §10 difficulty bands are now ~20–48, solving hardens (append-hop deepens the chain to 47.7), stuck softens — every evolved child gate-accepted.
- §4 determinism (`llm_handlers: 0`, same seed → same id) and the #317 exploit-author fold still pass.

Stacked on #327 (PR1: chain-kind mutation exclusion — so the chain pool evolves without wasted moves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
