### PR TITLE
cyber: enforce the credential-reuse chain can't be short-circuited

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/__init__.py
@@ -19,6 +19,7 @@ from cyber_webapp.families import WebappBuild, WebappPentest
 from cyber_webapp.invariants import (
     credential_reuse_binding,
     credential_value_binding,
+    flag_confined_to_gate,
     no_orphan_nodes,
     oracle_path_exists,
     secret_must_be_held,
@@ -55,6 +56,7 @@ class WebappPack(Pack):
             sqli_targets_db_backed_service,
             credential_reuse_binding,
             credential_value_binding,
+            flag_confined_to_gate,
             unique_vuln_per_endpoint,
         ]
 
@@ -108,6 +110,7 @@ __all__ = [
     "WebappRuntime",
     "credential_reuse_binding",
     "credential_value_binding",
+    "flag_confined_to_gate",
     "minimum_backing",
     "monotone_chain_gate",
     "no_orphan_nodes",

--- a/packs/cyber_webapp/cyber_webapp/invariants.py
+++ b/packs/cyber_webapp/cyber_webapp/invariants.py
@@ -333,6 +333,46 @@ def credential_value_binding(graph: WorldGraph) -> list[Issue]:
     return issues
 
 
+def _contains_value(obj: object, needle: str) -> bool:
+    if isinstance(obj, str):
+        return needle in obj
+    if isinstance(obj, Mapping):
+        return any(_contains_value(v, needle) for v in obj.values())
+    if isinstance(obj, (list, tuple, set)):
+        return any(_contains_value(v, needle) for v in obj)
+    return False
+
+
+def flag_confined_to_gate(graph: WorldGraph) -> list[Issue]:
+    """In a credential-reuse chain the flag is served only by the terminal gate out of
+    the HIDDEN ``secret_flag``, so the real value must appear nowhere else: the loot
+    record holds a decoy and no PUBLIC node or vuln param carries it. Otherwise a single
+    response-leak on an earlier hop would short-circuit the whole chain. Chain-only --
+    a single-service world legitimately keeps the flag in its loot record.
+    """
+    if not any(
+        v.attrs.get("kind") == "credential_gated_flag"
+        for v in graph.by_kind("vulnerability")
+    ):
+        return []
+    if "secret_flag" not in graph.nodes:
+        return []  # presence is secret_must_be_held's job
+    flag = str(graph.nodes["secret_flag"].attrs.get("value_ref", ""))
+    if not flag:
+        return []
+    return [
+        Issue(
+            "error",
+            "flag_short_circuit",
+            f"node {nid!r} ({node.kind}) exposes the real flag value outside the "
+            f"gated secret -- the chain could be short-circuited",
+            nid,
+        )
+        for nid, node in graph.nodes.items()
+        if nid != "secret_flag" and _contains_value(node.attrs, flag)
+    ]
+
+
 def sqli_targets_db_backed_service(graph: WorldGraph) -> list[Issue]:
     """SQL-injection vulns must target endpoints of services with a
     `backed_by` data_store edge (else the handler queries nothing)."""

--- a/tests/test_cyber_lateral.py
+++ b/tests/test_cyber_lateral.py
@@ -114,6 +114,32 @@ def test_admission_rejects_a_drifted_credential_value() -> None:
     assert any(i.code == "credential_value" and i.severity == "error" for i in issues)
 
 
+def test_admission_rejects_a_short_circuitable_chain() -> None:
+    # The flag must live only in the gated HIDDEN secret; planting the real value in a
+    # reachable node (here the loot record) would let one response-leak skip the chain.
+    import dataclasses
+
+    from cyber_webapp.invariants import flag_confined_to_gate
+    from graphschema import validate
+
+    pack = WebappPack()
+    graph = _admit().graph
+    assert not flag_confined_to_gate(graph)  # a fresh chain confines the flag
+
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    record = next(
+        graph.nodes[e.src]
+        for e in graph.edges.values()
+        if e.kind == "holds" and e.dst == "secret_flag"
+    )
+    leaky = {**record.attrs, "fields": {**record.attrs["fields"], "value": flag}}
+    graph.nodes[record.id] = dataclasses.replace(record, attrs=leaky)
+
+    assert any(i.code == "flag_short_circuit" for i in flag_confined_to_gate(graph))
+    issues = validate(graph, pack.ontology(), pack.invariants())
+    assert any(i.code == "flag_short_circuit" and i.severity == "error" for i in issues)
+
+
 def test_chain_credentials_are_not_guarded() -> None:
     # PUBLIC credential nodes must NOT join the guarded set — a HIDDEN token would
     # be swept in, and the leak handler serving it would trip the verifier on a


### PR DESCRIPTION
## What

A chain world is only a real multi-hop puzzle if the flag is reachable **only** through the final gate. In a credential-reuse chain the flag is served by the terminal `credential_gated_flag` out of the HIDDEN `secret_flag`; the loot record holds a *decoy*. Nothing enforced that the real value lives nowhere else — so a build/mutation that planted the real flag in a reachable node would let a single response-leak **short-circuit** the entire chain (a trivially-solvable world that still passes the structural binding and the consequence gate's single benign probe).

## Change

- New chain-only admission invariant `flag_confined_to_gate` (`invariants.py`): on any world with a `credential_gated_flag`, the real flag value must appear **only** in `secret_flag` — never in a record field, a vuln param, or a PUBLIC node attr. Uses a recursive containment check (catches the value even embedded in a larger string).
- Single-service worlds, which legitimately keep the flag in their loot record, are explicitly out of scope.
- Registered in `WebappPack.invariants()`.

## Verification

- New test `test_admission_rejects_a_short_circuitable_chain`: a fresh chain confines the flag; planting the real value in the loot record is rejected by `validate()`.
- Teeth-checked across placement classes — the flag planted in a vuln param and embedded in a PUBLIC service attr are both caught; a single-service world (flag in record) is correctly **not** flagged.
- Full cyber suite: **517 passed, 5 skipped**.
- No graph change at admission → world ids unchanged → no notebook re-bake.

Static counterpart to #332's empirical sweep. Stacked on #332 (PR6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
