### PR TITLE
feat: OpenAI-compatible + LiteLLM backends (builds on #220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Optional Strands Agents support:
 uv sync --extra strands
 ```
 
+LLM backends live in `openrange.llm`: the CLI `CodexBackend` / `ClaudeBackend`, the
+zero-dep stdlib `OpenAICompatibleBackend` (OpenAI, vLLM, Ollama, llama.cpp, …), and
+`LiteLLMBackend` for any provider LiteLLM reaches. The last needs an extra:
+
+```bash
+uv sync --extra litellm
+```
+
 ## Build a world
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ strands = [
     "strands-agents>=1.38.0",
     "strands-agents-tools>=0.4.1",
 ]
+litellm = [
+    "litellm>=1.55",
+]
 # The HuggingFace TRL GRPO integration is a *separate* optional package,
 # ``packages/openrange-trl`` — OpenRange itself owns no trainer code or deps.
 
@@ -107,6 +110,11 @@ ignore_missing_imports = true
 module = ["trl", "trl.*"]
 ignore_missing_imports = true
 follow_imports = "skip"
+
+# litellm is an optional (``openrange[litellm]``) lazy import in LiteLLMBackend.
+[[tool.mypy.overrides]]
+module = ["litellm", "litellm.*"]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 # Repo root on the path so tests can import the example eval scripts (the

--- a/src/openrange/__init__.py
+++ b/src/openrange/__init__.py
@@ -51,7 +51,12 @@ from openrange.core.episode import (
     TickRequest,
     TickResult,
 )
-from openrange.llm import CodexBackend
+from openrange.llm import (
+    OPENAI_COMPATIBLE_DEFAULT_MODEL,
+    CodexBackend,
+    LiteLLMBackend,
+    OpenAICompatibleBackend,
+)
 from openrange.npc import (
     NPCS,
     NPCRegistry,
@@ -108,12 +113,15 @@ __all__ = [
     "EvalPool",
     "GraphPatch",
     "Issue",
+    "LiteLLMBackend",
     "NPCS",
     "NPCRegistry",
     "Node",
     "NodeKind",
+    "OPENAI_COMPATIBLE_DEFAULT_MODEL",
     "Observation",
     "Ontology",
+    "OpenAICompatibleBackend",
     "OpenRangeRun",
     "PACKS",
     "PackRegistry",

--- a/src/openrange/llm.py
+++ b/src/openrange/llm.py
@@ -1,22 +1,30 @@
-"""CLI LLM backends.
+"""LLM backends.
 
 The ``LLMBackend`` Protocol and ``LLMRequest`` / ``LLMResult`` value types live in
-``openrange_pack_sdk``. This module ships the concrete CLI backends — ``CodexBackend``
-and ``ClaudeBackend`` — plus the impl-specific exceptions they raise.
+``openrange_pack_sdk``. This module ships the concrete backends: the CLI
+``CodexBackend`` / ``ClaudeBackend``, the dependency-free HTTP
+``OpenAICompatibleBackend``, and ``LiteLLMBackend`` for any provider LiteLLM
+reaches — plus the impl-specific exceptions they raise.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import tempfile
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 from openrange_pack_sdk import LLMBackendError, LLMRequest, LLMResult
+
+OPENAI_COMPATIBLE_DEFAULT_MODEL = "gpt-4o-mini"
 
 
 @dataclass(frozen=True, slots=True)
@@ -224,3 +232,247 @@ def _first_json_object(text: str) -> str:
     if start != -1 and end > start:
         return text[start : end + 1]
     return text
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAICompatibleBackend:
+    """Dependency-free HTTP backend for OpenAI Chat Completions-compatible providers.
+
+    Speaks the ``/chat/completions`` shape over stdlib ``urllib`` — OpenAI, vLLM,
+    Ollama, llama.cpp, and the like. ``extra_headers`` are applied last, so a caller
+    can override the default ``Authorization`` bearer for providers using a different
+    auth scheme. The default ``model`` suits OpenAI's API; set it explicitly for local
+    and third-party servers.
+    """
+
+    base_url: str = "https://api.openai.com/v1"
+    model: str = OPENAI_COMPATIBLE_DEFAULT_MODEL
+    api_key: str | None = None
+    api_key_env: str = "OPENAI_API_KEY"
+    timeout: float = 120.0
+    extra_headers: Mapping[str, str] | None = None
+    json_schema_strict: bool = False
+
+    def preflight(self) -> None:
+        """Validate local configuration without making a network call."""
+        if not self.base_url.strip():
+            raise LLMBackendError("OpenAICompatibleBackend requires a base_url")
+        scheme = urlparse(self.base_url).scheme
+        if scheme not in {"http", "https"}:
+            raise LLMBackendError(
+                "OpenAICompatibleBackend base_url must use http or https",
+            )
+        if not self.model.strip():
+            raise LLMBackendError("OpenAICompatibleBackend requires a model")
+        if self.timeout <= 0:
+            raise LLMBackendError("OpenAICompatibleBackend timeout must be positive")
+
+    def complete(self, request: LLMRequest) -> LLMResult:
+        self.preflight()
+        http_request = Request(
+            self._chat_completions_url(),
+            data=json.dumps(self._payload(request)).encode("utf-8"),
+            headers=self._headers(),
+            method="POST",
+        )
+        try:
+            with urlopen(http_request, timeout=self.timeout) as response:
+                raw = response.read().decode("utf-8")
+        except HTTPError as exc:
+            detail = _openai_compatible_error_detail(exc)
+            raise LLMBackendError(
+                f"OpenAI-compatible HTTP {exc.code}: {detail}",
+                returncode=exc.code,
+            ) from exc
+        except TimeoutError as exc:
+            raise _openai_compatible_timeout_error(self.timeout) from exc
+        except URLError as exc:
+            if isinstance(exc.reason, TimeoutError):
+                raise _openai_compatible_timeout_error(self.timeout) from exc
+            raise LLMBackendError(
+                f"OpenAI-compatible request failed: {exc.reason}",
+            ) from exc
+
+        return _openai_compatible_result(raw, request)
+
+    def _chat_completions_url(self) -> str:
+        return f"{self.base_url.rstrip('/')}/chat/completions"
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        api_key = (
+            self.api_key if self.api_key is not None else os.getenv(self.api_key_env)
+        )
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        if self.extra_headers is not None:
+            headers.update(self.extra_headers)
+        return headers
+
+    def _payload(self, request: LLMRequest) -> dict[str, object]:
+        messages: list[dict[str, str]] = []
+        if request.system is not None:
+            messages.append({"role": "system", "content": request.system})
+        messages.append({"role": "user", "content": request.prompt})
+
+        payload: dict[str, object] = {
+            "model": self.model,
+            "messages": messages,
+        }
+        if request.json_schema is not None:
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "openrange_response",
+                    "strict": self.json_schema_strict,
+                    "schema": request.json_schema,
+                },
+            }
+        return payload
+
+
+def _openai_compatible_error_detail(exc: HTTPError) -> str:
+    body = exc.read().decode("utf-8", errors="replace").strip()
+    if not body:
+        return str(exc.reason)
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        return body
+    if isinstance(data, dict):
+        error = data.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if isinstance(message, str) and message:
+                return message
+        message = data.get("message")
+        if isinstance(message, str) and message:
+            return message
+    return body
+
+
+def _openai_compatible_timeout_error(timeout: float) -> LLMBackendError:
+    return LLMBackendError(
+        f"OpenAI-compatible request timed out after {timeout} seconds",
+    )
+
+
+def _openai_compatible_result(raw: str, request: LLMRequest) -> LLMResult:
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise LLMBackendError(
+            f"OpenAI-compatible response was not JSON: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise LLMBackendError("OpenAI-compatible response was not an object")
+
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise LLMBackendError("OpenAI-compatible response had no choices")
+    first = choices[0]
+    if not isinstance(first, dict):
+        raise LLMBackendError("OpenAI-compatible choice was not an object")
+    message = first.get("message")
+    if not isinstance(message, dict):
+        raise LLMBackendError("OpenAI-compatible choice had no message")
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise LLMBackendError("OpenAI-compatible message content was not text")
+
+    if request.json_schema is None:
+        return LLMResult(content)
+    return LLMResult(content, parse_json_object(content))
+
+
+@dataclass(frozen=True, slots=True)
+class LiteLLMBackend:
+    """An ``LLMBackend`` over LiteLLM, reaching any provider it supports.
+
+    ``model`` is a LiteLLM model id (``"openai/gpt-4o-mini"``,
+    ``"anthropic/claude-..."``, ``"hosted_vllm/<name>"``, ``"ollama/<name>"``, …);
+    ``api_base`` points at a self-hosted or compatible endpoint. Needs the optional
+    ``litellm`` extra (``uv sync --extra litellm``). ``extra_params`` passes provider
+    arguments (e.g. ``temperature``) straight through to ``litellm.completion``.
+    """
+
+    model: str
+    api_base: str | None = None
+    api_key: str | None = None
+    api_key_env: str | None = None
+    timeout: float = 120.0
+    extra_params: Mapping[str, object] | None = None
+    json_schema_strict: bool = False
+
+    def preflight(self) -> None:
+        """Validate configuration and that the ``litellm`` extra is installed."""
+        if not self.model.strip():
+            raise LLMBackendError("LiteLLMBackend requires a model")
+        if self.timeout <= 0:
+            raise LLMBackendError("LiteLLMBackend timeout must be positive")
+        _require_litellm()
+
+    def complete(self, request: LLMRequest) -> LLMResult:
+        litellm = _require_litellm()
+        api_key = self.api_key
+        if api_key is None and self.api_key_env is not None:
+            api_key = os.getenv(self.api_key_env)
+        params: dict[str, object] = {
+            "model": self.model,
+            "messages": self._messages(request),
+            "timeout": self.timeout,
+        }
+        if self.api_base is not None:
+            params["api_base"] = self.api_base
+        if api_key is not None:
+            params["api_key"] = api_key
+        if request.json_schema is not None:
+            params["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "openrange_response",
+                    "strict": self.json_schema_strict,
+                    "schema": request.json_schema,
+                },
+            }
+        if self.extra_params is not None:
+            params.update(self.extra_params)
+        try:
+            response = litellm.completion(**params)
+        except Exception as exc:
+            raise LLMBackendError(f"LiteLLM request failed: {exc}") from exc
+        content = _litellm_content(response)
+        if request.json_schema is None:
+            return LLMResult(content)
+        return LLMResult(content, parse_json_object(content))
+
+    def _messages(self, request: LLMRequest) -> list[dict[str, str]]:
+        messages: list[dict[str, str]] = []
+        if request.system is not None:
+            messages.append({"role": "system", "content": request.system})
+        messages.append({"role": "user", "content": request.prompt})
+        return messages
+
+
+def _require_litellm() -> Any:
+    try:
+        import litellm
+    except ImportError as exc:
+        raise LLMBackendError(
+            "LiteLLMBackend needs the optional 'litellm' extra "
+            "(uv sync --extra litellm)",
+        ) from exc
+    return litellm
+
+
+def _litellm_content(response: Any) -> str:
+    try:
+        content = response.choices[0].message.content
+    except (AttributeError, IndexError, KeyError, TypeError) as exc:
+        raise LLMBackendError("LiteLLM response had no message content") from exc
+    if not isinstance(content, str):
+        raise LLMBackendError("LiteLLM message content was not text")
+    return content

--- a/tests/test_openai_compatible_backend.py
+++ b/tests/test_openai_compatible_backend.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+import time
+from collections.abc import Callable, Iterator, Mapping
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, cast
+
+import pytest
+from openrange_pack_sdk import LLMBackendError, LLMRequest, LLMResult
+
+import openrange as OR
+
+ServerResponse = tuple[int, Mapping[str, object] | str, float]
+RequestHandler = Callable[
+    [Mapping[str, object], Mapping[str, str], str],
+    ServerResponse,
+]
+
+
+@contextlib.contextmanager
+def running_openai_server(
+    handler: RequestHandler,
+) -> Iterator[tuple[str, list[dict[str, object]]]]:
+    requests: list[dict[str, object]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, _format: str, *_args: object) -> None:
+            pass
+
+        def do_POST(self) -> None:
+            content_length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(content_length).decode("utf-8")
+            payload = cast(dict[str, object], json.loads(body))
+            headers = dict(self.headers.items())
+            requests.append(
+                {
+                    "path": self.path,
+                    "headers": headers,
+                    "payload": payload,
+                },
+            )
+
+            status, response, delay = handler(payload, headers, self.path)
+            if delay:
+                time.sleep(delay)
+            response_bytes = (
+                response.encode("utf-8")
+                if isinstance(response, str)
+                else json.dumps(response).encode("utf-8")
+            )
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(response_bytes)))
+            self.end_headers()
+            with contextlib.suppress(BrokenPipeError):
+                self.wfile.write(response_bytes)
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host = cast(str, server.server_address[0])
+        port = server.server_address[1]
+        yield f"http://{host}:{port}", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_openai_compatible_backend_sends_plain_chat_completion() -> None:
+    def handler(
+        _payload: Mapping[str, object],
+        _headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        return 200, {"choices": [{"message": {"content": "plain answer"}}]}, 0
+
+    with running_openai_server(handler) as (base_url, requests):
+        result = OR.OpenAICompatibleBackend(
+            base_url=f"{base_url}/v1",
+            api_key="test-key",
+            model="demo-model",
+            extra_headers={"X-Test": "yes"},
+        ).complete(LLMRequest("build a world", system="be precise"))
+
+    assert result == LLMResult("plain answer")
+    request = requests[0]
+    payload = cast(dict[str, Any], request["payload"])
+    assert request["path"] == "/v1/chat/completions"
+    assert payload["model"] == "demo-model"
+    assert payload["messages"] == [
+        {"role": "system", "content": "be precise"},
+        {"role": "user", "content": "build a world"},
+    ]
+    assert "response_format" not in payload
+    headers = cast(dict[str, str], request["headers"])
+    assert headers["Authorization"] == "Bearer test-key"
+    assert headers["X-Test"] == "yes"
+
+
+def test_openai_compatible_backend_requests_structured_json() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"ok": {"type": "boolean"}},
+        "required": ["ok"],
+    }
+
+    def handler(
+        payload: Mapping[str, object],
+        _headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        response_format = cast(dict[str, Any], payload["response_format"])
+        assert response_format["type"] == "json_schema"
+        assert response_format["json_schema"]["schema"] == schema
+        assert response_format["json_schema"]["strict"] is False
+        return 200, {"choices": [{"message": {"content": '{"ok": true}'}}]}, 0
+
+    with running_openai_server(handler) as (base_url, _requests):
+        result = OR.OpenAICompatibleBackend(
+            base_url=f"{base_url}/v1",
+            api_key="test-key",
+            model="demo-model",
+        ).complete(LLMRequest("return json", json_schema=schema))
+
+    assert result.text == '{"ok": true}'
+    assert result.parsed_json == {"ok": True}
+
+
+def test_openai_compatible_backend_can_request_strict_json_schema() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"ok": {"type": "boolean"}},
+        "required": ["ok"],
+    }
+
+    def handler(
+        payload: Mapping[str, object],
+        _headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        response_format = cast(dict[str, Any], payload["response_format"])
+        assert response_format["json_schema"]["strict"] is True
+        return 200, {"choices": [{"message": {"content": '{"ok": true}'}}]}, 0
+
+    with running_openai_server(handler) as (base_url, _requests):
+        result = OR.OpenAICompatibleBackend(
+            base_url=f"{base_url}/v1",
+            api_key="test-key",
+            model="demo-model",
+            json_schema_strict=True,
+        ).complete(LLMRequest("return json", json_schema=schema))
+
+    assert result.parsed_json == {"ok": True}
+
+
+def test_openai_compatible_backend_reads_api_key_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENRANGE_TEST_API_KEY", "env-key")
+
+    def handler(
+        _payload: Mapping[str, object],
+        headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        assert headers["Authorization"] == "Bearer env-key"
+        return 200, {"choices": [{"message": {"content": "plain answer"}}]}, 0
+
+    with running_openai_server(handler) as (base_url, _requests):
+        result = OR.OpenAICompatibleBackend(
+            base_url=f"{base_url}/v1",
+            api_key_env="OPENRANGE_TEST_API_KEY",
+            model="demo-model",
+        ).complete(LLMRequest("hello"))
+
+    assert result == LLMResult("plain answer")
+
+
+def test_openai_compatible_backend_rejects_non_http_base_url() -> None:
+    backend = OR.OpenAICompatibleBackend(
+        base_url="file:///tmp/openai",
+        api_key="test-key",
+        model="demo-model",
+    )
+
+    with pytest.raises(LLMBackendError, match="base_url must use http or https"):
+        backend.preflight()
+
+
+def test_openai_compatible_backend_maps_http_errors() -> None:
+    def handler(
+        _payload: Mapping[str, object],
+        _headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        return 401, {"error": {"message": "bad api key"}}, 0
+
+    with running_openai_server(handler) as (base_url, _requests):
+        backend = OR.OpenAICompatibleBackend(
+            base_url=f"{base_url}/v1",
+            api_key="test-key",
+            model="demo-model",
+        )
+        with pytest.raises(LLMBackendError, match="HTTP 401: bad api key"):
+            backend.complete(LLMRequest("hello"))
+
+
+def test_openai_compatible_backend_maps_timeouts() -> None:
+    def handler(
+        _payload: Mapping[str, object],
+        _headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        return 200, {"choices": [{"message": {"content": "late"}}]}, 0.2
+
+    with running_openai_server(handler) as (base_url, _requests):
+        backend = OR.OpenAICompatibleBackend(
+            base_url=f"{base_url}/v1",
+            api_key="test-key",
+            model="demo-model",
+            timeout=0.01,
+        )
+        with pytest.raises(LLMBackendError, match="timed out after 0.01 seconds"):
+            backend.complete(LLMRequest("hello"))
+
+
+def test_litellm_backend_completes_via_an_openai_compatible_server() -> None:
+    pytest.importorskip("litellm")  # the optional ``litellm`` extra
+
+    def handler(
+        _payload: Mapping[str, object],
+        _headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        body = {
+            "id": "cmpl-1",
+            "object": "chat.completion",
+            "model": "demo-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "litellm answer"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+        return 200, body, 0
+
+    with running_openai_server(handler) as (base_url, requests):
+        result = OR.LiteLLMBackend(
+            model="openai/demo-model",
+            api_base=f"{base_url}/v1",
+            api_key="test-key",
+        ).complete(LLMRequest("hello", system="be precise"))
+
+    assert result.text == "litellm answer"
+    payload = cast(dict[str, Any], requests[0]["payload"])
+    assert payload["messages"] == [
+        {"role": "system", "content": "be precise"},
+        {"role": "user", "content": "hello"},
+    ]
+
+
+def test_litellm_backend_requires_a_model() -> None:
+    with pytest.raises(LLMBackendError, match="requires a model"):
+        OR.LiteLLMBackend(model="  ").preflight()

--- a/uv.lock
+++ b/uv.lock
@@ -496,12 +496,40 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
 ]
 
 [[package]]
@@ -723,6 +751,41 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -790,6 +853,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
     { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
     { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.89.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/f1/f7cfead063f2ab1877c8fb465d0d7fe300b75f081bcb73525f6d550aeb1c/litellm-1.89.3.tar.gz", hash = "sha256:8fcdb2b7a0ef3381d41adf164443842e31ef9f0cd5bcda6fc3c0bd8bc2959510", size = 14080611, upload-time = "2026-06-20T22:42:26.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/f1/34d174ff1d84e459b30f971606ac9cb7078ad24cd7661e9786b25adf7def/litellm-1.89.3-py3-none-any.whl", hash = "sha256:414ef5aee504b2b3eb1b219d39f1c11902db399cbdbc06e5fb550c15d731abeb", size = 15495226, upload-time = "2026-06-20T22:42:23.156Z" },
 ]
 
 [[package]]
@@ -1181,6 +1267,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/fa/88d0c58a0c58df7e6758e66b99c5d028d5e0bb49f8812d7203940cd9dbf1/openai-2.43.0.tar.gz", hash = "sha256:e74d238200a26868977002190fb6631613480a93dfe0c9c982e77021ed60a017", size = 785369, upload-time = "2026-06-17T17:06:56.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/d2/ba767f4bbb30776c03d40906a2d3afad716a165ffa1771fc23b8992f7920/openai-2.43.0-py3-none-any.whl", hash = "sha256:65a670b54fadf2268c9e1330133373c963eb779ee969e5cbad419ec2c21dce97", size = 1355077, upload-time = "2026-06-17T17:06:53.614Z" },
+]
+
+[[package]]
 name = "openrange"
 version = "0.1.0"
 source = { editable = "." }
@@ -1192,6 +1297,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+litellm = [
+    { name = "litellm" },
+]
 strands = [
     { name = "strands-agents" },
     { name = "strands-agents-tools" },
@@ -1213,12 +1321,13 @@ dev = [
 requires-dist = [
     { name = "graphschema", editable = "packages/graphschema" },
     { name = "jinja2", specifier = ">=3.1" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.55" },
     { name = "openrange-pack-sdk", editable = "packages/openrange-pack-sdk" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "strands-agents", marker = "extra == 'strands'", specifier = ">=1.38.0" },
     { name = "strands-agents-tools", marker = "extra == 'strands'", specifier = ">=0.4.1" },
 ]
-provides-extras = ["strands"]
+provides-extras = ["strands", "litellm"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2010,6 +2119,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2113,6 +2231,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Builds on **#220 by @pntech20** (which went stale — `CONFLICTING` after the chain/manifest work landed under it). His `OpenAICompatibleBackend` is ported here, with him credited as co-author; this also adds the LiteLLM backend so generation is genuinely model-agnostic.

## Why
`openrange.llm` shipped only CLI backends (`CodexBackend`, `ClaudeBackend`) — both shell out to a vendor binary. So the self-authoring / #261 generation path could only run if `claude`/`codex` was on PATH; it couldn't point at a self-hosted vLLM, a local `llama-server`, or any OpenAI-compatible API. These two backends fix that.

## What
- **`OpenAICompatibleBackend`** (ported from #220, zero deps) — stdlib `urllib` Chat Completions client for OpenAI, vLLM, Ollama, llama.cpp, OpenRouter, Groq, Together, … `base_url` / `api_key` (field or env) / `model` / `timeout` / `extra_headers`, with JSON-schema structured output. Re-based onto the current SDK `LLMBackend` protocol (the request/result/error types moved to `openrange_pack_sdk` in #225, after #220 was opened — the source of the conflict).
- **`LiteLLMBackend`** (new) — reaches any provider LiteLLM supports, behind the optional `litellm` extra (`uv sync --extra litellm`), wired into mypy overrides and `uv.lock`. Lazy import with a clear error when the extra is absent.

Both implement `preflight()` + `complete()` and are exported from `openrange`.

## Verified live
Against a **self-hosted vLLM** on Spark (`nemotron-nano`), through both backends:
- `OpenAICompatibleBackend`: plain completion → `"pong"`; JSON-schema → parsed `{"sum": 4}`.
- `LiteLLMBackend` (`hosted_vllm/nemotron-nano`): plain completion → `"pong"`.

## Tests
`tests/test_openai_compatible_backend.py` drives a **real local HTTP server** (no mocks — matches the repo's integration-test style): plain + structured + strict-schema + env-key + non-http rejection + HTTP-error + timeout mapping, plus a LiteLLM round-trip against the same server (skips when the extra isn't installed). `ruff` + `mypy` clean.

Supersedes #220 — close that in favor of this once reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
