### PR TITLE
cyber: bind the consequence verdict to the default path, un-stick the soften, surface difficulty

### DIFF
--- a/examples/trl_grpo_cyber.ipynb
+++ b/examples/trl_grpo_cyber.ipynb
@@ -829,19 +829,11 @@
    "cell_type": "markdown",
    "id": "67c87834",
    "metadata": {},
-   "source": [
-    "## 9. Train on an evolving pool of worlds\n",
-    "\n",
-    "Training runs over a *pool* of worlds, not one. Each round samples a spread from the pool — a **mix floor** always keeps an easy one in — trains a GRPO pass, then evolves the worlds the model learns most from into harder admitted children, keeping the parents. The pool is the curriculum, and it sharpens as the model improves.\n",
-    "\n",
-    "Every evolved world is gated by the **consequence verifier** (`consequence_gate`): the reference breach must still leak the flag — and a benign request must not — or the candidate is rejected. So the curriculum can harden without ever shipping a world the agent (or the grader) can't actually solve. This is *self-verifying generation*: the verifier, not the generator, decides what counts as a real world. (It checks under the cheap PROCESS backing — faithful to CONTAINER, since the reference breach grades identically on both.)\n",
-    "\n",
-    "`run_pool_curriculum` drives the loop; `make_grpo_rounds` returns the `(train_round, eval_round)` pair. `eval_round` scores a **fenced held-out** pool under a frozen update — no learning — so the train-vs-held-out gap measures generalization, not memorization. One real round:"
-   ]
+   "source": "## 9. Train on an evolving pool of worlds\n\nTraining runs over a *pool* of worlds, not one. Each round samples a spread from the pool — a **mix floor** always keeps an easy one in — trains a GRPO pass, then evolves the worlds the model learns most from into harder admitted children, keeping the parents. The pool is the curriculum, and it sharpens as the model improves.\n\nEvery world is gated by the **consequence verifier** — both the **seeds** that enter the pool (`consequence_seed_gate`) and every **evolved** child (`consequence_gate`): the reference breach must leak the flag, **and** a benign request (any reachable endpoint) must not, or the world is rejected. So the pool never holds a world the agent (or the grader) can't actually solve — and never one a benign request already leaks — at seeding *or* after hardening. This is *self-verifying generation*: the verifier, not the generator, decides what counts as a real world. (It checks under the cheap PROCESS backing — faithful to CONTAINER, since the reference breach grades identically on both.)\n\n`run_pool_curriculum` drives the loop; `make_grpo_rounds` returns the `(train_round, eval_round)` pair. `eval_round` scores a **fenced held-out** pool under a frozen update — no learning — so the train-vs-held-out gap measures generalization, not memorization. One real round:"
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "9277400c",
    "metadata": {
     "execution": {
@@ -851,100 +843,8 @@
      "shell.execute_reply": "2026-06-21T09:15:05.734902Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '0.0001', 'num_tokens': '1298', 'completions/mean_length': '212', 'completions/min_length': '168', 'completions/max_length': '256', 'completions/clipped_ratio': '0.5', 'completions/mean_terminated_length': '168', 'completions/min_terminated_length': '168', 'completions/max_terminated_length': '168', 'tools/call_frequency': '0.5', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.3333', 'rewards/reward_func/std': '0', 'reward': '0.3333', 'reward_std': '0', 'frac_reward_zero_std': '1', 'entropy': '4.208', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '26.96', 'epoch': '0.5'}\n",
-      "{'train_runtime': '27.15', 'train_samples_per_second': '0.074', 'train_steps_per_second': '0.037', 'train_loss': '0', 'epoch': '0.5'}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '0', 'num_tokens': '1198', 'completions/mean_length': '162', 'completions/min_length': '68', 'completions/max_length': '256', 'completions/clipped_ratio': '0.5', 'completions/mean_terminated_length': '68', 'completions/min_terminated_length': '68', 'completions/max_terminated_length': '68', 'tools/call_frequency': '0.5', 'tools/failure_frequency': '0', 'rewards/reward_func/mean': '0.3333', 'rewards/reward_func/std': '0', 'reward': '0.3333', 'reward_std': '0', 'frac_reward_zero_std': '1', 'entropy': '5.926', 'clip_ratio/low_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/high_max': '0', 'clip_ratio/region_mean': '0', 'step_time': '23.13', 'epoch': '0.25'}\n",
-      "{'train_runtime': '23.31', 'train_samples_per_second': '0.086', 'train_steps_per_second': '0.043', 'train_loss': '0', 'epoch': '0.25'}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "one real GRPO round → train 0.000  held-out 0.000  gap +0.000\n"
-     ]
-    }
-   ],
-   "source": [
-    "from cyber_webapp.difficulty import world_difficulty\n",
-    "from cyber_webapp.verify import accepts\n",
-    "from openrange_trl import make_grpo_rounds\n",
-    "\n",
-    "from openrange.core import consequence_gate\n",
-    "from openrange.pool import EvalPool, WorldPool, run_pool_curriculum\n",
-    "\n",
-    "\n",
-    "def company(seed):\n",
-    "    return {\n",
-    "        \"world\": {\"goal\": \"recover the hidden flag from the internal estate\"},\n",
-    "        \"pack\": {\"id\": \"webapp\"},\n",
-    "        \"runtime\": {\"tick\": {\"mode\": \"off\"}},\n",
-    "        \"npc\": [],\n",
-    "        \"seed\": seed,\n",
-    "        \"topology\": \"chain\",\n",
-    "    }\n",
-    "\n",
-    "\n",
-    "pool = WorldPool.seed(\n",
-    "    pack,\n",
-    "    [company(s) for s in range(3)],\n",
-    "    difficulty_fn=lambda s: float(world_difficulty(s.graph)),\n",
-    "    family=\"webapp.pentest\",\n",
-    "    max_size=6,\n",
-    ")\n",
-    "held_out = EvalPool.seed(\n",
-    "    pack,\n",
-    "    [company(s) for s in (7, 8)],\n",
-    "    difficulty_fn=lambda s: float(world_difficulty(s.graph)),\n",
-    "    family=\"webapp.pentest\",\n",
-    ")\n",
-    "train_round, eval_round = make_grpo_rounds(\n",
-    "    pack,\n",
-    "    model=model,\n",
-    "    args=config,\n",
-    "    tools=[shell, submit],\n",
-    "    run_root=\"or-runs/cyber/pool\",\n",
-    "    processing_class=tokenizer,\n",
-    "    peft_config=lora,\n",
-    "    backing=BACKING,\n",
-    "    sandbox=True,\n",
-    ")\n",
-    "verify_gate = consequence_gate(pack, \"or-runs/cyber/gate\", accepts)\n",
-    "\n",
-    "\n",
-    "def verified_pentest(snap, mut):\n",
-    "    # keep a pentest-family child only if its reference breach still leaks\n",
-    "    return mut.family == \"webapp.pentest\" and verify_gate(snap, mut)\n",
-    "\n",
-    "\n",
-    "metrics = run_pool_curriculum(\n",
-    "    pool,\n",
-    "    train_round,\n",
-    "    rounds=1,\n",
-    "    pack=pack,\n",
-    "    groups=1,\n",
-    "    num_generations=num_generations,\n",
-    "    gate=verified_pentest,\n",
-    "    eval_pool=held_out,\n",
-    "    eval_round=eval_round,\n",
-    ")\n",
-    "m = metrics[0]\n",
-    "print(\n",
-    "    f\"one real GRPO round → train {m.train_solve_rate:.3f}  \"\n",
-    "    f\"held-out {m.held_out_solve_rate:.3f}  gap {m.generalization_gap:+.3f}\"\n",
-    ")"
-   ]
+   "outputs": [],
+   "source": "from cyber_webapp.difficulty import world_difficulty\nfrom cyber_webapp.verify import accepts\nfrom openrange_trl import make_grpo_rounds\n\nfrom openrange.core import consequence_gate, consequence_seed_gate\nfrom openrange.pool import EvalPool, WorldPool, run_pool_curriculum\n\n\ndef company(seed):\n    return {\n        \"world\": {\"goal\": \"recover the hidden flag from the internal estate\"},\n        \"pack\": {\"id\": \"webapp\"},\n        \"runtime\": {\"tick\": {\"mode\": \"off\"}},\n        \"npc\": [],\n        \"seed\": seed,\n        \"topology\": \"chain\",\n    }\n\n\n# Gate both ends with the consequence verifier: a world enters the pool, and every\n# evolved child stays, only if its breach leaks the flag and a benign request does not.\nseed_gate = consequence_seed_gate(pack, \"or-runs/cyber/gate\", accepts)\nverify_gate = consequence_gate(pack, \"or-runs/cyber/gate\", accepts)\n\n\ndef verified_pentest(snap, mut):\n    # keep a pentest-family child only if its reference breach still leaks\n    return mut.family == \"webapp.pentest\" and verify_gate(snap, mut)\n\n\npool = WorldPool.seed(\n    pack,\n    [company(s) for s in range(3)],\n    difficulty_fn=lambda s: float(world_difficulty(s.graph)),\n    family=\"webapp.pentest\",\n    max_size=6,\n    seed_gate=seed_gate,\n)\nheld_out = EvalPool.seed(\n    pack,\n    [company(s) for s in (7, 8)],\n    difficulty_fn=lambda s: float(world_difficulty(s.graph)),\n    family=\"webapp.pentest\",\n    seed_gate=seed_gate,\n)\ntrain_round, eval_round = make_grpo_rounds(\n    pack,\n    model=model,\n    args=config,\n    tools=[shell, submit],\n    run_root=\"or-runs/cyber/pool\",\n    processing_class=tokenizer,\n    peft_config=lora,\n    backing=BACKING,\n    sandbox=True,\n)\n\n\nmetrics = run_pool_curriculum(\n    pool,\n    train_round,\n    rounds=1,\n    pack=pack,\n    groups=1,\n    num_generations=num_generations,\n    gate=verified_pentest,\n    eval_pool=held_out,\n    eval_round=eval_round,\n)\nm = metrics[0]\nprint(\n    f\"one real GRPO round → train {m.train_solve_rate:.3f}  \"\n    f\"held-out {m.held_out_solve_rate:.3f}  gap {m.generalization_gap:+.3f}\"\n)"
   },
   {
    "cell_type": "markdown",
@@ -958,7 +858,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "1ee78765",
    "metadata": {
     "execution": {
@@ -968,77 +868,8 @@
      "shell.execute_reply": "2026-06-21T09:17:07.500029Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "agent solves : seeded [20.0, 33.7, 34.3]  ->  [20.0, 33.7, 34.3, 48.3]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "agent stuck  : seeded [20.0, 33.7, 34.3]  ->  [20.0, 33.7, 33.7, 34.3]\n"
-     ]
-    }
-   ],
-   "source": [
-    "def make_round(solving):\n",
-    "    def _round(rows, snapshots):\n",
-    "        by_id = {s.snapshot_id: s for s in snapshots}\n",
-    "        svc = EpisodeService(pack, \"or-runs/cyber/adaptive\", backing=BACKING)\n",
-    "        env = EpisodeEnv(\n",
-    "            service=svc, snapshots=by_id, tools=[shell, submit], sandbox=True\n",
-    "        )\n",
-    "        reports = {}\n",
-    "        try:\n",
-    "            for row in rows:\n",
-    "                snap = by_id[row[\"snapshot_id\"]]\n",
-    "                env.reset(snapshot_id=row[\"snapshot_id\"], task_id=row[\"task_id\"])\n",
-    "                if solving:\n",
-    "                    breach(env, snap)\n",
-    "                else:\n",
-    "                    env.shell(curl(entry_url(snap)))\n",
-    "                env._finalize()\n",
-    "                key = (row[\"snapshot_id\"], row[\"task_id\"])\n",
-    "                reports.setdefault(key, []).append(env.report)\n",
-    "            return reports\n",
-    "        finally:\n",
-    "            svc.close()\n",
-    "\n",
-    "    return _round\n",
-    "\n",
-    "\n",
-    "def diff_band(p):\n",
-    "    return sorted(world_difficulty(s.graph) for s in p.snapshots())\n",
-    "\n",
-    "\n",
-    "runs = {}\n",
-    "for label, solving in ((\"solves\", True), (\"stuck\", False)):\n",
-    "    p = WorldPool.seed(\n",
-    "        pack,\n",
-    "        [company(s) for s in range(3)],\n",
-    "        difficulty_fn=lambda s: float(world_difficulty(s.graph)),\n",
-    "        family=\"webapp.pentest\",\n",
-    "        max_size=8,\n",
-    "    )\n",
-    "    seeded = diff_band(p)\n",
-    "    run_pool_curriculum(\n",
-    "        p,\n",
-    "        make_round(solving),\n",
-    "        rounds=3,\n",
-    "        pack=pack,\n",
-    "        groups=len(p),\n",
-    "        num_generations=1,\n",
-    "        gate=verified_pentest,\n",
-    "    )\n",
-    "    runs[label] = p\n",
-    "    print(f\"agent {label:6} : seeded {seeded}  ->  {diff_band(p)}\")\n",
-    "\n",
-    "pool = runs[\"solves\"]"
-   ]
+   "outputs": [],
+   "source": "def make_round(solving):\n    def _round(rows, snapshots):\n        by_id = {s.snapshot_id: s for s in snapshots}\n        svc = EpisodeService(pack, \"or-runs/cyber/adaptive\", backing=BACKING)\n        env = EpisodeEnv(\n            service=svc, snapshots=by_id, tools=[shell, submit], sandbox=True\n        )\n        reports = {}\n        try:\n            for row in rows:\n                snap = by_id[row[\"snapshot_id\"]]\n                env.reset(snapshot_id=row[\"snapshot_id\"], task_id=row[\"task_id\"])\n                if solving:\n                    breach(env, snap)\n                else:\n                    env.shell(curl(entry_url(snap)))\n                env._finalize()\n                key = (row[\"snapshot_id\"], row[\"task_id\"])\n                reports.setdefault(key, []).append(env.report)\n            return reports\n        finally:\n            svc.close()\n\n    return _round\n\n\ndef diff_band(p):\n    return sorted(world_difficulty(s.graph) for s in p.snapshots())\n\n\nruns = {}\nfor label, solving in ((\"solves\", True), (\"stuck\", False)):\n    p = WorldPool.seed(\n        pack,\n        [company(s) for s in range(3)],\n        difficulty_fn=lambda s: float(world_difficulty(s.graph)),\n        family=\"webapp.pentest\",\n        max_size=8,\n        seed_gate=seed_gate,\n    )\n    seeded = diff_band(p)\n    run_pool_curriculum(\n        p,\n        make_round(solving),\n        rounds=3,\n        pack=pack,\n        groups=len(p),\n        num_generations=1,\n        gate=verified_pentest,\n    )\n    runs[label] = p\n    print(f\"agent {label:6} : seeded {seeded}  ->  {diff_band(p)}\")\n\npool = runs[\"solves\"]"
   },
   {
    "cell_type": "markdown",

--- a/packs/cyber_webapp/cyber_webapp/codegen/handlers.py
+++ b/packs/cyber_webapp/cyber_webapp/codegen/handlers.py
@@ -151,22 +151,33 @@ def _default_handler_body(service_name: str, path: str, kind: str) -> str:
             "json.dumps(payload).encode()\n"
         )
     elif kind == "db":
+        # A benign lookup enforces access control: it never serves a guarded
+        # (HIDDEN) value. Leaking the flag is the job of a vuln's own handler
+        # (the bypass), not of the default endpoint a sibling route renders.
         body = (
             'schema = state["schema"]\n'
             'table = schema["table"]\n'
             'key_col = schema["key_column"]\n'
             'value_col = schema["value_column"]\n'
+            'guarded = set(state.get("guarded", {}).values())\n'
             'requested = (query.get("key", [""]) or [""])[0]\n'
             'cursor = state["db"].cursor()\n'
             "if requested:\n"
             '    sql = f"SELECT {key_col}, {value_col} FROM {table} WHERE '
             '{key_col} = ?"\n'
             "    rows = [\n"
-            "        dict(r) for r in cursor.execute(sql, (requested,)).fetchall()\n"
+            "        d for d in (dict(r) for r in "
+            "cursor.execute(sql, (requested,)).fetchall())\n"
+            "        if str(d.get(value_col, '')) not in guarded\n"
             "    ]\n"
             "else:\n"
-            '    sql = f"SELECT {key_col} FROM {table} ORDER BY {key_col}"\n'
-            "    rows = [{key_col: r[0]} for r in cursor.execute(sql).fetchall()]\n"
+            '    sql = f"SELECT {key_col}, {value_col} FROM {table} '
+            'ORDER BY {key_col}"\n'
+            "    rows = [\n"
+            "        {key_col: d[key_col]} for d in (dict(r) for r in "
+            "cursor.execute(sql).fetchall())\n"
+            "        if str(d.get(value_col, '')) not in guarded\n"
+            "    ]\n"
             'payload = {"rows": rows, "count": len(rows)}\n'
             'return 200, {"Content-Type": "application/json"}, '
             "json.dumps(payload).encode()\n"

--- a/packs/cyber_webapp/cyber_webapp/codegen/handlers.py
+++ b/packs/cyber_webapp/cyber_webapp/codegen/handlers.py
@@ -151,9 +151,8 @@ def _default_handler_body(service_name: str, path: str, kind: str) -> str:
             "json.dumps(payload).encode()\n"
         )
     elif kind == "db":
-        # A benign lookup enforces access control: it never serves a guarded
-        # (HIDDEN) value. Leaking the flag is the job of a vuln's own handler
-        # (the bypass), not of the default endpoint a sibling route renders.
+        # A sibling route shares this table; the benign default must not serve a
+        # guarded (HIDDEN) value here — only the vuln's bypass may.
         body = (
             'schema = state["schema"]\n'
             'table = schema["table"]\n'

--- a/packs/cyber_webapp/cyber_webapp/mutation.py
+++ b/packs/cyber_webapp/cyber_webapp/mutation.py
@@ -20,6 +20,9 @@ from cyber_webapp.vulnerabilities import BODY_SHAPED_KINDS
 from cyber_webapp.vulnerabilities import CATALOG as VULN_CATALOG
 
 _REMOVE_RELEVANCE_FLOOR = 0.05
+# A chain-collapse soften justified by the agent's foothold engagement must outrank a
+# cosmetic decoy-removal, so its relevance floors above _REMOVE_RELEVANCE_FLOOR.
+_HOP_SOFTEN_FLOOR = 0.5
 
 _ADD_ABSENT_RELEVANCE = 0.5
 
@@ -83,19 +86,14 @@ def available_mutations(
             ),
         )
 
-    # Rescues an agent stuck ON the chain, which decoy-removal can't. Relevance is the
-    # agent's whole-chain engagement, so it outranks decoy-removal only when the chain
-    # is the focus.
-    chain_vuln_ids = [
-        v.id
-        for v in graph.by_kind("vulnerability")
-        if str(v.attrs.get("kind", "")).startswith("credential")
-    ]
-    hop_soften = _soften_remove_hop_mutation(
-        graph,
-        family_id,
-        _exploitation_score(chain_vuln_ids, paths_per_vuln, path_hits),
-    )
+    # Rescues an agent stuck ON the chain, which decoy-removal can't. The chain is
+    # reached only through the public SSRF foothold; the internal hops are proxied
+    # server-side and never reach requests_made -- foothold engagement is the one
+    # observable signal that the agent is on the chain. Floored above decoy-removal
+    # so a chain-engaged agent eases the chain, not a cosmetic decoy.
+    engagement = _chain_engagement_score(graph, path_hits)
+    hop_relevance = max(engagement, _HOP_SOFTEN_FLOOR) if engagement > 0.0 else 0.0
+    hop_soften = _soften_remove_hop_mutation(graph, family_id, hop_relevance)
     if hop_soften is not None:
         options.append(hop_soften)
 
@@ -702,6 +700,35 @@ def _exploitation_score(
     hits = sum(path_hits.get(p, 0) for p in affected)
     total = sum(path_hits.values())
     return min(1.0, hits / max(1, total))
+
+
+def _public_foothold_paths(graph: WorldGraph) -> set[str]:
+    # The agent reaches the chain through the SSRF endpoint; requests_made logs the
+    # requested URL (``public_url``), so match on that, not the bare ``path`` attr.
+    urls: set[str] = set()
+    for vuln in graph.by_kind("vulnerability"):
+        if str(vuln.attrs.get("kind", "")) != "ssrf":
+            continue
+        for edge in graph.out_edges(vuln.id, "affects"):
+            endpoint = graph.nodes.get(edge.dst)
+            if endpoint is None or endpoint.kind != "endpoint":
+                continue
+            service = _service_of_endpoint(graph, endpoint.id)
+            if service is not None and service.attrs.get("exposure") == "public":
+                url = str(endpoint.attrs.get("public_url", ""))
+                if url:
+                    urls.add(url)
+    return urls
+
+
+def _chain_engagement_score(graph: WorldGraph, path_hits: Mapping[str, int]) -> float:
+    foothold = _public_foothold_paths(graph)
+    if not foothold or not path_hits:
+        return 0.0
+    hits = sum(
+        count for path, count in path_hits.items() if path.split("?", 1)[0] in foothold
+    )
+    return min(1.0, hits / max(1, sum(path_hits.values())))
 
 
 def _fresh_vuln_id(kind: str, existing_ids: set[str]) -> str:

--- a/packs/cyber_webapp/cyber_webapp/mutation.py
+++ b/packs/cyber_webapp/cyber_webapp/mutation.py
@@ -20,8 +20,7 @@ from cyber_webapp.vulnerabilities import BODY_SHAPED_KINDS
 from cyber_webapp.vulnerabilities import CATALOG as VULN_CATALOG
 
 _REMOVE_RELEVANCE_FLOOR = 0.05
-# A chain-collapse soften justified by the agent's foothold engagement must outrank a
-# cosmetic decoy-removal, so its relevance floors above _REMOVE_RELEVANCE_FLOOR.
+# Above _REMOVE_RELEVANCE_FLOOR so a chain soften outranks decoy-removal.
 _HOP_SOFTEN_FLOOR = 0.5
 
 _ADD_ABSENT_RELEVANCE = 0.5
@@ -86,11 +85,8 @@ def available_mutations(
             ),
         )
 
-    # Rescues an agent stuck ON the chain, which decoy-removal can't. The chain is
-    # reached only through the public SSRF foothold; the internal hops are proxied
-    # server-side and never reach requests_made -- foothold engagement is the one
-    # observable signal that the agent is on the chain. Floored above decoy-removal
-    # so a chain-engaged agent eases the chain, not a cosmetic decoy.
+    # Internal chain hops are proxied server-side and never reach requests_made, so the
+    # public SSRF foothold is the only observable signal the agent is on the chain.
     engagement = _chain_engagement_score(graph, path_hits)
     hop_relevance = max(engagement, _HOP_SOFTEN_FLOOR) if engagement > 0.0 else 0.0
     hop_soften = _soften_remove_hop_mutation(graph, family_id, hop_relevance)
@@ -703,8 +699,7 @@ def _exploitation_score(
 
 
 def _public_foothold_paths(graph: WorldGraph) -> set[str]:
-    # The agent reaches the chain through the SSRF endpoint; requests_made logs the
-    # requested URL (``public_url``), so match on that, not the bare ``path`` attr.
+    # requests_made logs the endpoint's public_url, not its path attr -- match on that.
     urls: set[str] = set()
     for vuln in graph.by_kind("vulnerability"):
         if str(vuln.attrs.get("kind", "")) != "ssrf":

--- a/packs/cyber_webapp/cyber_webapp/verify.py
+++ b/packs/cyber_webapp/cyber_webapp/verify.py
@@ -63,9 +63,6 @@ def perform(base_url: str, request: Request) -> str:
 
 
 def _benign_sweep(graph: WorldGraph, base_url: str) -> dict[str, str]:
-    """Benign GET bodies for every directly reachable endpoint. A networked world's
-    internal services answer only through the pivot, so only public endpoints are
-    swept; a flat world exposes every endpoint directly."""
     networked = _is_networked(graph)
     service_of_endpoint = {
         e.dst: e.src for e in graph.edges.values() if e.kind == "exposes"
@@ -74,6 +71,7 @@ def _benign_sweep(graph: WorldGraph, base_url: str) -> dict[str, str]:
     bodies: dict[str, str] = {}
     for endpoint in graph.by_kind("endpoint"):
         service = services.get(service_of_endpoint.get(endpoint.id, ""))
+        # internal services answer only via the pivot; a direct fetch can't reach them
         if (
             networked
             and service is not None

--- a/packs/cyber_webapp/cyber_webapp/verify.py
+++ b/packs/cyber_webapp/cyber_webapp/verify.py
@@ -18,7 +18,11 @@ from graphschema import WorldGraph
 from openrange_pack_sdk import Snapshot
 
 from cyber_webapp import _is_networked
-from cyber_webapp.realize_admit import AdmissionVerdict, classify_admission
+from cyber_webapp.realize_admit import (
+    AdmissionVerdict,
+    classify_admission,
+    classify_service_admission,
+)
 from cyber_webapp.reference_solver import (
     Request,
     exploit_and_benign,
@@ -58,28 +62,64 @@ def perform(base_url: str, request: Request) -> str:
     return raw.decode("utf-8", "replace")
 
 
+def _benign_sweep(graph: WorldGraph, base_url: str) -> dict[str, str]:
+    """Benign GET bodies for every directly reachable endpoint. A networked world's
+    internal services answer only through the pivot, so only public endpoints are
+    swept; a flat world exposes every endpoint directly."""
+    networked = _is_networked(graph)
+    service_of_endpoint = {
+        e.dst: e.src for e in graph.edges.values() if e.kind == "exposes"
+    }
+    services = {n.id: n for n in graph.nodes.values() if n.kind == "service"}
+    bodies: dict[str, str] = {}
+    for endpoint in graph.by_kind("endpoint"):
+        service = services.get(service_of_endpoint.get(endpoint.id, ""))
+        if (
+            networked
+            and service is not None
+            and service.attrs.get("exposure") != "public"
+        ):
+            continue
+        public_url = str(endpoint.attrs.get("public_url", ""))
+        if public_url:
+            bodies[public_url] = _fetch(base_url + public_url)
+    return bodies
+
+
 def verdict(graph: WorldGraph, base_url: str, entry_path: str) -> AdmissionVerdict:
     """Drive the reference breach against an already-running world at ``base_url`` and
-    classify whether the exploit leaks while a benign request to ``entry_path`` does
-    not."""
+    classify it whole-world: the exploit must leak, the benign entry must not, and NO
+    directly reachable benign endpoint may leak — a sibling endpoint that serves the
+    flag would make the world winnable without the intended exploit."""
 
     def fetch(path: str) -> str:
         return _fetch(base_url + str(path))
 
     benign = fetch(entry_path)
+    reachable = _benign_sweep(graph, base_url)
     if _is_networked(graph):
         try:
             terminal = solve_chain(graph, fetch).terminal
         except Exception:  # noqa: BLE001 — a chain that won't drive isn't solvable
             return AdmissionVerdict(False, False, False, "reference breach failed")
-        return classify_admission(graph, terminal, benign)
+        return classify_service_admission(
+            graph,
+            oracle_exploit_body=terminal,
+            oracle_benign_body=benign,
+            benign_endpoint_bodies=reachable,
+            root_ok=True,
+        )
     for vuln in graph.by_kind("vulnerability"):
         try:
             exploit_req, benign_req = exploit_and_benign(graph, str(vuln.attrs["kind"]))
         except Exception:  # noqa: BLE001 — no reference exploit for this kind
             continue
-        return classify_admission(
-            graph, perform(base_url, exploit_req), perform(base_url, benign_req)
+        return classify_service_admission(
+            graph,
+            oracle_exploit_body=perform(base_url, exploit_req),
+            oracle_benign_body=perform(base_url, benign_req),
+            benign_endpoint_bodies=reachable,
+            root_ok=True,
         )
     return AdmissionVerdict(False, False, False, "no reference exploit to verify")
 
@@ -87,13 +127,13 @@ def verdict(graph: WorldGraph, base_url: str, entry_path: str) -> AdmissionVerdi
 def accepts(snapshot: Snapshot, base_url: str) -> bool:
     """True iff the evolved world's reference breach leaks (a benign request does not).
     The shape ``consequence_gate`` wants: it realizes the world, this drives the breach.
-    A world with no pentest task or entrypoint can't be assessed, so it passes."""
+    A world with no pentest task or entrypoint can't be assessed, so it is rejected."""
     task = next(
         (t for t in snapshot.tasks if t.meta.get("family") == "webapp.pentest"),
         None,
     )
     if task is None or not task.entrypoints:
-        return True
+        return False
     entry = str(snapshot.graph.nodes[task.entrypoints[0]].attrs["public_url"])
     return verdict(snapshot.graph, base_url, entry).accepted
 

--- a/src/openrange/core/__init__.py
+++ b/src/openrange/core/__init__.py
@@ -16,6 +16,7 @@ from openrange.core.curriculum import (
     Direction,
     auto_evolve,
     consequence_gate,
+    consequence_seed_gate,
     direction_from_reports,
 )
 from openrange.core.errors import (
@@ -44,6 +45,7 @@ __all__ = [
     "admit",
     "auto_evolve",
     "consequence_gate",
+    "consequence_seed_gate",
     "direction_from_reports",
     "snapshot_to_dict",
     "validate_task_bindings",

--- a/src/openrange/core/curriculum.py
+++ b/src/openrange/core/curriculum.py
@@ -78,8 +78,7 @@ def _verify_realized(
     snapshot: Snapshot,
     accept: Callable[[Snapshot, str], bool],
 ) -> bool:
-    # No realizable task means the world can't be driven to prove it leaks; an
-    # unassessable world is not admissible, so it fails rather than passing blind.
+    # No realizable task: fail closed (reject) rather than pass blind.
     task = next((t for t in snapshot.tasks if t.entrypoints), None)
     if task is None:
         return False

--- a/src/openrange/core/curriculum.py
+++ b/src/openrange/core/curriculum.py
@@ -78,9 +78,11 @@ def _verify_realized(
     snapshot: Snapshot,
     accept: Callable[[Snapshot, str], bool],
 ) -> bool:
+    # No realizable task means the world can't be driven to prove it leaks; an
+    # unassessable world is not admissible, so it fails rather than passing blind.
     task = next((t for t in snapshot.tasks if t.entrypoints), None)
     if task is None:
-        return True
+        return False
     svc = EpisodeService(pack, root)
     try:
         handle = svc.start_episode(snapshot, task.id)
@@ -97,7 +99,7 @@ def consequence_gate(
     """An :data:`EvolutionGate` that realizes each evolved world and keeps it only when
     ``accept(snapshot, base_url)`` confirms it — a pack-supplied check run against the
     realized world. ``accept`` is the pack's verdict, so core needs no pack import. A
-    world with no realizable task can't be checked and passes through."""
+    world with no realizable task can't be checked, so it is rejected."""
     root = Path(workdir)
 
     def gate(evolved: Snapshot, mutation: Mutation) -> bool:

--- a/src/openrange/dashboard/static/dashboard.js
+++ b/src/openrange/dashboard/static/dashboard.js
@@ -1745,6 +1745,7 @@ function renderBuildPanel() {
     <dl class="kv-grid">
       <dt>Pack</dt><dd>${escapeHtml(target.pack?.id || "—")}</dd>
       <dt>Builder</dt><dd>${escapeHtml(target.manifest?.builder || "default")}</dd>
+      <dt>Difficulty</dt><dd>${target.world_difficulty != null ? Number(target.world_difficulty).toFixed(1) : "—"}</dd>
       <dt>NPCs</dt><dd>${(target.manifest?.npc || []).map((n) => escapeHtml(n.type)).join(", ") || "—"}</dd>
       <dt>Mode</dt><dd>${escapeHtml(target.manifest?.mode || "simulation")}</dd>
     </dl>`);

--- a/src/openrange/dashboard/view.py
+++ b/src/openrange/dashboard/view.py
@@ -460,6 +460,7 @@ def _lineage_node(snapshot: Snapshot) -> dict[str, object]:
     manifest.pop("_evolve", None)
     difficulty = lineage.get("curriculum_difficulty")
     curriculum = dict(difficulty) if isinstance(difficulty, Mapping) else {}
+    solve_cost = lineage.get("world_difficulty")
     return {
         "id": snapshot.snapshot_id,
         "parent_id": _parent_snapshot_id(lineage),
@@ -467,6 +468,9 @@ def _lineage_node(snapshot: Snapshot) -> dict[str, object]:
         "manifest": manifest,
         "pack": {"id": lineage.get("pack"), "version": lineage.get("pack_version")},
         "curriculum": curriculum,
+        "world_difficulty": float(solve_cost)
+        if isinstance(solve_cost, int | float)
+        else None,
         "evolve": dict(evolve) if evolve else None,
         "graph": graph_projection(snapshot.graph),
     }

--- a/src/openrange/pool.py
+++ b/src/openrange/pool.py
@@ -9,6 +9,8 @@ Difficulty is injected by the caller so the pool stays pack-agnostic.
 
 from __future__ import annotations
 
+import dataclasses
+import logging
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 
@@ -24,6 +26,8 @@ from openrange.core.curriculum import (
 )
 from openrange.core.episode import EpisodeReport
 from openrange.training import Reward, episode_reward
+
+_LOG = logging.getLogger(__name__)
 
 RewardFn = Callable[[EpisodeReport], Reward]
 
@@ -72,6 +76,16 @@ def _members_of(
         )
 
 
+def _stamp_difficulty(snapshot: Snapshot, difficulty: float) -> Snapshot:
+    # Persist the solve-cost onto the evolved snapshot's lineage so the dashboard
+    # can surface a difficulty trend. The initial builder stamps it; evolve re-admits
+    # through a core builder that can't. The snapshot id is graph-addressed, so adding
+    # lineage metadata leaves the id unchanged.
+    return dataclasses.replace(
+        snapshot, lineage={**dict(snapshot.lineage), "world_difficulty": difficulty}
+    )
+
+
 def _gated_members(
     pack: Pack,
     manifests: Sequence[Mapping[str, object]],
@@ -87,6 +101,11 @@ def _gated_members(
         if isinstance(result, AdmissionFailure):
             continue
         if seed_gate is not None and not seed_gate(result):
+            _LOG.warning(
+                "seed world %s dropped: consequence gate rejected it "
+                "(unsolvable, or a benign request already leaks)",
+                result.snapshot_id,
+            )
             continue
         _members_of(result, difficulty_fn(result), family, members)
     return members
@@ -284,6 +303,7 @@ class WorldPool:
                 capped = True
                 continue
             difficulty = self._difficulty_fn(child)
+            child = _stamp_difficulty(child, difficulty)
             gains.append(difficulty - member.difficulty)
             for task in child.tasks:
                 if str(task.meta.get("family", "")) != member.family:

--- a/src/openrange/pool.py
+++ b/src/openrange/pool.py
@@ -77,10 +77,9 @@ def _members_of(
 
 
 def _stamp_difficulty(snapshot: Snapshot, difficulty: float) -> Snapshot:
-    # Persist the solve-cost onto the evolved snapshot's lineage so the dashboard
-    # can surface a difficulty trend. The initial builder stamps it; evolve re-admits
-    # through a core builder that can't. The snapshot id is graph-addressed, so adding
-    # lineage metadata leaves the id unchanged.
+    # The seed builder stamps world_difficulty for the dashboard; evolve re-admits
+    # through pack-agnostic core that can't, so re-stamp here. Lineage is outside the
+    # graph content hash, so the snapshot_id (the members key) stays stable.
     return dataclasses.replace(
         snapshot, lineage={**dict(snapshot.lineage), "world_difficulty": difficulty}
     )

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -32,6 +32,7 @@ from cyber_webapp.difficulty import (
 )
 from cyber_webapp.invariants import unique_vuln_per_endpoint
 from cyber_webapp.mutation import _oracle_path_targets, available_mutations
+from cyber_webapp.realize_admit import classify_service_admission
 from cyber_webapp.reference_solver import solve_chain
 from cyber_webapp.verify import accepts, verdict
 from graphschema import Edge, Node, Visibility, WorldGraph
@@ -1421,3 +1422,117 @@ def test_warm_pool_reuses_real_containers(tmp_path: Path) -> None:
     finally:
         svc.close()
     assert not svc._warm
+
+
+_FLAT_SQLI = {
+    "pack": {"id": "webapp"},
+    "runtime": {"tick": {"mode": "off"}},
+    "npc": [],
+    "vuln": {"pin": [{"kind": "sql_injection"}]},
+    "loot": {"db": 1, "file": 0},
+}
+
+
+def _flat_sqli_with_sibling_db() -> Snapshot:
+    # A db-loot world whose db service exposes more than one endpoint: the SQLi oracle
+    # plus a sibling on the default handler — the case that used to leak the flag by a
+    # plain ?key lookup with no exploit.
+    for seed in range(16):
+        snap = _admit({**_FLAT_SQLI, "seed": seed})
+        svc_of_ep = {
+            e.dst: e.src for e in snap.graph.edges.values() if e.kind == "exposes"
+        }
+        db_eps = sum(
+            1
+            for ep in snap.graph.by_kind("endpoint")
+            if snap.graph.nodes.get(svc_of_ep.get(ep.id, "")) is not None
+            and snap.graph.nodes[svc_of_ep[ep.id]].attrs.get("kind") == "db"
+        )
+        if db_eps >= 2:
+            return snap
+    pytest.skip("no flat sqli world with a sibling db endpoint in range(16)")
+
+
+def test_benign_db_endpoint_never_serves_the_flag(tmp_path: Path) -> None:
+    # The honest contract: a benign request never returns a guarded (HIDDEN) value; the
+    # vuln's own handler is the only path that leaks it. A sibling default-db endpoint
+    # used to hand over the flag for ?key=<flagkey> with no exploit (the sibling leak).
+    snap = _flat_sqli_with_sibling_db()
+    graph = snap.graph
+    holds = {e.src: e.dst for e in graph.edges.values() if e.kind == "holds"}
+    flag_record = next(rid for rid, sid in holds.items() if sid == "secret_flag")
+    flag_key = str(graph.nodes[flag_record].attrs["key"])
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+
+    task = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+    svc = EpisodeService(WebappPack(), tmp_path)
+    try:
+        base = svc.base_url(svc.start_episode(snap, task.id))
+        for ep in graph.by_kind("endpoint"):
+            url = str(ep.attrs["public_url"])
+            assert flag not in _http(base, f"{url}?key={flag_key}")
+            assert flag not in _http(base, url)
+        # The intended SQLi exploit still leaks, and the whole-world verdict accepts.
+        entry = str(graph.nodes[task.entrypoints[0]].attrs["public_url"])
+        outcome = verdict(graph, base, entry)
+        assert outcome.accepted
+        assert "no benign endpoint leaks" in outcome.reason
+    finally:
+        svc.close()
+
+
+def test_whole_world_verdict_rejects_a_sibling_leak() -> None:
+    # The guarantee verify.verdict now enforces: even when the oracle is honest (its
+    # exploit leaks and its benign does not), a sibling benign endpoint that serves the
+    # flag rejects the world — it would be winnable without the intended exploit.
+    graph = _admit({**_FLAT_SQLI, "seed": 0}).graph
+    flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
+    outcome = classify_service_admission(
+        graph,
+        oracle_exploit_body=flag,
+        oracle_benign_body="{}",
+        benign_endpoint_bodies={"/orders": "{}", "/leak": flag},
+        root_ok=True,
+    )
+    assert not outcome.accepted
+    assert "benign endpoint" in outcome.reason
+
+
+def test_evolved_snapshot_persists_world_difficulty(tmp_path: Path) -> None:
+    # The pool stamps each evolved child's recomputed solve-cost onto its lineage (the
+    # core re-admit builder can't), so the dashboard can surface a difficulty trend.
+    pack = WebappPack()
+    seeds = [{**_COMPANY_MANIFEST, "seed": s} for s in range(4)]
+    round_no = [0]
+
+    def run_round(
+        rows: list[dict[str, object]], snapshots: list[Snapshot]
+    ) -> dict[tuple[str, str], list[EpisodeReport]]:
+        round_no[0] += 1
+        return _solve_round(pack, tmp_path / f"r{round_no[0]}", rows, snapshots)
+
+    pool = WorldPool.seed(
+        pack,
+        seeds,
+        difficulty_fn=lambda s: float(world_difficulty(s.graph)),
+        family="webapp.pentest",
+        max_size=5,
+    )
+    run_pool_curriculum(
+        pool,
+        run_round,
+        rounds=2,
+        pack=pack,
+        groups=3,
+        num_generations=2,
+        gate=_pentest_only,
+    )
+    evolved = [
+        s
+        for s in pool.snapshots()
+        if (s.lineage.get("_evolve") or {}).get("kind") == "patch"
+    ]
+    assert evolved  # a solving agent hardened at least one world
+    for snap in evolved:
+        stamped = snap.lineage.get("world_difficulty")
+        assert stamped == pytest.approx(float(world_difficulty(snap.graph)))

--- a/tests/test_cyber_company.py
+++ b/tests/test_cyber_company.py
@@ -1434,9 +1434,6 @@ _FLAT_SQLI = {
 
 
 def _flat_sqli_with_sibling_db() -> Snapshot:
-    # A db-loot world whose db service exposes more than one endpoint: the SQLi oracle
-    # plus a sibling on the default handler — the case that used to leak the flag by a
-    # plain ?key lookup with no exploit.
     for seed in range(16):
         snap = _admit({**_FLAT_SQLI, "seed": seed})
         svc_of_ep = {
@@ -1454,9 +1451,8 @@ def _flat_sqli_with_sibling_db() -> Snapshot:
 
 
 def test_benign_db_endpoint_never_serves_the_flag(tmp_path: Path) -> None:
-    # The honest contract: a benign request never returns a guarded (HIDDEN) value; the
-    # vuln's own handler is the only path that leaks it. A sibling default-db endpoint
-    # used to hand over the flag for ?key=<flagkey> with no exploit (the sibling leak).
+    # A sibling default-db endpoint once served the flag for ?key=<flagkey> with
+    # no exploit — hence the probe with the flag's own key.
     snap = _flat_sqli_with_sibling_db()
     graph = snap.graph
     holds = {e.src: e.dst for e in graph.edges.values() if e.kind == "holds"}
@@ -1472,7 +1468,6 @@ def test_benign_db_endpoint_never_serves_the_flag(tmp_path: Path) -> None:
             url = str(ep.attrs["public_url"])
             assert flag not in _http(base, f"{url}?key={flag_key}")
             assert flag not in _http(base, url)
-        # The intended SQLi exploit still leaks, and the whole-world verdict accepts.
         entry = str(graph.nodes[task.entrypoints[0]].attrs["public_url"])
         outcome = verdict(graph, base, entry)
         assert outcome.accepted
@@ -1482,9 +1477,6 @@ def test_benign_db_endpoint_never_serves_the_flag(tmp_path: Path) -> None:
 
 
 def test_whole_world_verdict_rejects_a_sibling_leak() -> None:
-    # The guarantee verify.verdict now enforces: even when the oracle is honest (its
-    # exploit leaks and its benign does not), a sibling benign endpoint that serves the
-    # flag rejects the world — it would be winnable without the intended exploit.
     graph = _admit({**_FLAT_SQLI, "seed": 0}).graph
     flag = str(graph.nodes["secret_flag"].attrs["value_ref"])
     outcome = classify_service_admission(
@@ -1499,8 +1491,6 @@ def test_whole_world_verdict_rejects_a_sibling_leak() -> None:
 
 
 def test_evolved_snapshot_persists_world_difficulty(tmp_path: Path) -> None:
-    # The pool stamps each evolved child's recomputed solve-cost onto its lineage (the
-    # core re-admit builder can't), so the dashboard can surface a difficulty trend.
     pack = WebappPack()
     seeds = [{**_COMPANY_MANIFEST, "seed": s} for s in range(4)]
     round_no = [0]
@@ -1532,7 +1522,7 @@ def test_evolved_snapshot_persists_world_difficulty(tmp_path: Path) -> None:
         for s in pool.snapshots()
         if (s.lineage.get("_evolve") or {}).get("kind") == "patch"
     ]
-    assert evolved  # a solving agent hardened at least one world
+    assert evolved
     for snap in evolved:
         stamped = snap.lineage.get("world_difficulty")
         assert stamped == pytest.approx(float(world_difficulty(snap.graph)))

--- a/tests/test_cyber_lateral.py
+++ b/tests/test_cyber_lateral.py
@@ -351,11 +351,8 @@ def test_lateral_solves_across_real_containers() -> None:
 
 
 def test_chain_soften_is_reachable_from_real_reports(tmp_path: Path) -> None:
-    # Loop reachability, not just the mechanism: a real report from an agent that
-    # reached the public SSRF foothold but did not finish must make available_mutations
-    # OFFER the hop-collapse soften with positive, decoy-beating relevance -- otherwise
-    # the move is dead in the curriculum even though _soften_remove_hop_mutation works
-    # in isolation (the bug the foothold-engagement relevance closes).
+    # The soften must be OFFERED from a real foothold-engagement report, not merely
+    # work in isolation -- otherwise it's dead in the loop.
     from cyber_webapp.mutation import _REMOVE_RELEVANCE_FLOOR, available_mutations
 
     pack = WebappPack()
@@ -372,7 +369,7 @@ def test_chain_soften_is_reachable_from_real_reports(tmp_path: Path) -> None:
     try:
         handle = svc.start_episode(snap, task.id)
         entry = str(graph.nodes[task.entrypoints[0]].attrs["public_url"])
-        _get(svc.base_url(handle), entry)  # reaches the foothold, then gives up
+        _get(svc.base_url(handle), entry)  # reaches the foothold without finishing
         report = svc.stop_episode(handle)
     finally:
         svc.close()
@@ -386,7 +383,5 @@ def test_chain_soften_is_reachable_from_real_reports(tmp_path: Path) -> None:
         ),
         None,
     )
-    # offered from real foothold engagement, not a hardcoded value
     assert hop is not None
-    # and it outranks a cosmetic decoy-removal
     assert hop.relevance > _REMOVE_RELEVANCE_FLOOR

--- a/tests/test_cyber_lateral.py
+++ b/tests/test_cyber_lateral.py
@@ -348,3 +348,45 @@ def test_lateral_solves_across_real_containers() -> None:
         assert "secret_flag" in runtime.collect()["leaked_secret_ids"]
     finally:
         runtime.stop()
+
+
+def test_chain_soften_is_reachable_from_real_reports(tmp_path: Path) -> None:
+    # Loop reachability, not just the mechanism: a real report from an agent that
+    # reached the public SSRF foothold but did not finish must make available_mutations
+    # OFFER the hop-collapse soften with positive, decoy-beating relevance -- otherwise
+    # the move is dead in the curriculum even though _soften_remove_hop_mutation works
+    # in isolation (the bug the foothold-engagement relevance closes).
+    from cyber_webapp.mutation import _REMOVE_RELEVANCE_FLOOR, available_mutations
+
+    pack = WebappPack()
+    snap = admit(
+        pack,
+        manifest={**_manifest(1), "chain": {"depth": {"min": 2, "max": 2}}},
+        max_repairs=3,
+    )
+    assert isinstance(snap, Snapshot)
+    graph = snap.graph
+    task = next(t for t in snap.tasks if t.meta.get("family") == "webapp.pentest")
+
+    svc = EpisodeService(pack, tmp_path)
+    try:
+        handle = svc.start_episode(snap, task.id)
+        entry = str(graph.nodes[task.entrypoints[0]].attrs["public_url"])
+        _get(svc.base_url(handle), entry)  # reaches the foothold, then gives up
+        report = svc.stop_episode(handle)
+    finally:
+        svc.close()
+
+    options = available_mutations(graph, "webapp.pentest", [report])
+    hop = next(
+        (
+            m
+            for m in options
+            if m.direction == "soften" and m.note.startswith("collapse")
+        ),
+        None,
+    )
+    # offered from real foothold engagement, not a hardcoded value
+    assert hop is not None
+    # and it outranks a cosmetic decoy-removal
+    assert hop.relevance > _REMOVE_RELEVANCE_FLOOR

--- a/tests/test_dashboard_runs.py
+++ b/tests/test_dashboard_runs.py
@@ -448,9 +448,8 @@ def test_snapshot_id_helper_resolves_from_new_snapshot() -> None:
 
 
 def test_lineage_node_surfaces_world_difficulty() -> None:
-    # The dashboard reads the solve-cost the builder stamps into admission_meta ->
-    # lineage (world_difficulty), not the unrelated curriculum_difficulty knob dict, so
-    # the Build panel shows a real number on the common patch-driven pool.
+    # world_difficulty (the stamped solve-cost), not the unrelated
+    # curriculum_difficulty knob dict.
     from cyber_webapp.difficulty import world_difficulty
 
     from openrange.dashboard.view import _lineage_node

--- a/tests/test_dashboard_runs.py
+++ b/tests/test_dashboard_runs.py
@@ -445,3 +445,26 @@ def test_snapshot_id_helper_resolves_from_new_snapshot() -> None:
         assert state["snapshot_id"] == snap.snapshot_id
     finally:
         view.close()
+
+
+def test_lineage_node_surfaces_world_difficulty() -> None:
+    # The dashboard reads the solve-cost the builder stamps into admission_meta ->
+    # lineage (world_difficulty), not the unrelated curriculum_difficulty knob dict, so
+    # the Build panel shows a real number on the common patch-driven pool.
+    from cyber_webapp.difficulty import world_difficulty
+
+    from openrange.dashboard.view import _lineage_node
+
+    snap = admit(
+        WebappPack(),
+        manifest={
+            "pack": {"id": "webapp"},
+            "runtime": {"tick": {"mode": "off"}},
+            "npc": [],
+            "seed": 3,
+        },
+        max_repairs=3,
+    )
+    assert isinstance(snap, Snapshot)
+    node = _lineage_node(snap)
+    assert node["world_difficulty"] == float(world_difficulty(snap.graph))


### PR DESCRIPTION
## Why

A rigorous review of the cyber worldgen / evolution / curriculum / dashboard turned up four problems that make the training signal untrustworthy or the pool illegible. The verifier is supposed to set the agent's ceiling, but it didn't actually bind the default training path, and the curriculum's "soften" mutation was dead code on the exact worlds it's meant to help. This PR fixes them **before** any GPU run, so the reward we'd be training against is honest, and makes the evolving pool readable in the dashboard.

This is the **A + thin C** slice from that review (honesty fixes + difficulty made visible). No new capability — it makes the existing one trustworthy.

## What

### Honest worlds (A)

- **A benign request can no longer leak the flag.** The default db handler used to serve any value by `?key`, including a guarded (HIDDEN) one — so a sibling endpoint could make a world "winnable" without the intended exploit. The handler now filters guarded values, and `verify.verdict` sweeps **every reachable benign endpoint** and rejects the world if any of them leaks. (Closes the sibling-db key-lookup leak.)
- **The consequence gate binds the default path.** A task-less world now **fails** instead of passing blind; seed-gate rejections are logged; and the seed gate is wired into the notebook's training pool + held-out set (the evolve-time gate was already wired).
- **The chain-collapse soften is reachable again.** On networked worlds its relevance was always 0 (it keyed on in-process paths that never appear in `requests_made`). It now derives relevance from the agent's engagement with the **public SSRF foothold** — the one signal that survives the in-process proxy — floored above decoy-removal, so a chain-stuck agent actually eases the chain instead of cosmetically dropping a decoy. First loop-reachability test for it.

### Legible pool (C)

- The pool now stamps each evolved world's **solve-cost** onto its lineage, and the dashboard reads + displays it. (It was reading an unrelated key that was always empty, so the panel never showed a difficulty.)

## Testing

- 5 new regression tests:
  - benign db endpoint never serves the flag
  - whole-world verdict rejects a sibling leak
  - evolved snapshot persists `world_difficulty`
  - chain-soften is reachable from real agent reports
  - lineage node surfaces `world_difficulty` to the dashboard
- Full suite green: **984 passed, 17 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
