### PR TITLE
cyber: document the as-built credential-reuse chain + sharpen framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ for task in snapshot.tasks:
     print(task.id, task.instruction)
 ```
 
-The built-in `webapp` pack procedurally samples a multi-service webapp world (graph topology, vulnerabilities, accounts, secrets), AST-splices vulnerability templates into the realized service code, and ships with NPCs that generate background traffic alongside the agent. The pack exposes two `TaskFamily` classes against that same world — `webapp.build` (implement / repair a feature endpoint) and `webapp.pentest` (recover a hidden flag through a vulnerability chain). Task instructions are pure templating over the graph; the pentest family's `available_mutations` is the only path that consults an optional LLM, and only to enrich the parameters of candidate curriculum mutations.
+The built-in `webapp` pack procedurally samples a multi-service webapp world (graph topology, vulnerabilities, secrets), AST-splices vulnerability templates into the realized service code, and ships with NPCs that generate background traffic alongside the agent. The pack exposes two `TaskFamily` classes against that same world — `webapp.build` (implement / repair a feature endpoint) and `webapp.pentest` (recover a hidden flag through a vulnerability chain — its flagship is a multi-hop credential-reuse pivot across a believable company estate). Task instructions are pure templating over the graph; the pentest family's `available_mutations` is the only path that consults an optional LLM, and only to enrich the parameters of candidate curriculum mutations.
 
 ## Run an eval
 

--- a/packs/cyber_webapp/DESIGN.md
+++ b/packs/cyber_webapp/DESIGN.md
@@ -458,6 +458,23 @@ flag lives in the gated secret. That composable hop is the action a search-based
 ([#193](https://github.com/vecna-labs/open-range/issues/193)) composes and scores — the
 substrate for "synthesize, don't hand-shape."
 
+**Every chain is guarded, not just generated** (§8 — the verifier is the ceiling). Three
+admission invariants keep a synthesized chain a genuine multi-hop puzzle:
+`credential_reuse_binding` checks the structure (each gate's credential comes from exactly
+one strictly-earlier hop); `credential_value_binding` makes the credential *node* the single
+source of truth for its token, rejecting any drift between the node and the handler's param
+copy; and `flag_confined_to_gate` rejects any world where the real flag is reachable outside
+the terminal gate, so a single response-leak can never short-circuit the chain. The chain is
+**memorization-proof** by construction — the agent loots each token live from the hop before —
+and `reseed_chain` re-rolls the flag and every token together (kept value-consistent) to
+prove it: a genuine breach recovers the fresh flag, a memorized one fails. Curriculum
+evolution can **deepen** a chain (append a hop) but never strip it — the internal-only chain
+kinds and the public SSRF foothold are excluded from soften/diversify, so no move drops the
+recon, the foothold, or a hop. A believability sweep drives the reference walk over the
+sampled depth spread to confirm every chain is reachable, solvable, benign-safe, and
+un-short-circuitable, and each admitted world records its solve-path-cost difficulty
+([#322](https://github.com/vecna-labs/open-range/issues/322)) on its lineage.
+
 Correctness is as in §2–§3: procedural owns topology, flag placement, and the
 solvable-by-construction chain; feasibility proves reachability across services
 (`_enable_closure`); cross-backing parity stays the load-bearing check. The next stages on

--- a/packs/cyber_webapp/README.md
+++ b/packs/cyber_webapp/README.md
@@ -2,7 +2,7 @@
 
 A procedural multi-service web target with HTTP-shaped vulnerabilities (SQL
 injection, SSRF, broken-authz, …). The builder samples a small webapp —
-services, endpoints, accounts, and a hidden flag tucked behind a vuln chain —
+services, endpoints, and a hidden flag tucked behind a vuln chain —
 and realizes it as a real Flask app the solver hits over HTTP. **One world,
 two roles:** the same app is something to break into (`webapp.pentest`) *and*
 code to write (`webapp.build`).
@@ -13,7 +13,7 @@ entry point.
 ## What the builder built (one world)
 
 - services: `web`, `api`, `auth`, `db`, `db1` + a backing data store
-- 8 HTTP endpoints, 1 account
+- 8 HTTP endpoints
 - vulns: `sql_injection`, `ssrf`
 - a **hidden** admin flag (`secret_flag`, a UUID) stored in the data, reachable
   only by exploiting the vuln chain


### PR DESCRIPTION
## What

The credential-reuse chain's **verification layer** — the admission invariants, re-seed integrity, evolution-safety, and the believability sweep — was built across this series (#327–#335) but undocumented. This closes that gap and sharpens the front-of-funnel framing.

## Change

- `DESIGN.md` §11: one **"Every chain is guarded, not just generated"** paragraph recording the as-built verification — `credential_reuse_binding` (structure), `credential_value_binding` (the node is the token's single source of truth), `flag_confined_to_gate` (no short-circuit), `reseed_chain` (memorization-proof), the soften/diversify exclusions that protect the recon / foothold / hops, the believability sweep, and difficulty-on-lineage.
- Repo `README.md` + pack `README.md`: drop the now-retired **"accounts"** (#298 / #329) from the world-content lists, and name the pentest flagship as a multi-hop credential-reuse pivot across a believable company estate. The NPC *traffic* mentions (a separate, still-present system) are untouched.

Docs only — one paragraph, no sprawl (per the repo's docs golden-path: sharpen and subtract over adding).

Final PR of the credential-reuse series; stacked on #335 (PR9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
