### PR TITLE
cyber: persist world_difficulty onto the snapshot lineage

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/builder.py
+++ b/packs/cyber_webapp/cyber_webapp/builder.py
@@ -14,6 +14,7 @@ from openrange_pack_sdk import (
     TaskSpec,
 )
 
+from cyber_webapp.difficulty import world_difficulty
 from cyber_webapp.families import WebappBuild, WebappPentest
 from cyber_webapp.priors import default_prior
 from cyber_webapp.sampling import sample_graph
@@ -37,6 +38,9 @@ class WebappBuilder(ProceduralBuilder):
                 "seed": self.current_seed,
                 "prior_source": prior.source,
                 "manifest_keys": sorted(manifest.keys()),
+                # The #322 solve-path-cost metric, recorded so the pool / dashboard /
+                # lineage can read a world's difficulty without re-deriving it.
+                "world_difficulty": float(world_difficulty(graph)),
             },
         )
 

--- a/tests/test_cyber_webapp_v2.py
+++ b/tests/test_cyber_webapp_v2.py
@@ -537,8 +537,9 @@ def test_real_webapp_pack_seed_yields_distinct_worlds() -> None:
 
 def test_real_webapp_pack_lineage_carries_pack_provenance() -> None:
     """The Snapshot's lineage captures pack id, version, attempt count,
-    and the builder's admission_meta (seed, prior source, etc.)."""
+    and the builder's admission_meta (seed, prior source, world difficulty)."""
     from cyber_webapp import WebappPack
+    from cyber_webapp.difficulty import world_difficulty
 
     snap = admit(WebappPack(), manifest={"seed": 0})
     assert isinstance(snap, Snapshot)
@@ -547,6 +548,8 @@ def test_real_webapp_pack_lineage_carries_pack_provenance() -> None:
     assert snap.lineage["builder"] == "cyber.webapp.v2"
     assert snap.lineage["seed"] == 0
     assert "prior_source" in snap.lineage
+    # the #322 solve-path-cost metric is persisted, queryable without recompute
+    assert snap.lineage["world_difficulty"] == float(world_difficulty(snap.graph))
 
 
 def test_real_webapp_pack_history_records_all_phases() -> None:


### PR DESCRIPTION
## What

The #322 solve-path-cost metric (`world_difficulty`) was only ever computed on demand — the pool's `difficulty_fn` re-derives it every call, and the snapshot recorded nothing. So a dashboard, lineage view, or analysis pass had no difficulty to read without re-running the metric (the "difficulty absent from cyber lineage" gap noted in the world-generation audit + deferred from #322).

## Change

- The cyber builder stamps `world_difficulty(graph)` into its `admission_meta`, which core spreads into `Snapshot.lineage`. Every admitted world now records its difficulty, queryable without recompute.
- Lineage is **not** part of the content hash, so world ids are unchanged (seed-3 lateral stays `6fb3314383c4`) — no notebook re-bake.
- The notebook's §10 already exercises the metric on lateral seeds (difficulty ~20–48) since the flagship flip in #328, so the "exercise on lateral seeds" half of this work is already shipped.

## Verification

- `lineage["world_difficulty"]` equals `world_difficulty(graph)` across company / lateral / single-service worlds (48.0 / 34.9 / 10.0); ids verified stable.
- New assertion in the lineage-provenance test; full cyber suite **517 passed, 5 skipped**.

Stacked on #333 (PR7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
