### PR TITLE
dashboard: world view by default, Cast (NPCs) in its own right panel

### DIFF
--- a/src/openrange/dashboard/static/dashboard.css
+++ b/src/openrange/dashboard/static/dashboard.css
@@ -1047,3 +1047,49 @@ button { font: inherit; cursor: pointer; }
 .evo-dots { display: flex; gap: 6px; margin-top: 8px; flex-wrap: wrap; }
 .evo-dot { width: 11px; height: 11px; border-radius: 50%; border: 1px solid var(--line); background: var(--bg-1-solid); cursor: pointer; padding: 0; }
 .evo-dot.on { background: var(--accent); border-color: var(--accent); }
+
+.cast-rail {
+  position: absolute;
+  top: 72px;
+  right: 12px;
+  width: 244px;
+  max-height: calc(100% - 132px);
+  z-index: 8;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-1-solid);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: var(--shadow-2);
+  overflow: hidden;
+}
+.cast-rail-head {
+  padding: 14px 16px 10px 16px;
+  border-bottom: 1px solid var(--line-s);
+}
+.cast-rail-head h2 {
+  margin: 0;
+  font: 700 16px var(--f-display);
+  letter-spacing: -0.012em;
+  color: var(--ink-0);
+}
+.cast-rail-sub {
+  display: block;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  color: var(--ink-3);
+  margin-top: 2px;
+}
+.cast-rail-body {
+  padding: 6px 10px 12px 10px;
+  overflow-y: auto;
+}
+.persona-row {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 8px 8px;
+}
+.persona-row + .persona-row { border-top: 1px solid var(--line-s); }
+.persona-row .name { font-weight: 600; font-size: 13px; color: var(--ink-0); }
+.persona-row .role { font-family: var(--f-mono); font-size: 11px; color: var(--ink-3); }

--- a/src/openrange/dashboard/static/dashboard.js
+++ b/src/openrange/dashboard/static/dashboard.js
@@ -1885,7 +1885,14 @@ function renderWorldPanel() {
   if (rail.worldSubtab === "services") return renderWorldServices(root);
   if (rail.worldSubtab === "topology") return renderWorldTopology(root);
   if (rail.worldSubtab === "network") return renderWorldNetwork(root);
-  if (rail.worldSubtab === "cast") return renderWorldCast(root);
+  return renderWorldServices(root);
+}
+
+function renderCastRail() {
+  const root = document.getElementById("cast-content");
+  if (root) renderWorldCast(root);
+  const sub = document.getElementById("cast-rail-sub");
+  if (sub) sub.textContent = plural((model.topology.green_personas || []).length, "persona");
 }
 
 function renderWorldServices(root) {
@@ -2562,6 +2569,7 @@ function render() {
   }
   // Re-render the active rail panel so it reflects fresh data.
   if (rail.open) renderRailPanel(rail.active);
+  renderCastRail();
   renderEvoView();
   // Surface a build banner when a new lineage node lands.
   checkForNewLineage();
@@ -2772,6 +2780,7 @@ function wireUI() {
   wireUI();
   await safeRefreshRuns();
   await safeRefresh();
+  showRailTab("world");
   setInterval(safeRefreshRuns, 5000);
   setInterval(() => {
     if (runState.activeRun) safeRefresh();

--- a/src/openrange/dashboard/static/index.html
+++ b/src/openrange/dashboard/static/index.html
@@ -122,7 +122,6 @@
             <button class="rail-subtab is-active" data-world-tab="services">Services</button>
             <button class="rail-subtab" data-world-tab="topology">Topology</button>
             <button class="rail-subtab" data-world-tab="network">Network</button>
-            <button class="rail-subtab" data-world-tab="cast">Cast</button>
           </div>
         </header>
         <div class="rail-content" id="world-content"></div>
@@ -152,6 +151,14 @@
         <div class="rail-content" id="actor-content"></div>
       </section>
     </div>
+  </aside>
+
+  <aside class="cast-rail" id="cast-rail" aria-label="Cast">
+    <header class="cast-rail-head">
+      <h2>Cast</h2>
+      <span class="cast-rail-sub" id="cast-rail-sub">personas</span>
+    </header>
+    <div class="cast-rail-body" id="cast-content"></div>
   </aside>
 
   <!-- Empty-state when no snapshot. -->


### PR DESCRIPTION
## What

The dashboard opened on the bare 3D office scene, with the world's structure hidden behind a collapsed rail tab and the personas/NPCs buried as a "Cast" subtab. This makes the **world the default view** and gives the **Cast its own space**.

- **World panel opens on load** — the structured Services / Topology / Network view, so you see the estate immediately instead of an empty office floor.
- **Cast (personas / NPCs) → dedicated right-side panel** — moved out of the World subtabs, docked opposite the world.

## Scope

Static frontend only: `index.html` / `dashboard.js` / `dashboard.css`. No server or view changes.

## Verification

- Dashboard tests: **44 passed**.
- Verified **live** against a served company world: the World panel is default-open (estate visible on load), and the Cast panel renders persona rows (`renderCastRail` → "3 personas" + names) as well as the empty state ("No personas seated…") for worlds without any.

For review, not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
