### PR TITLE
cyber: re-seed integrity for the credential-reuse chain

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/reseed.py
+++ b/packs/cyber_webapp/cyber_webapp/reseed.py
@@ -1,19 +1,25 @@
-"""Re-roll the flag on an admitted world, changing nothing else.
+"""Re-roll the flag (and, for a chain world, its credentials) on an admitted world,
+changing nothing else.
 
 The flag value lives in exactly two nodes -- the loot record's ``fields.value`` and the
 HIDDEN ``secret_flag``'s ``value_ref`` -- so a copy of the world with both rewritten is
 byte-identical except for the secret. This backs the #317 re-seed integrity check: a
 genuine exploit (one that reads the flag out of the live world) recovers the fresh
-value, while a memorized one (a hard-coded old value) does not. It is a post-build
-transform, so it never changes how worlds are originally generated.
+value, while a memorized one (a hard-coded old value) does not. ``reseed_chain`` extends
+this to the credential-reuse chain, re-rolling the flag and every per-hop token so a
+genuine response-driven breach loots the live values while a memorized walk fails. Both
+are post-build transforms, so they never change how worlds are originally generated.
 """
 
 from __future__ import annotations
 
 import dataclasses
+import random
 
 from graphschema import Edge, Node, WorldGraph
 from openrange_pack_sdk import PackError, Snapshot
+
+from cyber_webapp.sampling import _b62, generate_flag
 
 
 def replant_flag(snapshot: Snapshot, new_value: str) -> Snapshot:
@@ -35,6 +41,59 @@ def replant_flag(snapshot: Snapshot, new_value: str) -> Snapshot:
             and attrs["fields"].get("value") == old_value
         ):
             attrs["fields"] = {**attrs["fields"], "value": new_value}
+        clone.nodes[nid] = Node(
+            id=node.id,
+            kind=node.kind,
+            attrs=attrs,
+            roles=set(node.roles),
+            visibility=node.visibility,
+            runtime=dict(node.runtime),
+            meta=dict(node.meta),
+        )
+    for eid, edge in graph.edges.items():
+        clone.edges[eid] = Edge(
+            id=edge.id,
+            kind=edge.kind,
+            src=edge.src,
+            dst=edge.dst,
+            attrs=dict(edge.attrs),
+        )
+
+    return dataclasses.replace(snapshot, snapshot_id=clone.content_hash(), graph=clone)
+
+
+def reseed_chain(snapshot: Snapshot, rng: random.Random) -> Snapshot:
+    """Return a copy of ``snapshot`` with a fresh flag and fresh chain tokens, otherwise
+    identical (a new ``snapshot_id``). Each value's consistent copies are rewritten
+    together -- the flag's two nodes, and each token's credential node plus the
+    producer/gate params that mirror it (see ``credential_value_binding``) -- so the
+    re-seeded world still admits. A genuine breach loots the live values and recovers
+    the fresh flag; a memorized one does not. Raises if the world has no flag.
+    """
+    graph = snapshot.graph
+    if "secret_flag" not in graph.nodes:
+        raise PackError("world has no flag to reseed")
+    subst: dict[str, str] = {
+        str(graph.nodes["secret_flag"].attrs["value_ref"]): generate_flag(rng)
+    }
+    for node in graph.by_kind("credential"):
+        if node.attrs.get("kind") == "token":
+            subst[str(node.attrs["value_ref"])] = _b62(rng, 24)
+
+    def _sub(value: object) -> object:
+        # Flag/token values only ever live as flat string params/fields, never nested
+        # in a list or dict, so a shallow substitution rewrites every copy.
+        return subst.get(value, value) if isinstance(value, str) else value
+
+    clone = WorldGraph(ontology=graph.ontology, meta=dict(graph.meta))
+    for nid, node in graph.nodes.items():
+        attrs = dict(node.attrs)
+        if "value_ref" in attrs:
+            attrs["value_ref"] = _sub(attrs["value_ref"])
+        if node.kind == "record" and isinstance(attrs.get("fields"), dict):
+            attrs["fields"] = {k: _sub(v) for k, v in attrs["fields"].items()}
+        if node.kind == "vulnerability" and isinstance(attrs.get("params"), dict):
+            attrs["params"] = {k: _sub(v) for k, v in attrs["params"].items()}
         clone.nodes[nid] = Node(
             id=node.id,
             kind=node.kind,

--- a/tests/test_cyber_reseed.py
+++ b/tests/test_cyber_reseed.py
@@ -1,16 +1,22 @@
 """The flag-only re-roll primitive (`replant_flag`) behind the #317 integrity check:
 a world byte-identical except for the secret, so the SAME exploit recovers the fresh
-flag (genuine) while a memorized old value does not."""
+flag (genuine) while a memorized old value does not. `reseed_chain` extends it to the
+credential-reuse chain (flag + every per-hop token), proving the chain is
+memorization-proof: the response-driven breach loots the live values."""
 
 from __future__ import annotations
 
+import random
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 from cyber_webapp import WebappPack
-from cyber_webapp.reference_solver import Request, exploit_and_benign
-from cyber_webapp.reseed import replant_flag
+from cyber_webapp.reference_solver import Request, exploit_and_benign, solve_chain
+from cyber_webapp.reseed import replant_flag, reseed_chain
 from cyber_webapp.verify import perform
-from openrange_pack_sdk import Snapshot
+from graphschema import validate
+from openrange_pack_sdk import Backing, Snapshot
 
 from openrange.core.admit import admit
 from openrange.core.episode import EpisodeService
@@ -24,11 +30,33 @@ _SQLI = {
     "loot_shapes": {"db": 1, "file": 0},
 }
 
+_LATERAL = {
+    "pack": {"id": "webapp"},
+    "runtime": {"tick": {"mode": "off"}},
+    "npc": [],
+    "seed": 3,
+    "lateral_movement": True,
+}
+
 
 def _admit() -> Snapshot:
     snap = admit(WebappPack(), manifest=_SQLI, max_repairs=3)
     assert isinstance(snap, Snapshot), snap
     return snap
+
+
+def _admit_lateral() -> Snapshot:
+    snap = admit(WebappPack(), manifest=_LATERAL, max_repairs=3)
+    assert isinstance(snap, Snapshot), snap
+    return snap
+
+
+def _tokens(snap: Snapshot) -> set[str]:
+    return {
+        str(n.attrs["value_ref"])
+        for n in snap.graph.by_kind("credential")
+        if n.attrs.get("kind") == "token"
+    }
 
 
 def _pentest_task(snap: Snapshot) -> str:
@@ -75,3 +103,47 @@ def test_same_exploit_recovers_the_fresh_flag(tmp_path: Path) -> None:
     # memorized old value would be absent from world B.
     assert old in body_a and fresh not in body_a
     assert fresh in body_b and old not in body_b
+
+
+def test_reseed_chain_refreshes_flag_and_tokens_and_still_admits() -> None:
+    pack = WebappPack()
+    snap = _admit_lateral()
+    old_flag = str(snap.graph.nodes["secret_flag"].attrs["value_ref"])
+    old_tokens = _tokens(snap)
+    assert old_tokens, "a lateral world has per-hop tokens"
+
+    fresh = reseed_chain(snap, random.Random(99))
+
+    assert fresh.snapshot_id != snap.snapshot_id
+    assert fresh.graph.nodes["secret_flag"].attrs["value_ref"] != old_flag
+    assert _tokens(fresh).isdisjoint(old_tokens)  # every token re-rolled
+    # The re-seed rewrote the node value_ref and the param mirrors together, so the
+    # value-consistency invariant still holds and the fresh world admits.
+    assert not validate(fresh.graph, pack.ontology(), pack.invariants())
+
+
+def test_reseeded_chain_loots_live_not_memorized(tmp_path: Path) -> None:
+    pack = WebappPack()
+    snap = _admit_lateral()
+    old_flag = str(snap.graph.nodes["secret_flag"].attrs["value_ref"])
+    fresh = reseed_chain(snap, random.Random(123))
+    fresh_flag = str(fresh.graph.nodes["secret_flag"].attrs["value_ref"])
+    assert fresh_flag != old_flag
+
+    svc = EpisodeService(pack, tmp_path, backing=Backing.PROCESS)
+    try:
+        base = svc.base_url(svc.start_episode(fresh, _pentest_task(fresh)))
+
+        def fetch(path: str) -> str:
+            try:
+                with urllib.request.urlopen(f"{base}{path}", timeout=15) as resp:
+                    return str(resp.read().decode())
+            except urllib.error.HTTPError as exc:
+                return exc.read().decode()
+
+        trace = solve_chain(fresh.graph, fetch)
+    finally:
+        svc.close()
+    # The walk loots the FRESH flag live; a memorized old value never appears.
+    assert fresh_flag in trace.terminal
+    assert old_flag not in trace.terminal


### PR DESCRIPTION
## What

The credential-reuse chain is **response-driven**: each hop's reply hands over the next host and credential, so a solving agent loots the flag and every token **live** from the running world. That makes the chain inherently **memorization-proof** — a key property for training (the model must learn to *loot and pivot*, not memorize a value). But only the flag was re-rollable (`replant_flag`); the per-hop tokens were fixed across re-seeds.

## Change

- `reseed_chain(snapshot, rng)`: re-rolls the flag **and** every chain token, rewriting each value's consistent copies together — the credential node's `value_ref` plus the producer/gate params that mirror it (the exact triple #330's `credential_value_binding` guards) — so the re-seeded world still admits. Structure is otherwise byte-identical; new `snapshot_id`.
- Backs the chain's re-seed integrity: a genuine breach loots the live values and recovers the fresh flag; a memorized walk does not.

## Scope note

The standalone **LLM-authored chain proof** (the chain analog of #317's single-service exploit-author) is **deferred to #261**. Because the chain is response-driven, a single authored payload is thin (the "exploit" is just following the breadcrumb protocol from the entry); independent novel-shape authoring belongs with #261's generation work, not here.

## Verification

- New tests (`tests/test_cyber_reseed.py`): re-seed refreshes the flag + **all** tokens and the world still admits (value-consistency holds); the reference `solve_chain` recovers the **fresh** flag live while the old flag/tokens never appear in any response.
- Full cyber suite: **503 passed, 5 skipped**.
- Adversarial audit: **clean** — 123 reseeds across seeds 0–40 all admit (no `credential_value`/`credential_binding` errors), edges byte-identical (only flag/token values change, no collisions, single-pass), integrity verified live on depth-1/2/3 chains, non-chain + no-flag edge cases sane, no import cycle.
- No graph change at admission → world ids unchanged → no notebook re-bake.

Stacked on #330 (PR4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
