### PR TITLE
sdk: self-verifying LLM-Builder seam (WorldAuthor + realize_verified); migrate cyber

### DIFF
--- a/examples/trl_grpo_cyber.ipynb
+++ b/examples/trl_grpo_cyber.ipynb
@@ -371,7 +371,7 @@
     "    # \"vuln\": realize this world's handler behind the verifier\n",
     "    gen = _seed(\"vuln\")\n",
     "    realized = realize_generated(gen, ClaudeBackend(), _realize_boot)\n",
-    "    print(\"realized kinds:\", realized.lineage[\"realized_handlers\"])\n",
+    "    print(\"realized kinds:\", realized.lineage[\"realized\"])\n",
     "    print(\"re-froze to a new snapshot:\", realized.snapshot_id != gen.snapshot_id)\n",
     "\n",
     "    # \"novel\": the LLM invents a class the catalog lacks; the same gate admits it\n",

--- a/packages/openrange-pack-sdk/src/openrange_pack_sdk/__init__.py
+++ b/packages/openrange-pack-sdk/src/openrange_pack_sdk/__init__.py
@@ -14,6 +14,10 @@ from openrange_pack_sdk._errors import (
     OpenRangeError,
     PackError,
 )
+from openrange_pack_sdk._generate import (
+    WorldAuthor,
+    realize_verified,
+)
 from openrange_pack_sdk._helpers import (
     add_edge,
     add_node,
@@ -99,6 +103,7 @@ __all__ = [
     "TaskFamily",
     "TaskSeed",
     "TaskSpec",
+    "WorldAuthor",
     "add_edge",
     "add_node",
     "edge_id",
@@ -107,6 +112,7 @@ __all__ = [
     "manifest_int",
     "manifest_list",
     "manifest_str",
+    "realize_verified",
     "run_submission",
     "write_tree",
 ]

--- a/packages/openrange-pack-sdk/src/openrange_pack_sdk/_generate.py
+++ b/packages/openrange-pack-sdk/src/openrange_pack_sdk/_generate.py
@@ -1,0 +1,63 @@
+"""Self-verifying world generation: author a part, keep it only if a verifier accepts.
+
+An author — LLM-backed in practice — proposes part of a world, but the part ships
+only if an independent verifier accepts it: the verifier, not the author, decides
+what is real. The loop is domain-agnostic; a pack supplies the domain pieces through
+:class:`WorldAuthor`. Booting the world to verify needs the runtime, so that transport
+lives inside the author's ``verify`` and the loop stays runtime-free.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+from openrange_pack_sdk._types import Snapshot
+
+
+class WorldAuthor(Protocol):
+    """A pack's hook for authoring self-verified parts of a world.
+
+    For each key in ``authorable``, :func:`realize_verified` calls ``apply`` (which
+    authors the part — typically via an LLM — and mutates ``snapshot.graph``,
+    returning whether it took), then keeps it iff ``verify`` accepts it, else
+    ``revert`` undoes it. ``verify`` owns the consequence check — booting the world
+    and running the same gate that grades the agent — so a faked or unsolvable
+    authoring is rejected here, not in training.
+    """
+
+    def authorable(self, snapshot: Snapshot) -> Sequence[str]: ...
+
+    def apply(self, snapshot: Snapshot, key: str) -> bool: ...
+
+    def verify(self, snapshot: Snapshot, key: str) -> bool: ...
+
+    def revert(self, snapshot: Snapshot, key: str) -> None: ...
+
+
+def realize_verified(snapshot: Snapshot, author: WorldAuthor) -> Snapshot:
+    """Author each authorable key, keeping only the verifier-accepted ones, and
+    re-freeze to a content-addressed snapshot recording them in ``lineage["realized"]``.
+    Mutates ``snapshot.graph`` — use the returned snapshot.
+    """
+    realized: list[str] = []
+    for key in author.authorable(snapshot):
+        if not author.apply(snapshot, key):
+            continue
+        if author.verify(snapshot, key):
+            realized.append(key)
+        else:
+            author.revert(snapshot, key)
+    return _refrozen(snapshot, tuple(realized))
+
+
+def _refrozen(snapshot: Snapshot, realized: tuple[str, ...]) -> Snapshot:
+    graph = snapshot.graph
+    return Snapshot(
+        snapshot_id=graph.content_hash(),
+        ontology_id=snapshot.ontology_id,
+        graph=graph,
+        tasks=snapshot.tasks,
+        lineage={**dict(snapshot.lineage), "realized": realized},
+        history=snapshot.history,
+    )

--- a/packages/openrange-pack-sdk/tests/test_generate.py
+++ b/packages/openrange-pack-sdk/tests/test_generate.py
@@ -1,0 +1,64 @@
+"""realize_verified keeps only verifier-accepted authoring, and re-freezes.
+
+No mocks: a real WorldAuthor over a real WorldGraph drives the loop end to end.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from graphschema import Node, WorldGraph
+from openrange_pack_sdk import Snapshot, realize_verified
+
+
+@dataclass
+class _Author:
+    accept: set[str]
+
+    def authorable(self, snapshot: Snapshot) -> Sequence[str]:
+        return ("kept", "rejected", "skipped")
+
+    def apply(self, snapshot: Snapshot, key: str) -> bool:
+        if key == "skipped":
+            return False
+        snapshot.graph.nodes["n"].attrs[key] = "authored"
+        return True
+
+    def verify(self, snapshot: Snapshot, key: str) -> bool:
+        return key in self.accept
+
+    def revert(self, snapshot: Snapshot, key: str) -> None:
+        del snapshot.graph.nodes["n"].attrs[key]
+
+
+def _snapshot() -> Snapshot:
+    graph = WorldGraph(ontology="t@1", nodes={"n": Node(id="n", kind="thing")})
+    return Snapshot(
+        snapshot_id=graph.content_hash(),
+        ontology_id="t@1",
+        graph=graph,
+        tasks=(),
+        lineage={"seed": 1},
+        history=(),
+    )
+
+
+def test_keeps_only_verifier_accepted_authoring() -> None:
+    snap = _snapshot()
+    out = realize_verified(snap, _Author(accept={"kept"}))
+
+    assert out.lineage["realized"] == ("kept",)
+    attrs = out.graph.nodes["n"].attrs
+    assert attrs.get("kept") == "authored"
+    assert "rejected" not in attrs
+    assert "skipped" not in attrs
+    assert out.lineage["seed"] == 1
+    assert out.snapshot_id == out.graph.content_hash() != snap.snapshot_id
+
+
+def test_nothing_accepted_realizes_nothing() -> None:
+    out = realize_verified(_snapshot(), _Author(accept=set()))
+
+    assert out.lineage["realized"] == ()
+    assert out.graph.nodes["n"].attrs == {}

--- a/packs/cyber_webapp/cyber_webapp/llm_realize.py
+++ b/packs/cyber_webapp/cyber_webapp/llm_realize.py
@@ -17,7 +17,13 @@ from contextlib import AbstractContextManager
 from dataclasses import dataclass
 
 from graphschema import Node, WorldGraph
-from openrange_pack_sdk import LLMBackend, LLMRequest, PackError, Snapshot
+from openrange_pack_sdk import (
+    LLMBackend,
+    LLMRequest,
+    PackError,
+    Snapshot,
+    realize_verified,
+)
 
 from cyber_webapp.codegen.handlers import _extract_handle_body
 from cyber_webapp.realize_admit import (
@@ -505,57 +511,51 @@ def exploit_from_result(parsed_json: Mapping[str, object] | None) -> tuple[str, 
     )
 
 
-def realize_world(
-    snapshot: Snapshot,
-    propose: Callable[[WorldGraph, str], str],
-    run_probes: Callable[[str], tuple[str, str, str | None]],
-) -> Snapshot:
-    """Generate-verify-freeze: turn a procedural snapshot into an LLM-realized one.
+@dataclass(frozen=True, slots=True)
+class _HandlerAuthor:
+    propose: Callable[[WorldGraph, str], str]
+    run_probes: Callable[[str], tuple[str, str, str | None]]
 
-    For each realizable vuln: `propose` a handler, have the host `run_probes` boot the
-    world and return the (exploit, benign, control) response bodies, and keep the
-    handler only if the gate accepts it — the exploit leaks the flag, a benign request
-    does not, and the faithfulness control computes (so a faked/hard-coded handler is
-    rejected) — otherwise fall back to the procedural template. The result is re-frozen
-    to a new content-addressed snapshot recording the realized kinds in lineage. The
-    host injects `propose` (the LLM) and `run_probes` (booting an episode is a host
-    concern), so the pack stays transport-free. Mutates `snapshot.graph` — use the
-    returned snapshot.
-    """
-    graph = snapshot.graph
-    realized: list[str] = []
-    for kind in REALIZABLE_KINDS:
-        vuln = next(
-            (n for n in graph.by_kind("vulnerability") if n.attrs.get("kind") == kind),
-            None,
-        )
-        if vuln is None:
-            continue
-        handler = propose(graph, kind)
+    def authorable(self, snapshot: Snapshot) -> list[str]:
+        kinds = {n.attrs.get("kind") for n in snapshot.graph.by_kind("vulnerability")}
+        return [k for k in REALIZABLE_KINDS if k in kinds]
+
+    def apply(self, snapshot: Snapshot, kind: str) -> bool:
+        handler = self.propose(snapshot.graph, kind)
         if not handler.strip() or not _is_valid_handler(handler):
-            continue
-        vuln.attrs["realized_handler"] = handler
-        exploit_body, benign_body, control_body = run_probes(kind)
+            return False
+        _vuln_of_kind(snapshot.graph, kind).attrs["realized_handler"] = handler
+        return True
+
+    def verify(self, snapshot: Snapshot, kind: str) -> bool:
+        graph = snapshot.graph
+        exploit_body, benign_body, control_body = self.run_probes(kind)
         control = control_request(graph, kind)
-        verdict = classify_admission_with_control(
+        return classify_admission_with_control(
             graph,
             exploit_body,
             benign_body,
             control_body,
             control.expected if control else None,
-        )
-        if verdict.accepted:
-            realized.append(kind)
-        else:
-            del vuln.attrs["realized_handler"]  # rejected — keep the template
-    return Snapshot(
-        snapshot_id=graph.content_hash(),
-        ontology_id=snapshot.ontology_id,
-        graph=graph,
-        tasks=snapshot.tasks,
-        lineage={**dict(snapshot.lineage), "realized_handlers": tuple(realized)},
-        history=snapshot.history,
-    )
+        ).accepted
+
+    def revert(self, snapshot: Snapshot, kind: str) -> None:
+        del _vuln_of_kind(snapshot.graph, kind).attrs["realized_handler"]
+
+
+def realize_world(
+    snapshot: Snapshot,
+    propose: Callable[[WorldGraph, str], str],
+    run_probes: Callable[[str], tuple[str, str, str | None]],
+) -> Snapshot:
+    """Generate-verify-freeze each realizable vuln's handler through the kind-agnostic
+    gate: `propose` it, keep it only if the gate accepts (the exploit leaks the flag, a
+    benign request does not, and the faithfulness control computes), else fall back to
+    the procedural template. The host injects `propose` (the LLM) and `run_probes`
+    (booting an episode), so the pack stays transport-free; the realized kinds land in
+    `lineage["realized"]`. Mutates `snapshot.graph` — use the returned snapshot.
+    """
+    return realize_verified(snapshot, _HandlerAuthor(propose, run_probes))
 
 
 def realize_with_backend(

--- a/tests/test_cyber_llm_realize.py
+++ b/tests/test_cyber_llm_realize.py
@@ -614,7 +614,7 @@ def test_realize_world_bakes_in_a_faithful_handler(tmp_path: Path) -> None:
     out = realize_world(
         snap, lambda g, _k: _faithful_sqli(g), _episode_runner(snap, tmp_path)
     )
-    assert "sql_injection" in out.lineage["realized_handlers"]
+    assert "sql_injection" in out.lineage["realized"]
     assert out.snapshot_id == out.graph.content_hash()  # re-frozen
     assert out.snapshot_id != before  # the realized handler changed the world
 
@@ -625,7 +625,7 @@ def test_realize_world_falls_back_on_a_trivial_handler(tmp_path: Path) -> None:
     out = realize_world(
         snap, lambda g, _k: _trivial_sqli(g), _episode_runner(snap, tmp_path)
     )
-    assert out.lineage["realized_handlers"] == ()  # rejected
+    assert out.lineage["realized"] == ()  # rejected
     assert out.snapshot_id == before  # template kept -> world unchanged
 
 
@@ -633,7 +633,7 @@ def test_realize_world_skips_an_empty_proposal(tmp_path: Path) -> None:
     snap = _admit("db", "sql_injection", context="single")
     before = snap.graph.content_hash()  # live hash (the pin mutated the graph)
     out = realize_world(snap, lambda _g, _k: "", _episode_runner(snap, tmp_path))
-    assert out.lineage["realized_handlers"] == ()
+    assert out.lineage["realized"] == ()
     assert out.snapshot_id == before
 
 
@@ -646,7 +646,7 @@ def test_realize_world_skips_an_unparseable_handler(tmp_path: Path) -> None:
         lambda _g, _k: "def handle(query, state):\n    return )(",
         _episode_runner(snap, tmp_path),
     )
-    assert out.lineage["realized_handlers"] == ()
+    assert out.lineage["realized"] == ()
     assert out.snapshot_id == before
 
 
@@ -681,7 +681,7 @@ def test_realize_generated_vuln_bakes_a_realized_handler(
         out = realize_generated(
             snap, OpenAICompatibleBackend(base_url=base), _boot(tmp_path)
         )
-    assert "sql_injection" in out.lineage["realized_handlers"]
+    assert "sql_injection" in out.lineage["realized"]
     assert out.snapshot_id == out.graph.content_hash()
     assert out.snapshot_id != before
 
@@ -897,7 +897,7 @@ def test_realize_with_backend_drives_a_live_llm(tmp_path: Path) -> None:
     backend.preflight()
     snap = _admit("db", "sql_injection", context="single")
     out = realize_with_backend(snap, backend, _episode_runner(snap, tmp_path))
-    assert "sql_injection" in out.lineage["realized_handlers"]
+    assert "sql_injection" in out.lineage["realized"]
     assert out.snapshot_id == out.graph.content_hash()
 
 


### PR DESCRIPTION
Extract the cyber pack's bespoke LLM-realization loop into a **domain-agnostic SDK seam** so a pack doesn't reinvent the orchestration: the verifier, not the author, decides what ships. (Implements #349.)

## What ships
- **`openrange_pack_sdk._generate`** — a `WorldAuthor` protocol (`authorable` / `apply` / `verify` / `revert`) + `realize_verified(snapshot, author)`: author each part, keep it only if `verify` accepts, else `revert`; re-freeze recording `lineage["realized"]`.
- It lives in the **SDK, not `openrange.core`** — packs may import only `openrange_pack_sdk` + `graphschema` (the boundary firewall enforces it), and packs are who implement/call this. The loop needs **no runtime** (`verify` owns the boot/gate transport), so it stays domain-agnostic.
- **cyber migrated**: `llm_realize.realize_world` is now a thin call to `realize_verified` via a `_HandlerAuthor` wrapping its `(propose, run_probes)`; the duplicated per-vuln loop is gone. Lineage key `realized_handlers` → generic `realized`.

## Verification
- The **147 cyber LLM-realize tests pass unchanged** (behavior-preserving migration).
- A **no-doubles** SDK test (`packages/openrange-pack-sdk/tests/test_generate.py`) covers `realize_verified`'s branches with a real `WorldAuthor` over a real graph (100% branch coverage).
- `scripts/check_boundary.sh` + ruff + mypy clean.
- A 3-lens adversarial audit confirmed exact behavior-equivalence, contract generality (a second OnDemand pack with a `surface` instead of a `base_url` can implement `WorldAuthor` — `verify` is runtime-opaque), and test rigor.

## Follow-ups (not in this PR)
- `realize_novel_with_backend` is a distinct single-proposal shape (not the per-element loop), so it's left as-is — no duplication.
- Wiring a second pack (and the inert manifest `generate` dial, #261) onto the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
