### PR TITLE
cyber: make the credential node the single source of truth for its token

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/__init__.py
@@ -18,6 +18,7 @@ from cyber_webapp.container import minimum_backing
 from cyber_webapp.families import WebappBuild, WebappPentest
 from cyber_webapp.invariants import (
     credential_reuse_binding,
+    credential_value_binding,
     no_orphan_nodes,
     oracle_path_exists,
     secret_must_be_held,
@@ -53,6 +54,7 @@ class WebappPack(Pack):
             oracle_path_exists,
             sqli_targets_db_backed_service,
             credential_reuse_binding,
+            credential_value_binding,
             unique_vuln_per_endpoint,
         ]
 
@@ -105,6 +107,7 @@ __all__ = [
     "WebappRuntimeError",
     "WebappRuntime",
     "credential_reuse_binding",
+    "credential_value_binding",
     "minimum_backing",
     "monotone_chain_gate",
     "no_orphan_nodes",

--- a/packs/cyber_webapp/cyber_webapp/invariants.py
+++ b/packs/cyber_webapp/cyber_webapp/invariants.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from graphschema import Issue, WorldGraph
 
 _ORPHAN_EXEMPT: frozenset[str] = frozenset({"host", "network"})
@@ -175,9 +177,9 @@ def credential_reuse_binding(graph: WorldGraph) -> list[Issue]:
     one strictly-earlier hop on the `enables` chain, and the producing and
     gating vulns must keep their credential-chain kinds.
 
-    Binds by credential-node identity + enable ordering; it does not read
-    `value_ref` or detect cycles (the chain is a DAG by construction), and the
-    handler param-name / response-shape contract stays the verifier's job. The
+    Binds by credential-node identity + enable ordering; value-consistency is
+    `credential_value_binding`'s job and cycle-freedom holds by DAG construction,
+    while the handler param-name / response-shape contract stays the verifier's. The
     kind check is what stops a mutation that rewrites a chain vuln in place from
     leaving the binding structurally intact but the world unsolvable. Endpoints
     without a `requires_credential` edge are untouched.
@@ -267,6 +269,67 @@ def credential_reuse_binding(graph: WorldGraph) -> list[Issue]:
                         endpoint_id,
                     )
                 )
+    return issues
+
+
+def credential_value_binding(graph: WorldGraph) -> list[Issue]:
+    """The credential node is the single source of truth for its token value: the
+    producing hop emits exactly the node's ``value_ref`` and the gating hop validates
+    against exactly that same value. This catches drift between the node and the
+    handler param-string copies -- a mutation or hand-edit that changes one but not
+    the other, leaving the chain structurally bound yet unsolvable. The reference
+    solver stays response-driven; this is the admission backstop that lets the graph
+    node be authoritative.
+    """
+    cred_value = {
+        n.id: str(n.attrs.get("value_ref", "")) for n in graph.by_kind("credential")
+    }
+    vuln = {n.id: n for n in graph.by_kind("vulnerability")}
+    affects: dict[str, list[str]] = {}
+    for edge in graph.edges.values():
+        if edge.kind == "affects":
+            affects.setdefault(edge.dst, []).append(edge.src)
+
+    def _param(vuln_id: str, key: str) -> str | None:
+        node = vuln.get(vuln_id)
+        params = node.attrs.get("params") if node is not None else None
+        if not isinstance(params, Mapping):
+            return None
+        value = params.get(key)
+        return None if value is None else str(value)
+
+    issues: list[Issue] = []
+    for edge in graph.edges.values():
+        if edge.kind == "produces":
+            kind = str(vuln[edge.src].attrs.get("kind", "")) if edge.src in vuln else ""
+            relay = kind == "credential_gated_relay"
+            emitted = _param(edge.src, "next_credential" if relay else "credential")
+            if emitted is not None and emitted != cred_value.get(edge.dst):
+                issues.append(
+                    Issue(
+                        "error",
+                        "credential_value",
+                        f"producer {edge.src!r} emits a token that does not match "
+                        f"credential node {edge.dst!r}'s value_ref",
+                        edge.src,
+                    )
+                )
+        elif edge.kind == "requires_credential":
+            expected = cred_value.get(edge.dst)
+            for gate in affects.get(edge.src, []):
+                if str(vuln[gate].attrs.get("kind", "")) not in _CHAIN_GATE_KINDS:
+                    continue
+                got = _param(gate, "credential")
+                if got is not None and got != expected:
+                    issues.append(
+                        Issue(
+                            "error",
+                            "credential_value",
+                            f"gate {gate!r} validates a token that does not match "
+                            f"credential node {edge.dst!r}'s value_ref",
+                            gate,
+                        )
+                    )
     return issues
 
 

--- a/tests/test_cyber_lateral.py
+++ b/tests/test_cyber_lateral.py
@@ -88,6 +88,32 @@ def test_admission_rejects_a_broken_credential_binding() -> None:
     assert any(i.code == "credential_binding" and i.severity == "error" for i in issues)
 
 
+def test_admission_rejects_a_drifted_credential_value() -> None:
+    # The credential node is the single source of truth: if a gate's param-string
+    # token drifts from the node's value_ref, admission rejects it even though the
+    # structural binding is still intact.
+    import dataclasses
+
+    from cyber_webapp.invariants import credential_value_binding
+    from graphschema import validate
+
+    pack = WebappPack()
+    graph = _admit().graph
+    assert not credential_value_binding(graph)  # a fresh world is value-consistent
+
+    gate = next(
+        n
+        for n in graph.by_kind("vulnerability")
+        if n.attrs.get("kind") in ("credential_gated_relay", "credential_gated_flag")
+    )
+    drifted = {**gate.attrs, "params": {**gate.attrs["params"], "credential": "WRONG"}}
+    graph.nodes[gate.id] = dataclasses.replace(gate, attrs=drifted)
+
+    assert any(i.code == "credential_value" for i in credential_value_binding(graph))
+    issues = validate(graph, pack.ontology(), pack.invariants())
+    assert any(i.code == "credential_value" and i.severity == "error" for i in issues)
+
+
 def test_chain_credentials_are_not_guarded() -> None:
     # PUBLIC credential nodes must NOT join the guarded set — a HIDDEN token would
     # be swept in, and the leak handler serving it would trip the verifier on a


### PR DESCRIPTION
## What

The credential-reuse chain stores each hop's token **three ways**: the credential node's `value_ref`, the producing/gating vuln params (`credential` / `next_credential`), and the handler baked from those params. Nothing checked they agree — so a mutation or hand-edit could drift one copy and leave the chain structurally bound (`credential_reuse_binding` passes) yet **unsolvable**, which the gate would only catch downstream.

## Change

- New admission invariant `credential_value_binding` (`invariants.py`): for each `produces` edge it pins the producer's emitted token (`credential` for `credential_leak`, `next_credential` for `credential_gated_relay`) to the credential node's `value_ref`; for each `requires_credential` edge it pins the gate's validated `credential` to that node's `value_ref`. The **node is now the authoritative source** — any drift between it and a param/handler copy is rejected at admission.
- `credential_reuse_binding` keeps owning structure (identity + enable ordering); the reference solver stays **response-driven** (unchanged — that's what proves the multi-hop pivot).
- Registered in `WebappPack.invariants()`; docstrings updated to reflect the division of labor.

## Deliberately deferred

Physically de-duplicating the param copies (reading the token off the edge / from the node at runtime) would mean rewriting the vuln templates that bake it from params, for marginal gain now that drift can't survive admission. Left as future work; the response-driven solver must stay.

## Verification

- Full cyber suite: **501 passed, 5 skipped**. New test `test_admission_rejects_a_drifted_credential_value` (a fresh world is consistent; a value-drifted gate is rejected by `validate()`).
- Adversarial audit: **clean** — no false positives (lateral seeds 0–49 + plain/company worlds all pass), every drift class fires (leak / relay-producer / gate / node `value_ref`, incl. the relay's dual gate+producer role and deep hops), confirmed wired into `validate()`, graceful on missing params, no double-fire with the structural binding.
- No graph change → world ids unchanged → no notebook re-bake.

Stacked on #329 (PR3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
