### PR TITLE
cyber: trim WHAT comments to WHY-only per .rules

### DIFF
--- a/packs/cyber_webapp/cyber_webapp/llm_realize.py
+++ b/packs/cyber_webapp/cyber_webapp/llm_realize.py
@@ -34,9 +34,8 @@ from cyber_webapp.reference_solver import (
 )
 from cyber_webapp.verify import perform, verdict_authored
 
-# A host callback that boots an episode for ``(snapshot, task_id)`` and yields its
-# base_url for the duration of the context, owning the episode lifecycle. Booting an
-# episode needs the runtime (a host concern), so realization takes it injected.
+# Injected by the host: booting an episode needs the runtime, which the pack must not
+# import, so it takes the boot as a callback yielding the world's base_url.
 BootEpisode = Callable[[Snapshot, str], AbstractContextManager[str]]
 
 # The classes a prompt exists for. command_injection is the first realized class (#266);

--- a/tests/test_cyber_llm_realize.py
+++ b/tests/test_cyber_llm_realize.py
@@ -586,9 +586,8 @@ def test_gate_admits_faithful_rejects_trivial(
 
 
 def _boot(base_dir: Path) -> BootEpisode:
-    # The host side of realization: boot an episode for (snapshot, task) and yield its
-    # base_url, owning the episode lifecycle. A fresh service per call rebuilds the
-    # runtime, so a handler injected onto the graph between probes is exercised.
+    # A fresh service per call rebuilds the runtime, so a handler injected onto the
+    # graph between probes is exercised.
     counter = iter(range(1000))
 
     @contextlib.contextmanager
@@ -675,8 +674,6 @@ def test_realize_generated_vuln_bakes_a_realized_handler(
     chat_server: Callable[..., contextlib.AbstractContextManager[str]],
     chat_completion: Callable[[str], str],
 ) -> None:
-    # The whole dial end to end: a generate:"vuln" world routes through a real backend
-    # over HTTP, the gate admits the (graph-matching) handler, and the world re-freezes.
     snap = _admit("db", "sql_injection", generate="vuln", context="single")
     before = snap.graph.content_hash()
     reply = chat_completion(json.dumps({"handler": _faithful_sqli(snap.graph)}))


### PR DESCRIPTION
`.rules` says default to no comments and don't explain WHAT — well-named identifiers do that; keep a comment only when the WHY is non-obvious.

Three comments added in #340 leaned WHAT (the code already said it):
- `BootEpisode`'s comment restated the type signature — trimmed to just the boundary-injection WHY.
- the dial acceptance test's comment narrated its own body — removed (the test name + body are self-evident).
- the `_boot` helper's comment described what it does — trimmed to the non-obvious fresh-runtime-per-call WHY.

The genuine WHY comments (the AST-parse-crash constraint, the import-cycle workaround, the re-seed integrity invariant) are kept.

Tests green (77 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)