### PR TITLE
fix(agent): use standard shell code fences as the action format

### DIFF
--- a/src/openrange/agent.py
+++ b/src/openrange/agent.py
@@ -132,17 +132,29 @@ def agent_briefing(ctx: EpisodeContext) -> str:
     return "\n\n".join(parts)
 
 
-_ACTION_BLOCK = re.compile(r"```(run_shell|finish)\n(.*?)```", re.DOTALL)
+_ACTION_BLOCK = re.compile(
+    r"```(bash|sh|shell|console|zsh|finish)[ \t]*\n(.*?)```", re.DOTALL
+)
 
 
 def parse_action(text: str) -> AgentAction:
-    """Parse one action from a model reply: a fenced ```run_shell``` / ```finish```
-    block. A reply with no recognized block becomes a ``finish`` carrying the whole
-    text, so a model that ignores the protocol still terminates rather than loops."""
-    match = _ACTION_BLOCK.search(text)
-    if match is None:
+    """Parse the agent's action from its reply: a fenced shell command
+    (```bash / ```sh / ```shell / ```console / ```zsh) or a ```finish``` block.
+
+    Shell actions use the standard markdown code fence a model is trained to
+    emit — executable code as the action, CodeAct-style — rather than a bespoke
+    tool token it only ever sees in our prompt and routinely forgets. The *last*
+    recognized block wins, so an illustrative snippet earlier in the reply is not
+    executed in place of the action the model actually settled on. A reply with
+    no recognized block becomes a ``finish`` carrying the whole text, so a model
+    that ignores the protocol terminates rather than loops."""
+    matches = list(_ACTION_BLOCK.finditer(text))
+    if not matches:
         return AgentAction(tool="finish", command=text.strip())
-    return AgentAction(tool=match.group(1), command=match.group(2).strip())
+    match = matches[-1]
+    lang = match.group(1).lower()
+    tool = "finish" if lang == "finish" else "run_shell"
+    return AgentAction(tool=tool, command=match.group(2).strip())
 
 
 def run_shell(

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -102,7 +102,7 @@ def _finish(answer: str = "done") -> Reply:
 
 
 def _shell(command: str) -> Reply:
-    return lambda _prompt: f"```run_shell\n{command}\n```"
+    return lambda _prompt: f"```bash\n{command}\n```"
 
 
 def _cmdi_snapshot() -> Snapshot:
@@ -140,7 +140,7 @@ def _exploit_reply(snap: Snapshot) -> Reply:
             )
         else:
             curl = f"curl -s '{target}'"
-        return f"```run_shell\n{curl}\n```"
+        return f"```bash\n{curl}\n```"
 
     return reply
 
@@ -250,7 +250,7 @@ def test_arun_rollouts_overlaps_concurrent_episodes(tmp_path: Path) -> None:
 
 
 def test_parse_action_reads_blocks_and_falls_back_to_finish() -> None:
-    shell = parse_action("intro\n```run_shell\ncurl -s http://x/\n```\noutro")
+    shell = parse_action("intro\n```bash\ncurl -s http://x/\n```\noutro")
     assert shell.tool == "run_shell"
     assert shell.command == "curl -s http://x/"
     done = parse_action("```finish\nthe answer\n```")
@@ -259,6 +259,22 @@ def test_parse_action_reads_blocks_and_falls_back_to_finish() -> None:
     bare = parse_action("just prose, no block")
     assert bare.tool == "finish"
     assert bare.command == "just prose, no block"
+
+
+def test_parse_action_accepts_standard_shell_fences_and_takes_the_last() -> None:
+    # A shell action is the markdown code fence the model is trained to emit:
+    # ```bash / ```sh / ```shell / ```console / ```zsh all read as one command.
+    for lang in ("bash", "sh", "shell", "console", "zsh"):
+        act = parse_action(f"thinking...\n```{lang}\nsubmit it\n```")
+        assert act.tool == "run_shell", lang
+        assert act.command == "submit it"
+    # An illustrative block before the real action is not executed in its place —
+    # the last recognized block is the one the model settled on.
+    settled = parse_action(
+        "maybe\n```bash\necho first\n```\non reflection:\n```bash\necho second\n```"
+    )
+    assert settled.tool == "run_shell"
+    assert settled.command == "echo second"
 
 
 def test_run_shell_requires_a_bound_run_capability() -> None:

--- a/tests/test_rllm_shim.py
+++ b/tests/test_rllm_shim.py
@@ -32,7 +32,7 @@ from openrange import EpisodeService, SampleResult, run_agent
 from openrange.core.admit import admit
 from openrange.core.sandbox import CommandResult
 
-_SHELL = "```run_shell\necho probe\n```"
+_SHELL = "```bash\necho probe\n```"
 _FINISH = "```finish\ndone\n```"
 
 


### PR DESCRIPTION
## What

Shell actions in the agent loop now use the **standard markdown code fence** a model is trained to emit — `` ```bash `` / `` ```sh `` / `` ```shell `` / `` ```console `` / `` ```zsh `` — instead of the bespoke `` ```run_shell `` token.

## Why

`parse_action` only recognized `` ```run_shell `` / `` ```finish ``. Any other fence failed the match and fell through to the "no recognized block → finish" path, which **ends the episode and discards the action** (including a `submit`). Instruct/cold models reach for `` ```bash `` constantly — it has overwhelming pretraining mass, while `` ```run_shell `` appears essentially only in our own prompt — so a competent rollout could die at a single step with its training signal lost.

open-range's design is one shell primitive + a finish (no per-verb tool menu), so there is nothing for a custom fence token to disambiguate; it is pure friction against the model's prior. This also matches the CodeAct finding — executable code as the action space outperforms bespoke/JSON tool encodings ([Wang et al. 2024](https://proceedings.mlr.press/v235/wang24h.html)).

## Changes

- `parse_action` accepts `bash|sh|shell|console|zsh` as a shell command and `finish` as the terminal block.
- The **last** recognized block wins, so an illustrative snippet earlier in a reply is not executed in place of the action the model actually settled on.
- The internal action identifier stays `run_shell`; only the wire format the model emits changes. No back-compat alias for the old `` ```run_shell `` fence (the only emitters were our own test fixtures).
- `finish` stays a sentinel — there is no standard markdown fence for "done".
- Tests updated, plus a new case covering the standard fences and last-block selection.

## Test

`pytest tests/test_agent_harness.py tests/test_rllm_shim.py` → **13 passed, 5 skipped** (rllm not installed locally). `ruff check`, `ruff format --check`, and `mypy` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
