### PR TITLE
docs: comment discipline

### DIFF
--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -75,7 +75,6 @@ from openrange.training import (
 
 Tool = Callable[..., str]
 
-# Tail tool output so a chatty surface can't flood the context window.
 _OUTPUT_TAIL = 2000
 
 
@@ -101,10 +100,10 @@ def _tool_method(env: EpisodeEnv, fn: Tool) -> Any:
             ns[f"_def_{p.name}"] = p.default
             decl += f" = _def_{p.name}"
         forward += f", {p.name}={p.name}"
-    exec(  # noqa: S102 - source is built from the tool's own signature, not input
-        f"def {fn.__name__}(self{decl}):\n    return self._invoke(_fn{forward})\n",
-        ns,
+    func_source = (
+        f"def {fn.__name__}(self{decl}):\n    return self._invoke(_fn{forward})\n"
     )
+    exec(func_source, ns)  # noqa: S102
     method = ns[fn.__name__]
     method.__doc__ = fn.__doc__
     method.__annotations__["return"] = str
@@ -159,7 +158,7 @@ class EpisodeEnv:
             setattr(self, fn.__name__, _tool_method(self, fn))
 
     if TYPE_CHECKING:
-        # Tools are attached dynamically; type them as string-returning tool calls.
+
         def __getattr__(self, name: str) -> Callable[..., str]: ...
 
     def reset(
@@ -205,7 +204,6 @@ class EpisodeEnv:
         return "Environment ready. Use the available tools."
 
     def _invoke(self, fn: Tool, **kwargs: Any) -> str:
-        # str(): a non-str return must not crash the slice/_record below.
         out = self._safe(lambda: str(fn(self._require_surface(), **kwargs)))
         self._record(fn.__name__, kwargs, out)
         return out[-_OUTPUT_TAIL:]
@@ -259,8 +257,6 @@ class EpisodeEnv:
             self._sandbox.close()
             self._sandbox = None
         if self._network is not None:
-            # Best-effort detach (stop_episode usually did it) so the network can be
-            # dropped even on an un-finalized re-reset.
             if self._target_container is not None:
                 _run_docker(
                     "network",
@@ -302,7 +298,7 @@ class EpisodeEnv:
     def _safe(fn: Callable[[], str]) -> str:
         try:
             return fn()
-        except Exception as exc:  # fail-soft: a bad tool call costs reward only
+        except Exception as exc:
             return f"error: {exc}"
 
     def _record(self, tool: str, args: Mapping[str, Any], result: str) -> None:
@@ -342,9 +338,6 @@ def _resolve_round_backing(
         effective = resolve_backing(
             effective, pack.minimum_backing(snapshot.graph), sandbox=sandbox
         )
-    # Auto-escalation into CONTAINER without Docker would train on an emulation the
-    # agent can't exploit, so fail loud. An explicit CONTAINER (``effective is
-    # backing``) is the caller's own choice.
     if effective is Backing.CONTAINER and effective is not backing and not docker_ok:
         raise RuntimeError(
             "this round needs the CONTAINER backing (a file-read/code-exec world or a "

--- a/packs/cyber_webapp/cyber_webapp/codegen/handlers.py
+++ b/packs/cyber_webapp/cyber_webapp/codegen/handlers.py
@@ -18,8 +18,6 @@ def build_handlers_and_routes(
     graph: WorldGraph,
     only_services: frozenset[str] | None = None,
 ) -> tuple[list[dict[str, str]], list[dict[str, str]], list[dict[str, str]]]:
-    # ``only_services`` restricts to one service's own endpoints — the per-service split
-    # that the networked CONTAINER backing realizes (each service is its own container).
     services_by_id: dict[str, Node] = {
         n.id: n for n in graph.nodes.values() if n.kind == "service"
     }
@@ -61,14 +59,11 @@ def build_handlers_and_routes(
         handler_name = _handler_name(service_name, endpoint_id)
         vuln_id = vuln_for_target.get(endpoint_id)
         if vuln_id is None:
-            # Service-level vulns also affect every endpoint of the service.
             vuln_id = vuln_for_target.get(service_id)
         if vuln_id is not None and vuln_id in vulns_by_id:
             vuln_node = vulns_by_id[vuln_id]
             body = _render_vuln_body(vuln_node)
         else:
-            # A benign endpoint may carry an LLM-realized body (admitted by
-            # realize_service_surface) — prefer it over the flat default stub.
             realized = endpoint.attrs.get("realized_handler")
             if isinstance(realized, str) and realized.strip():
                 body = _extract_handle_body(realized)
@@ -90,8 +85,6 @@ def build_handlers_and_routes(
 
 
 def _render_vuln_body(vuln_node: Node) -> str:
-    # A realized_handler was already admitted upstream (realize_admit), so use it
-    # verbatim like any rendered template.
     realized = vuln_node.attrs.get("realized_handler")
     if isinstance(realized, str) and realized.strip():
         return _extract_handle_body(realized)
@@ -107,7 +100,6 @@ def _render_vuln_body(vuln_node: Node) -> str:
 
 
 def _extract_handle_body(rendered: str) -> str:
-    # Inline as handler-local to avoid name collisions across handlers of the same kind.
     try:
         module = ast.parse(rendered)
     except SyntaxError as exc:
@@ -151,8 +143,6 @@ def _extract_handle_body(rendered: str) -> str:
 
 
 def _default_handler_body(service_name: str, path: str, kind: str) -> str:
-    # Per-kind bodies so the agent can't distinguish vulnerable from
-    # non-vulnerable endpoints purely by response shape.
     if kind == "api":
         body = (
             f'payload = {{"items": [], "next_cursor": None, '

--- a/packs/cyber_webapp/cyber_webapp/difficulty.py
+++ b/packs/cyber_webapp/cyber_webapp/difficulty.py
@@ -20,9 +20,6 @@ from cyber_webapp.mutation import (
 )
 from cyber_webapp.vulnerabilities import CATALOG
 
-# A curriculum re-weights by injecting its own difficulty_fn into the pool, not by
-# editing these. Per-class exploit hardness lives on the catalog
-# (Vulnerability.exploit_complexity), not here.
 _W_HOP = 10
 _W_PIVOT = 4
 _W_BOUNDARY = 3

--- a/packs/cyber_webapp/cyber_webapp/llm_realize.py
+++ b/packs/cyber_webapp/cyber_webapp/llm_realize.py
@@ -40,13 +40,8 @@ from cyber_webapp.reference_solver import (
 )
 from cyber_webapp.verify import perform, verdict_authored
 
-# Injected by the host: booting an episode needs the runtime, which the pack must not
-# import, so it takes the boot as a callback yielding the world's base_url.
 BootEpisode = Callable[[Snapshot, str], AbstractContextManager[str]]
 
-# The classes a prompt exists for. command_injection is the first realized class (#266);
-# sql_injection and path_traversal extend it across the response-leak and file-read
-# families. The rest follow the same shape.
 REALIZABLE_KINDS = (
     "command_injection",
     "sql_injection",
@@ -388,17 +383,11 @@ def _ssrf_prompt(param: str, ctx: str, params: Mapping[str, object]) -> str:
 
 
 def realization_request(graph: WorldGraph, kind: str) -> LLMRequest:
-    """The LLM request to realize `kind`'s handler, tailored to its sampled context.
-
-    Raises if `kind` has no prompt yet (see `REALIZABLE_KINDS`). The host runs this
-    against an `LLMBackend` and passes the returned handler through the admission gate.
-    """
+    """Raises if `kind` has no prompt (see `REALIZABLE_KINDS`)."""
     vuln = _vuln_of_kind(graph, kind)
     params = vuln.attrs["params"]
     if not isinstance(params, Mapping):
         raise PackError(f"{kind} vuln has no params mapping")
-    # Most classes inject through one query param; broken_authz/weak_credentials carry
-    # their own param names instead, so this stays optional.
     param = str(params.get("target_param", ""))
     if kind == "command_injection":
         ctx = str(params.get("inj_context", "separator"))
@@ -455,8 +444,6 @@ def handler_from_result(parsed_json: Mapping[str, object] | None) -> str:
 
 
 def _is_valid_handler(src: str) -> bool:
-    # A real LLM sometimes emits unparseable Python; codegen renders the handler by
-    # AST-parsing it, so an invalid one crashes the episode boot. Reject it up front.
     try:
         _extract_handle_body(src)
     except PackError:
@@ -480,10 +467,11 @@ _EXPLOIT_RETURN = (
 
 
 def exploit_request(graph: WorldGraph, kind: str) -> LLMRequest:
-    """The LLM request to author an (exploit, benign) pair for `kind`. The recipe
-    -- the technique plus the flag's LOCATION, never its value -- is read off the vuln's
-    meta if the world carries one (an LLM-built world supplies its own, #261), else
-    derived; so one generic prompt covers every kind."""
+    """Author an (exploit, benign) pair for `kind`.
+
+    The recipe carries the flag's LOCATION, never its value, so the proposal can't
+    echo a memorized flag. Read off `vuln.meta` if the world supplies one, else derived.
+    """
     vuln = _vuln_of_kind(graph, kind)
     endpoint_id = next(e.dst for e in graph.out_edges(vuln.id, "affects"))
     endpoint = graph.nodes[endpoint_id]
@@ -624,10 +612,10 @@ def realize_generated(
 
 @dataclass(frozen=True, slots=True)
 class NovelClass:
-    """An LLM-proposed vulnerability class the catalog does not have: a new `kind`, its
-    exploit `recipe` (technique + flag location, never the value), a vulnerable
-    `handler`, and the (exploit, benign) pair that proves it — verified as one coherent
-    unit behind the kind-agnostic gate."""
+    """An LLM-proposed vulnerability class outside the catalog.
+
+    `recipe` carries the flag's location, never its value.
+    """
 
     kind: str
     recipe: str
@@ -656,11 +644,11 @@ _CATALOG_KINDS = (
 
 
 def novel_class_request(graph: WorldGraph) -> LLMRequest:
-    """The LLM request to propose a NOVEL vulnerability class for a procedural skeleton
-    (#261): a class outside the catalog, leaking the same procedurally-planted flag from
-    the same db lookup endpoint. The prompt carries the endpoint, the param, the `state`
-    interface and the flag's LOCATION — never its value — so the proposal is honest by
-    construction (re-seed the flag, re-run the exploit; a genuine one still leaks)."""
+    """Request a NOVEL vulnerability class outside the catalog for a skeleton.
+
+    The prompt carries the flag's LOCATION, never its value, so the proposal is honest
+    by construction: re-seed the flag and re-run the exploit and a genuine one leaks.
+    """
     vuln = _novel_target(graph)
     params = vuln.attrs["params"]
     if not isinstance(params, Mapping):
@@ -710,17 +698,11 @@ def realize_novel(
     propose: Callable[[WorldGraph], NovelClass | None],
     boot: BootEpisode,
 ) -> Snapshot:
-    """Realize an LLM-PROPOSED vulnerability class the catalog does not have (#261).
+    """Realize an LLM-PROPOSED vulnerability class the catalog does not have.
 
-    `propose` reads the procedural skeleton and returns a coherent novel class, or None
-    to keep the skeleton. The proposal is stamped onto the skeleton's vuln (its `kind`,
-    the `realized_handler`, and the recipe on `meta`) and admitted by the SAME
-    kind-agnostic gate: the authored exploit must leak the flag and the benign must not,
-    and -- the integrity check -- the exploit must recover a FRESHLY re-seeded flag,
-    so a memorized value or a handler that hard-codes the flag is rejected. Accepted ->
-    re-freeze with the novel kind on the lineage; rejected -> return the skeleton
-    unchanged. The host injects `propose` (the LLM) and `boot` (an episode), so the pack
-    stays transport-free. Mutates `snapshot.graph` -- use the returned snapshot.
+    The proposal is admitted only if its exploit recovers a FRESHLY re-seeded flag, so a
+    memorized value or a handler that hard-codes the flag is rejected. Mutates
+    `snapshot.graph` — use the returned snapshot.
     """
     graph = snapshot.graph
     task = next(t for t in snapshot.tasks if t.meta.get("family") == "webapp.pentest")
@@ -775,8 +757,7 @@ def _novel_target(graph: WorldGraph) -> Node:
 def _novel_admits(
     snapshot: Snapshot, task_id: str, proposal: NovelClass, boot: BootEpisode
 ) -> bool:
-    # Function-local: importing reseed/sampling at module scope is a cycle.
-    from cyber_webapp.reseed import replant_flag
+    from cyber_webapp.reseed import replant_flag  # module-scope import cycles
     from cyber_webapp.sampling import generate_flag
 
     with boot(snapshot, task_id) as base_url:
@@ -785,8 +766,6 @@ def _novel_admits(
         )
     if not verdict.accepted:
         return False
-    # Integrity: a fresh flag + the SAME exploit must still recover it, so a memorized
-    # value or a flag-hard-coding handler (which passed the first gate) is caught.
     fresh = replant_flag(snapshot, generate_flag(random.Random(_RESEED_SEED)))
     with boot(fresh, task_id) as base_url:
         leaked = perform(
@@ -809,17 +788,16 @@ _SERVICE_SCHEMA: dict[str, object] = {
 
 
 def benign_endpoints_of(graph: WorldGraph, service_id: str) -> list[Node]:
-    """The service's endpoints with no affecting vuln — its realizable benign surface.
+    """Endpoints with no affecting vuln; empty if a vuln affects the whole service.
 
-    Empty if a vuln affects the whole service, or for the framework routes / and
-    /openapi.json (which the LLM must not author).
+    Excludes the framework routes / and /openapi.json.
     """
     vuln_eps = {
         e.dst
         for v in graph.by_kind("vulnerability")
         for e in graph.out_edges(v.id, "affects")
     }
-    if service_id in vuln_eps:  # a service-level vuln owns every endpoint
+    if service_id in vuln_eps:
         return []
     out: list[Node] = []
     for edge in graph.out_edges(service_id, "exposes"):
@@ -833,12 +811,7 @@ def benign_endpoints_of(graph: WorldGraph, service_id: str) -> list[Node]:
 
 
 def service_realization_request(graph: WorldGraph, service_id: str) -> LLMRequest:
-    """The LLM request to author realistic bodies for a service's benign endpoints.
-
-    Procedural keeps the vuln, flag and routes; the LLM only fills the non-vuln
-    endpoints with plausible content. The host runs this and passes the result through
-    `realize_service_surface`'s whole-service admission.
-    """
+    """Request realistic bodies for a service's benign (non-vuln) endpoints."""
     service = graph.nodes[service_id]
     kind = str(service.attrs.get("kind", "service"))
     name = str(service.attrs.get("name", service_id))

--- a/packs/cyber_webapp/cyber_webapp/mutation.py
+++ b/packs/cyber_webapp/cyber_webapp/mutation.py
@@ -19,18 +19,12 @@ from cyber_webapp.sampling import (
 from cyber_webapp.vulnerabilities import BODY_SHAPED_KINDS
 from cyber_webapp.vulnerabilities import CATALOG as VULN_CATALOG
 
-# Guarantees a remove pick exists even when the path-hit heuristic is silent.
 _REMOVE_RELEVANCE_FLOOR = 0.05
 
-# Fixed mid-value: no agent-data signal exists for a kind that isn't in
-# the world yet.
 _ADD_ABSENT_RELEVANCE = 0.5
 
-# Below remove relevance: rotating the exploit is a softer step than dropping the kind.
 _SWAP_PRESENT_RELEVANCE = 0.2
 
-# Above the decoy harden (0.5) so deepening the chain is the preferred frontier
-# step: it extends the required skill instead of adding an off-path vuln.
 _APPEND_HOP_RELEVANCE = 0.9
 
 _GATE_PATH = "/internal/vault"
@@ -121,9 +115,6 @@ def _harden_add_absent_mutations(
     services = list(graph.by_kind("service"))
     if not endpoints and not services:
         return []
-    # Prefer off-oracle surfaces for the decoy: a record-reading vuln on the
-    # flag's own surface can become a second path to it (easier). Only a
-    # preference — auto_evolve's consequence gate is the actual safeguard.
     oracle_endpoints, oracle_services = _oracle_path_targets(graph)
     endpoints_decoy_first = sorted(
         endpoints,
@@ -199,9 +190,6 @@ def _soften_remove_kind_mutation(
     relevance: float,
     score: float,
 ) -> Mutation:
-    # ``apply_patch`` drops dangling edges automatically; we enumerate
-    # them anyway so the patch reads as a complete diff and so callers
-    # inspecting ``edges_removed`` see the full picture.
     edge_ids: list[str] = []
     vuln_id_set = set(vuln_node_ids)
     for edge in graph.edges.values():
@@ -228,7 +216,6 @@ def _diversify_swap_kind_mutations(
     family_id: str,
     vulns_by_kind: Mapping[str, Sequence[str]],
 ) -> list[Mutation]:
-    # In-place update — affects edge keeps its id since src/kind/dst are unchanged.
     if not vulns_by_kind:
         return []
     networked = _is_networked(graph)
@@ -262,7 +249,7 @@ def _diversify_swap_kind_mutations(
         if alt_kind is None:
             continue
         if networked and alt_kind == _FOOTHOLD_KIND:
-            continue  # never introduce a second public foothold into a networked world
+            continue
         alt_entry = VULN_CATALOG[alt_kind]
         updated_node = Node(
             id=vuln_node.id,
@@ -427,7 +414,7 @@ def _soften_remove_hop_mutation(
     )
     relay = graph.nodes.get(relay_id) if relay_id is not None else None
     if relay is None or relay.attrs.get("kind") != "credential_gated_relay":
-        return None  # depth 1: nothing to collapse onto
+        return None
     relay_ep_id = _affects_target_id(graph, relay.id)
     relay_host = _service_of_endpoint(graph, relay_ep_id) if relay_ep_id else None
     store = _flag_store(graph)
@@ -688,7 +675,6 @@ def _oracle_path_targets(graph: WorldGraph) -> tuple[set[str], set[str]]:
 def _successful_path_hits(
     reports: Sequence[EpisodeReportLike],
 ) -> dict[str, int]:
-    # Status filtering already happened upstream — `requests_made` is the kept set.
     counts: dict[str, int] = {}
     for report in reports:
         requests_value = report.final_state.get("requests_made")
@@ -726,9 +712,6 @@ def _fresh_vuln_id(kind: str, existing_ids: set[str]) -> str:
 
 
 def _edge_id(src: str, kind: str, dst: str) -> str:
-    # Synthesizing from the triple keeps the same semantic edge stable
-    # across patches and avoids id collisions when several proposals
-    # are inspected side-by-side.
     return f"{src}--{kind}-->{dst}"
 
 
@@ -753,8 +736,6 @@ def _pick_alt_kind(
 
 
 def _oracle_allowed_shapes(graph: WorldGraph) -> frozenset[str] | None:
-    # Shapes that can read the flag from its store; see ``_ORACLE_SHAPES_FOR_LOOT``.
-    # ``None`` when there is no flag to constrain.
     flag = next(
         (n for n in graph.by_kind("secret") if n.attrs.get("kind") == "flag"), None
     )

--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -16,8 +16,6 @@ from cyber_webapp.ontology import ONTOLOGY_ID
 from cyber_webapp.vulnerabilities import BODY_SHAPED_KINDS
 from cyber_webapp.vulnerabilities import CATALOG as VULN_CATALOG
 
-# Secret formats modeled on real production credentials, not a CTF-style
-# ``ctf{...}`` / ``FLAG[...]`` wrapper.
 _HEX_ALPHABET = "0123456789abcdef"
 _BASE62 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 
@@ -134,7 +132,6 @@ _RECORD_KEYS: tuple[str, ...] = (
 )
 
 
-# Rides on ``WorldGraph.meta`` so codegen reads it.
 DISCOVERY_TITLES: tuple[str, ...] = (
     "Operations Portal API",
     "Customer Services Hub",
@@ -160,7 +157,6 @@ _CORP_DOMAINS: tuple[str, ...] = (
 _HOST_ENVS: tuple[str, ...] = ("prod", "stg", "infra")
 
 
-# Hyphen-safe so a name doubles as a docker host.
 _SERVICE_NAMES_BY_KIND: Mapping[str, tuple[str, ...]] = {
     "web": (
         "storefront",
@@ -212,7 +208,6 @@ _SERVICE_NAMES_BY_KIND: Mapping[str, tuple[str, ...]] = {
 }
 
 
-# Sampled per-build so exploit payloads differ across builds.
 _SQLI_PARAMS: tuple[str, ...] = ("q", "query", "search", "term", "filter", "ref")
 _SQLI_TABLES: tuple[str, ...] = (
     "records",
@@ -261,10 +256,6 @@ _PATH_TRAVERSAL_PARAMS: tuple[str, ...] = (
     "template",
     "page",
 )
-# Base dir the handler confines to (the confinement it fails to enforce);
-# distinct from the loot's private dirs so '../' or an absolute path escapes.
-# Varied depths (2-5) so the relative-traversal payload's "../" count is
-# build-specific rather than constant.
 _PATH_TRAVERSAL_BASE_DIRS: tuple[str, ...] = (
     "/var/data",
     "/srv/app/public",
@@ -280,9 +271,6 @@ _COMMAND_INJECTION_PARAMS: tuple[str, ...] = (
     "ip",
     "domain",
 )
-# Classes general sampling never places: each would leak the flag with no exploit on a
-# reachable endpoint. They go only inside the SSRF/cred-reuse chain or the company
-# recon disclosure.
 _INTERNAL_ONLY_KINDS: frozenset[str] = frozenset(
     {
         "metadata_credential_leak",
@@ -295,7 +283,6 @@ _INTERNAL_ONLY_KINDS: frozenset[str] = frozenset(
 
 _TOKEN_PARAMS: tuple[str, ...] = ("token", "api_key", "auth", "session", "key")
 
-# Actual depth is sampled per world and also bounded by the internal hosts available.
 _MAX_CHAIN_DEPTH = 3
 
 _RECON_PATHS: tuple[str, ...] = (
@@ -373,7 +360,6 @@ _DEFAULT_VULN_KIND_WEIGHTS: Mapping[str, int] = {
 
 _DB_STORE_KINDS: frozenset[str] = frozenset({"kv", "sql"})
 
-# ``file`` loot lives in an in-memory file map; the flag never lands on disk.
 _DEFAULT_LOOT_WEIGHTS: Mapping[str, int] = {"db": 7, "file": 3}
 _ORACLE_SHAPES_FOR_LOOT: Mapping[str, frozenset[str]] = {
     "db": frozenset({"response_leak"}),
@@ -394,8 +380,6 @@ _LOOT_FILE_NAMES: tuple[str, ...] = (
     "credentials.env",
     "token.dat",
 )
-# Benign files sharing the store with the flag so a file-read isn't a single-entry
-# giveaway.
 _DECOY_FILES: tuple[tuple[str, str], ...] = (
     ("/srv/app/public/index.html", "<h1>welcome</h1>"),
     ("/var/www/static/app.css", "body { margin: 0; }"),
@@ -405,8 +389,6 @@ _DECOY_FILES: tuple[tuple[str, str], ...] = (
 )
 
 
-# One is planted per file-loot world; its hint discloses the flag's dir so the path
-# is found by reading config, not only by guessing the pool.
 _HINT_CONFIG_PATHS: tuple[str, ...] = (
     "/etc/app/settings.conf",
     "/app/config.ini",
@@ -468,8 +450,6 @@ def _loot_store_attrs(loot_shape: str, name: str) -> dict[str, str]:
 
 
 def _sample_loot_path(rng: random.Random) -> str:
-    # High-entropy segment makes the absolute path unenumerable from the dir/name pools;
-    # the config hint derives from the same value to stay in sync.
     token = f"{rng.randrange(16**8):08x}"
     return f"{rng.choice(_LOOT_FILE_DIRS)}/{token}/{rng.choice(_LOOT_FILE_NAMES)}"
 
@@ -612,8 +592,6 @@ def sample_graph(
 
 
 def _annotate_exploit_recipes(graph: WorldGraph) -> None:
-    # Stamp the exploit recipe into meta (non-hashed, so the id is unchanged). Lazy
-    # import dodges a builder->solver cycle.
     from cyber_webapp.reference_solver import (
         SUPPORTED_KINDS,
         _vuln_of_kind,
@@ -625,7 +603,7 @@ def _annotate_exploit_recipes(graph: WorldGraph) -> None:
         try:
             vuln = _vuln_of_kind(graph, kind)
             recipe = exploit_recipe(graph, kind)
-        except Exception:  # noqa: BLE001 -- best-effort; the author derives it instead
+        except Exception:  # noqa: BLE001
             continue
         graph.nodes[vuln.id] = dataclasses.replace(
             vuln, meta={**vuln.meta, "exploit_recipe": recipe}
@@ -656,7 +634,6 @@ def _add_networks(graph: WorldGraph, company: bool) -> None:
             )
         )
         return
-    # A company estate is segmented: public in dmz, internal in an isolated segment.
     graph.add_node(
         Node(
             id="net_dmz",
@@ -708,9 +685,6 @@ def _sample_services(
 
 
 def _service_name(kind: str, used: set[str]) -> str:
-    # A realistic name from the kind's pool, distinct within the world. Deterministic
-    # (no rng draw) so adding it does not shift the structural sampling stream — the
-    # world is the same one, just better-named; the pool order gives the assignment.
     pool = _SERVICE_NAMES_BY_KIND.get(kind, (kind,))
     for name in pool:
         if name not in used:
@@ -730,8 +704,6 @@ def _sample_endpoints(
     prior: PackPrior | None,
     service: Mapping[str, str],
 ) -> list[Node]:
-    # Count clamped to ``len(pool)``: duplicate paths on one service would shadow each
-    # other in the codegen route table.
     count = _sample_int(rng, prior, "endpoints_per_service")
     pool = list(ENDPOINT_PATHS_BY_KIND.get(service["kind"], ("/",)))
     rng.shuffle(pool)
@@ -763,8 +735,6 @@ def _burn_retired_account_rng(rng: random.Random) -> None:
 
 
 def _public_url(service: Mapping[str, str], path: str) -> str:
-    # The mount convention lives in the graph, not the realizer, so the graph carries
-    # the truth.
     if service.get("exposure") == "public":
         return path
     return f"/svc/{service['name']}{path}"
@@ -778,9 +748,6 @@ def _sample_vulnerabilities(
     oracle_service_id: str | None = None,
     oracle_shapes: frozenset[str] = frozenset({"response_leak"}),
 ) -> None:
-    # The first placed vuln is the oracle: a kind whose exploit shape matches the loot,
-    # anchored to ``oracle_service_id``, so the flag is reachable by construction. The
-    # rest are decoys.
     count = _sample_int(rng, prior, "vuln_count")
     vuln_pin = [str(k) for k in (prior.topology.get("vuln_pin") or [])]
     pool = vuln_pin or _weighted_pool(prior, "vuln_kinds", exclude=_INTERNAL_ONLY_KINDS)
@@ -801,7 +768,6 @@ def _sample_vulnerabilities(
 
     rng.shuffle(endpoints)
 
-    # A file-only store has no table for a SQL-injection handler to query.
     store_kind: dict[str, str] = {
         n.id: str(n.attrs.get("kind", "")) for n in graph.by_kind("data_store")
     }
@@ -847,8 +813,6 @@ def _sample_vulnerabilities(
             if not candidates:
                 continue
             target_node = candidates[i % len(candidates)]
-        # Codegen renders one handler per (kind, endpoint); a duplicate pair is a dead
-        # node the uniqueness invariant rejects.
         if (kind, target_node.id) in placed_pairs:
             continue
         placed_pairs.add((kind, target_node.id))
@@ -875,8 +839,6 @@ def _sample_vulnerabilities(
                 "injection_site": str(target_node.attrs.get("path", "service")),
             },
         )
-        # Method follows the first vuln bound to the endpoint: a body-shaped kind makes
-        # it POST; a later co-located decoy must not change the decided method.
         if target_node.kind == "endpoint" and target_node.id not in bound_endpoints:
             bound_endpoints.add(target_node.id)
             if kind in BODY_SHAPED_KINDS:
@@ -903,8 +865,6 @@ def _forced_oracle(
     graph: WorldGraph,
     db_backed_services: set[str],
 ) -> tuple[str, Node] | None:
-    # Preferred = configured pool (lets a manifest steer the oracle class); fallback =
-    # any shape-matching catalog entry, so the world stays solvable.
     fallback = [
         k
         for k, v in VULN_CATALOG.items()
@@ -934,8 +894,6 @@ def _eligible_endpoints_for(
     graph: WorldGraph,
     db_backed_services: set[str],
 ) -> list[Node]:
-    # A db-requiring vuln on an endpoint with no ``backed_by`` data_store would query a
-    # table that does not exist.
     if vuln_kind not in VULN_KINDS_REQUIRING_DB:
         return endpoints
     eligible: list[Node] = []
@@ -1003,10 +961,7 @@ def default_vuln_params(
     target: Node,
     rng: random.Random,
 ) -> dict[str, object]:
-    """Sample per-build params for a vuln of ``kind``."""
     del target
-    # Each class samples a payload-context axis whose value demands a different exploit,
-    # so no fixed payload works across builds.
     if kind == "sql_injection":
         return {
             "target_param": rng.choice(_SQLI_PARAMS),
@@ -1041,8 +996,6 @@ def default_vuln_params(
             "trust_context": rng.choice(
                 ["single_token", "dual_factor", "encoded_token"]
             ),
-            # Confirm params for every context (not just dual_factor) so single /
-            # encoded recognize a foreign dual forge by its gate name and reject.
             "confirm_param": rng.choice(_BROKEN_AUTHZ_CONFIRM_PARAMS),
             "confirm_value": rng.choice(_BROKEN_AUTHZ_CONFIRM_VALUES),
             "confirm_pool": list(_BROKEN_AUTHZ_CONFIRM_PARAMS),

--- a/src/openrange/core/curriculum.py
+++ b/src/openrange/core/curriculum.py
@@ -39,6 +39,8 @@ Direction = Literal["harden", "soften", "diversify"]
 
 CurriculumPolicy = Callable[[Sequence[EpisodeReportLike]], "Direction | None"]
 
+_DIFFICULTY_STEP: dict[str, float] = {"harden": 0.2, "soften": -0.2}
+
 
 def direction_from_reports(
     reports: Sequence[EpisodeReportLike],
@@ -65,14 +67,8 @@ def _report_passed(report: EpisodeReportLike) -> bool:
         return False
 
 
-# True iff the candidate genuinely matches its claimed ``direction``; the caller
-# realizes + verifies, dropping a mutation whose static label lies. Absent a gate,
-# the family's label is trusted.
 EvolutionGate = Callable[["Snapshot", Mutation], bool]
 
-# True iff a candidate world is kept at pool-seeding time: the :data:`EvolutionGate`
-# verdict minus the mutation. Drops a live-unsolvable world before it seeds a
-# permanent zero-reward task.
 SeedGate = Callable[["Snapshot"], bool]
 
 
@@ -84,7 +80,7 @@ def _verify_realized(
 ) -> bool:
     task = next((t for t in snapshot.tasks if t.entrypoints), None)
     if task is None:
-        return True  # nothing realizable to check; let it through
+        return True
     svc = EpisodeService(pack, root)
     try:
         handle = svc.start_episode(snapshot, task.id)
@@ -105,7 +101,7 @@ def consequence_gate(
     root = Path(workdir)
 
     def gate(evolved: Snapshot, mutation: Mutation) -> bool:
-        del mutation  # the world is verified regardless of which move produced it
+        del mutation
         return _verify_realized(pack, root, evolved, accept)
 
     return gate
@@ -153,7 +149,7 @@ def auto_evolve(
     for chosen in _patch_candidates(pack, snapshot, reports, direction, llm=llm):
         try:
             evolved = _evolve_snapshot(snapshot, pack, chosen, max_repairs=max_repairs)
-        except Exception:  # noqa: BLE001 — pack-supplied code is untrusted
+        except Exception:  # noqa: BLE001
             continue
         if evolved is None or evolved.snapshot_id == snapshot.snapshot_id:
             continue
@@ -161,7 +157,7 @@ def auto_evolve(
             try:
                 if not gate(evolved, chosen):
                     continue
-            except Exception:  # noqa: BLE001 — caller-supplied gate is untrusted
+            except Exception:  # noqa: BLE001
                 continue
         return evolved
 
@@ -214,7 +210,7 @@ def _grow_snapshot(
     baseline = pack.default_prior()
     if baseline is None:
         return None
-    step = {"harden": 0.2, "soften": -0.2}.get(direction)
+    step = _DIFFICULTY_STEP.get(direction)
     if step is None:
         return None
     carried = snapshot.lineage.get("curriculum_difficulty")
@@ -240,8 +236,6 @@ def _grow_snapshot(
         return None
     grown = _with_grow_lineage(result, snapshot, direction, stepped)
     if grown.snapshot_id == snapshot.snapshot_id:
-        # Same world back means the builder ignored the bump; refuse it so lineage
-        # stays a chain.
         return None
     return grown
 
@@ -255,7 +249,6 @@ def _evolve_block(
     family: str | None = None,
     note: str = "",
 ) -> dict[str, object]:
-    # Absent fields are explicit None, not omitted, so every path shares one schema.
     return {
         "parent_snapshot_id": parent_snapshot_id,
         "direction": direction,
@@ -321,8 +314,6 @@ def _evolve_snapshot(
         dict(manifest_in) if isinstance(manifest_in, dict) else {}
     )
 
-    # Regenerate tasks so a shape-changing mutation reaches the agent's instruction,
-    # not just the graph.
     regenerated: list[TaskSpec] = []
     for family in pack.task_families():
         regenerated.extend(family.generate(evolved_graph, base_manifest, None))
@@ -344,8 +335,6 @@ def _evolve_snapshot(
         ),
         refs=(snapshot.snapshot_id,),
     )
-    # Carry grow difficulty across patch steps so a later grow resumes from it,
-    # not baseline.
     carried = snapshot.lineage.get("curriculum_difficulty")
     lineage = dict(result.lineage)
     if isinstance(carried, dict):

--- a/src/openrange/pool.py
+++ b/src/openrange/pool.py
@@ -34,7 +34,6 @@ RunRound = Callable[[list[PromptRow], list[Snapshot]], RoundReports]
 GateFactory = Callable[[Snapshot], EvolutionGate]
 
 _STALENESS_STEP = 0.1
-# Fresh children seat at this cap so a frontier world survives a round before eviction.
 _MAX_PRIORITY = 2.0
 
 
@@ -131,8 +130,6 @@ def _member_priority(
         if subgoals:
             achieved = sum(1 for hit in subgoals.values() if hit)
             gaps.append(1.0 - achieved / len(subgoals))
-    # Regret keeps a partly-solved world at the frontier that low reward-spread alone
-    # would retire.
     regret = sum(gaps) / len(gaps) if gaps else 0.0
     return learnability + regret
 
@@ -284,7 +281,6 @@ class WorldPool:
                 max_repairs=max_repairs,
             )
             if child is None:
-                # No admissible harder world passed the gate: the frontier is capped.
                 capped = True
                 continue
             difficulty = self._difficulty_fn(child)
@@ -320,9 +316,6 @@ class RoundMetrics:
     train_solve_rate: float
     held_out_solve_rate: float | None = None
     frontier_capped: bool = False
-    # Most any child advanced difficulty this round (signed; None if nothing evolved).
-    # Unlike frontier_capped, near-zero here means children admit but only creep on
-    # cosmetic decoys.
     difficulty_gain: float | None = None
 
     @property


### PR DESCRIPTION
Follow-up to #351 (now on `main`): a comment-discipline pass per `.rules` over the
files #351 touched. #351 merged before this strip landed, so `main` still carries the
verbose comments — this brings them to load-bearing WHY only.

## What changed
- **`#` comments ~halved** across the touched files (sampling 94→48, mutation 33→14,
  curriculum 15→2, pool 7→0, handlers 17→7, trl 19→11); `llm_realize`'s `#` comments to 0,
  its docstrings trimmed to the load-bearing line.
- **Root-fixed the justified ones** (per "fix the root where the comment is justified"):
  named `_DIFFICULTY_STEP` for the inline step dict; extracted `func_source` so the `exec`
  `# noqa` needs no prose.
- **Kept the irreducible domain gotchas** `.rules` says to keep (a hidden constraint /
  subtle invariant / bug workaround with no code fix): the rng-stream replay in
  `_burn_retired_account_rng`, the HIDDEN-credential verifier trap, the file-backed-flag
  networkize guard, Force-GET-for-the-SSRF-pivot.

Delete-by-default, skeptic-verified so load-bearing WHYs survive; no behavior change
(comment/docstring-only + two safe refactors).

## Verification
ruff · boundary · mypy (87 files) · **977 passed / 20 skipped** · coverage 88%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
