### PR TITLE
openrange-trl: keep EpisodeEnv.close out of the policy tool menu

### DIFF
--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -181,10 +181,8 @@ class EpisodeEnv:
         self._finalized = False
         return self._initial_observation()
 
-    def close(self) -> None:
-        """Release the env's resources: tear down any sandbox and close the underlying
-        ``EpisodeService`` (stopping live episodes and warm-pooled worlds). TRL never
-        closes the envs it builds from a factory, so the factory's owner must."""
+    # underscore-prefixed: TRL reflects every public env method into a policy tool.
+    def _close(self) -> None:
         self._teardown_sandbox()
         self.service.close()
 
@@ -503,7 +501,7 @@ def make_grpo_rounds(
             # TRL builds one env per batch slot and never closes them; without this
             # each round's CONTAINER worlds (a per-service container stack) leak.
             for env in getattr(trainer, "environments", None) or []:
-                env.close()
+                env._close()
         return collector
 
     def train_round(rows: list[PromptRow], snapshots: list[Snapshot]) -> RoundReports:

--- a/tests/test_trl_adapter.py
+++ b/tests/test_trl_adapter.py
@@ -188,17 +188,41 @@ def test_base_env_resets_with_no_tools(tmp_path: Path) -> None:
 
 
 def test_env_close_releases_the_service(tmp_path: Path) -> None:
-    # TRL builds envs from a factory and never closes them, so env.close() is the
+    # TRL builds envs from a factory and never closes them, so env._close() is the
     # only hook to stop the live episode + warm worlds. Without it, CONTAINER rollouts
-    # leak a container stack per env. close() is idempotent and safe before any reset.
+    # leak a container stack per env. _close() is idempotent and safe before any reset.
     snapshot = _admit("calc_sum")
     service = EpisodeService(SwePack(), tmp_path / "close")
     env = EpisodeEnv(service=service, snapshots={snapshot.snapshot_id: snapshot})
     env.reset(snapshot_id=snapshot.snapshot_id)
     assert service._episodes  # a live episode is registered
-    env.close()
+    env._close()
     assert not service._episodes  # closed: nothing left running
-    env.close()  # idempotent
+    env._close()  # idempotent
+
+
+def test_only_brought_tools_are_exposed(tmp_path: Path) -> None:
+    # TRL reflects every public env method except `reset` into a policy tool, so a
+    # lifecycle hook like close must stay private.
+    import inspect
+
+    def my_tool(surface: Mapping[str, Any]) -> str:
+        return "ok"
+
+    snapshot = _admit("calc_sum")
+    service = EpisodeService(SwePack(), tmp_path / "tools")
+    env = EpisodeEnv(
+        service=service, snapshots={snapshot.snapshot_id: snapshot}, tools=[my_tool]
+    )
+    try:
+        visible = {
+            n
+            for n, _ in inspect.getmembers(env, predicate=inspect.ismethod)
+            if n != "reset" and not n.startswith("_")
+        }
+        assert visible == {"my_tool"}, f"non-tool methods leaked to TRL: {visible}"
+    finally:
+        service.close()
 
 
 class TestBuildDataset:


### PR DESCRIPTION
## Problem
TRL's GRPO reflects **every public method** of an `environment_factory` env (except `reset`) into a callable tool the policy can invoke. `EpisodeEnv.close()` was public, so it leaked into the policy's tool menu as a "release resources / give up" action the model could call mid-episode — observed in a live run's tool schema next to the caller's real tools.

## Fix
- Rename `EpisodeEnv.close` -> `_close` (TRL skips underscore-prefixed methods); update the one internal caller (round cleanup in `make_grpo_rounds`).
- Add a regression test (`test_only_brought_tools_are_exposed`) asserting the TRL-visible method set is exactly the caller's brought tools.

No behavior change for env owners — the factory-owner cleanup path is internal.

## Test
`pytest tests/test_trl_adapter.py` -> 36 passed; ruff + boundary check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
