### PR TITLE
cyber: protect the networked foothold from curriculum evolution

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/__init__.py
@@ -34,6 +34,7 @@ from cyber_webapp.realize import (
     WebappRuntime,
     WebappRuntimeError,
 )
+from cyber_webapp.sampling import _is_networked
 
 
 class WebappPack(Pack):
@@ -78,24 +79,6 @@ class WebappPack(Pack):
 
     def task_families(self) -> list[TaskFamily]:
         return [WebappBuild(), WebappPentest()]
-
-
-def _is_networked(graph: WorldGraph) -> bool:
-    # Networked = the flag is reachable only by pivoting: an SSRF on a PUBLIC service
-    # reaches an internal service that holds the flag. A vuln co-located with the flag
-    # on one service is not networked — it stays single-container.
-    public_services = {
-        n.id for n in graph.by_kind("service") if n.attrs.get("exposure") == "public"
-    }
-    service_of_endpoint = {
-        e.dst: e.src for e in graph.edges.values() if e.kind == "exposes"
-    }
-    return any(
-        service_of_endpoint.get(edge.dst) in public_services
-        for vuln in graph.by_kind("vulnerability")
-        if vuln.attrs.get("kind") == "ssrf"
-        for edge in graph.out_edges(vuln.id, "affects")
-    )
 
 
 __all__ = [

--- a/packs/cyber_webapp/cyber_webapp/mutation.py
+++ b/packs/cyber_webapp/cyber_webapp/mutation.py
@@ -9,7 +9,7 @@ from graphschema import Edge, GraphPatch, Node, Visibility, WorldGraph
 from openrange_pack_sdk import EpisodeReportLike, Mutation, Snapshot
 
 from cyber_webapp.ontology import ONTOLOGY_ID
-from cyber_webapp.sampling import _INTERNAL_ONLY_KINDS
+from cyber_webapp.sampling import _INTERNAL_ONLY_KINDS, _is_networked
 from cyber_webapp.vulnerabilities import CATALOG as VULN_CATALOG
 
 # Keep the import alive even though only the validator reads ONTOLOGY_ID.
@@ -36,6 +36,11 @@ _TOKEN_PARAMS: tuple[str, ...] = ("token", "api_key", "auth", "session", "key")
 # Internal-only kinds are graph-synthesized (the credential-reuse chain) or owned
 # by the recon_disclosure knob: a soften/diversify/harden move on one is always
 # rejected by admission, so exclude them up front instead of wasting the budget.
+
+# In a networked world the SSRF is the one public foothold; softening or swapping it
+# away strips the only entry, so the result is unsolvable (rejected at admission). It
+# stays softenable in a single-service world, where it is an ordinary co-located vuln.
+_FOOTHOLD_KIND = "ssrf"
 
 
 def coerce_string_list(value: object) -> list[str]:
@@ -66,8 +71,11 @@ def available_mutations(
         _harden_add_absent_mutations(graph, family_id, vulns_by_kind),
     )
 
+    protected = _INTERNAL_ONLY_KINDS | (
+        {_FOOTHOLD_KIND} if _is_networked(graph) else frozenset()
+    )
     for kind, node_ids in vulns_by_kind.items():
-        if kind in _INTERNAL_ONLY_KINDS:
+        if kind in protected:
             continue
         score = _exploitation_score(node_ids, paths_per_vuln, path_hits)
         relevance = max(score, _REMOVE_RELEVANCE_FLOOR)
@@ -208,10 +216,12 @@ def _diversify_swap_kind_mutations(
     # In-place update — affects edge keeps its id since src/kind/dst are unchanged.
     if not vulns_by_kind:
         return []
+    networked = _is_networked(graph)
+    protected = _INTERNAL_ONLY_KINDS | ({_FOOTHOLD_KIND} if networked else frozenset())
     existing_kinds_by_target = _existing_kinds_by_target(graph)
     mutations: list[Mutation] = []
     for kind in sorted(vulns_by_kind):
-        if kind in _INTERNAL_ONLY_KINDS:
+        if kind in protected:
             continue
         node_ids = sorted(vulns_by_kind[kind])
         if not node_ids:
@@ -232,6 +242,8 @@ def _diversify_swap_kind_mutations(
         )
         if alt_kind is None:
             continue
+        if networked and alt_kind == _FOOTHOLD_KIND:
+            continue  # never introduce a second public foothold into a networked world
         alt_entry = VULN_CATALOG[alt_kind]
         updated_node = Node(
             id=vuln_node.id,

--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -275,6 +275,25 @@ _RECON_PATHS: tuple[str, ...] = (
     "/.well-known/app-config",
 )
 
+
+def _is_networked(graph: WorldGraph) -> bool:
+    # Networked = the flag is reachable only by pivoting: an SSRF on a PUBLIC service
+    # reaches an internal service that holds the flag. A vuln co-located with the flag
+    # on one service is not networked -- it stays single-container.
+    public_services = {
+        n.id for n in graph.by_kind("service") if n.attrs.get("exposure") == "public"
+    }
+    service_of_endpoint = {
+        e.dst: e.src for e in graph.edges.values() if e.kind == "exposes"
+    }
+    return any(
+        service_of_endpoint.get(edge.dst) in public_services
+        for vuln in graph.by_kind("vulnerability")
+        if vuln.attrs.get("kind") == "ssrf"
+        for edge in graph.out_edges(vuln.id, "affects")
+    )
+
+
 _COMMAND_INJECTION_BASE: tuple[str, ...] = (
     "ping",
     "nslookup",

--- a/tests/test_cyber_recon.py
+++ b/tests/test_cyber_recon.py
@@ -214,6 +214,18 @@ def test_evolution_leaves_the_credential_chain_intact_but_still_deepens_it() -> 
     assert appended  # the legitimate chain-deepening frontier move is still offered
 
 
+def test_evolution_keeps_the_networked_foothold() -> None:
+    # In a networked world the SSRF is the only public entry; soften/diversify must
+    # neither remove it nor swap it away (that strips the foothold -> unsolvable, which
+    # admission rejects), but the world must still be evolvable by other moves.
+    graph = _admit(_COMPANY).graph
+    moves = available_mutations(graph, "webapp.pentest", [])
+    for move in moves:
+        if move.direction in ("soften", "diversify"):
+            assert "ssrf" not in move.note, move.note  # the foothold is protected
+    assert any(m.direction in ("soften", "diversify") for m in moves)  # not frozen
+
+
 @pytest.mark.parametrize("seed", [1, 2, 3, 5, 7])
 def test_a_blind_world_always_names_the_flag_host_in_the_ssrf_pool(seed: int) -> None:
     graph = _admit({**_NONE, "seed": seed}).graph


### PR DESCRIPTION
## What

Completes the evolution-safety pass started in #327 (PR1). In a networked world (company / chain / any SSRF-pivot) the public **SSRF is the one mandatory foothold**. `soften` offered *"remove ssrf"* and `diversify` offered *"swap ssrf → …"* — both strip the only entry, producing an unsolvable world that admission rejects after the fact (wasted evolution budget, and it must never strip the entry).

## Change

- `mutation.py`: exclude the foothold SSRF from `soften` and `diversify` (both the swap **source** and the swap **target**) when the world is networked. A single-service world, where `ssrf` is an ordinary co-located vuln, is unaffected. `harden` can still add an SSRF decoy, and the world stays evolvable by every other move.
- To reuse the existing networked check without a `mutation` ↔ `__init__` import cycle, `_is_networked` **moves to `sampling.py`** and is re-exported from the package — one definition, no duplicate, every existing importer (verify.py, tests) unchanged.

## Verification

- Live probe: company/lateral worlds drop both ssrf soften/diversify moves (2 → 0) while keeping all three move directions; a minimal single-ssrf networked world stays evolvable (harden adds vulns); non-networked worlds unaffected.
- New test `test_evolution_keeps_the_networked_foothold`: a networked world offers no ssrf soften/diversify yet stays evolvable.
- Full cyber suite: **518 passed, 5 skipped**. The `_is_networked` move is transparent (networked/lateral/verify tests all green).
- No graph change → world ids unchanged → no notebook re-bake.

Stacked on #334 (PR8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
