### PR TITLE
Add per-domain RewardAdapter seam (Refs #199)

### DIFF
--- a/examples/reward_adapter_demo.py
+++ b/examples/reward_adapter_demo.py
@@ -1,0 +1,99 @@
+"""Per-domain ``RewardAdapter`` vs the generic default, no LLM or network.
+
+Builds a handful of ``EpisodeReport``s by hand — a clean miss, endpoint reached,
+data extracted, flag solved — and prints the reward each one earns under the
+domain-agnostic ``SubgoalFractionRewardAdapter`` and the cyber pack's
+``CyberPentestRewardAdapter`` (``WebappPack().default_reward_adapter()``). Then it
+feeds one report through the training seam to show ``episode_trajectory`` sourcing
+its scalar from a pack adapter.
+
+Run::
+
+    uv run python -m examples.reward_adapter_demo
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from cyber_webapp import WebappPack
+from openrange_pack_sdk import EpisodeResult, SubgoalFractionRewardAdapter
+
+from openrange.core.episode import EpisodeReport
+from openrange.training import episode_trajectory
+
+
+def _report(
+    label: str, *, success: bool, subgoals: Mapping[str, bool]
+) -> EpisodeReport:
+    return EpisodeReport(
+        snapshot_id="sha256:demo",
+        task_id=f"webapp.pentest.{label}",
+        episode_result=EpisodeResult(
+            success=success, subgoals=dict(subgoals), reason=label
+        ),
+    )
+
+
+def main() -> None:
+    reports = [
+        _report(
+            "miss",
+            success=False,
+            subgoals={
+                "reached_endpoint": False,
+                "extracted_anything": False,
+                "matched_flag": False,
+            },
+        ),
+        _report(
+            "reached",
+            success=False,
+            subgoals={
+                "reached_endpoint": True,
+                "extracted_anything": False,
+                "matched_flag": False,
+            },
+        ),
+        _report(
+            "extracted",
+            success=False,
+            subgoals={
+                "reached_endpoint": True,
+                "extracted_anything": True,
+                "matched_flag": False,
+            },
+        ),
+        _report(
+            "solved",
+            success=True,
+            subgoals={
+                "reached_endpoint": True,
+                "extracted_anything": True,
+                "matched_flag": True,
+            },
+        ),
+    ]
+
+    generic = SubgoalFractionRewardAdapter()
+    pack = WebappPack()
+    cyber = pack.default_reward_adapter()
+
+    print(f"{'case':<12}{'generic':>10}{'cyber':>10}")
+    for report in reports:
+        generic_reward = generic.reward(report)
+        cyber_reward = cyber.reward(report)
+        label = report.episode_result.reason
+        print(f"{label:<12}{generic_reward:>10.2f}{cyber_reward:>10.2f}")
+
+    extracted = reports[2]
+    trajectory = episode_trajectory(extracted, adapter=cyber)
+    print()
+    print(
+        "episode_trajectory('extracted', adapter=cyber).reward ->",
+        trajectory.reward.as_dict(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/openrange-pack-sdk/src/openrange_pack_sdk/__init__.py
+++ b/packages/openrange-pack-sdk/src/openrange_pack_sdk/__init__.py
@@ -39,7 +39,9 @@ from openrange_pack_sdk._protocols import (
     LLMBackend,
     Pack,
     PoolableRuntime,
+    RewardAdapter,
     RuntimeHandle,
+    SubgoalFractionRewardAdapter,
     TaskFamily,
 )
 from openrange_pack_sdk._runtime import (
@@ -97,9 +99,11 @@ __all__ = [
     "PackPrior",
     "PoolableRuntime",
     "ProceduralBuilder",
+    "RewardAdapter",
     "RuntimeHandle",
     "SandboxResult",
     "Snapshot",
+    "SubgoalFractionRewardAdapter",
     "SubprocessRuntime",
     "TaskFamily",
     "TaskSeed",

--- a/packages/openrange-pack-sdk/src/openrange_pack_sdk/_protocols.py
+++ b/packages/openrange-pack-sdk/src/openrange_pack_sdk/_protocols.py
@@ -58,21 +58,58 @@ class PoolableRuntime(Protocol):
 
 @runtime_checkable
 class EpisodeReportLike(Protocol):
-    """The slice of an episode report that families read.
+    """The slice of an episode report that families and reward adapters read.
 
-    ``passed`` is the gate the curriculum policy reads. ``final_state`` is
-    the runtime-emitted bag of facts the family's mutation/grading logic
-    interrogates (which records were touched, which requests fired, etc).
-    The contract is intentionally narrow — anything beyond these two
-    fields is a concrete-report concern and packs reach for it at their
-    own risk.
+    ``passed`` is the gate the curriculum policy reads. ``episode_result`` is
+    the structured outcome a :class:`RewardAdapter` shapes into a scalar —
+    its ``subgoals`` are the partial-credit signal. ``final_state`` is the
+    runtime-emitted bag of facts the family's mutation/grading logic
+    interrogates (which records were touched, which requests fired, etc), and
+    the raw substrate a future numeric-domain adapter reads. The contract is
+    intentionally narrow — anything beyond these is a concrete-report concern
+    and packs reach for it at their own risk.
     """
 
     @property
     def passed(self) -> bool: ...
 
     @property
+    def episode_result(self) -> EpisodeResult: ...
+
+    @property
     def final_state(self) -> Mapping[str, Any]: ...
+
+
+class RewardAdapter(ABC):
+    """Maps an episode's structured outcome into a trainer-facing reward.
+
+    A pack's ``check_success`` returns an :class:`EpisodeResult` — a boolean
+    plus per-subgoal flags — and deliberately never a scalar. Turning that
+    into the ``float`` (or multi-objective ``Sequence[float]``) a training loop
+    consumes is domain knowledge that belongs to the pack, not the trainer:
+    cyber's exploit-chain ladder, trading's risk-adjusted return, robotics'
+    success-plus-smoothness. Each pack ships its natural adapter via
+    :meth:`Pack.default_reward_adapter`; training loops consume the adapter and
+    stay domain-agnostic.
+    """
+
+    @abstractmethod
+    def reward(self, report: EpisodeReportLike) -> float | Sequence[float]: ...
+
+
+class SubgoalFractionRewardAdapter(RewardAdapter):
+    """The domain-agnostic default: ``1.0`` for a solved episode, otherwise the
+    fraction of subgoals that passed (partial credit), or ``0.0`` when the pack
+    reports no subgoals. This is the mapping the harness applied before packs
+    could own their reward shape."""
+
+    def reward(self, report: EpisodeReportLike) -> float:
+        if report.passed:
+            return 1.0
+        subgoals = report.episode_result.subgoals
+        if subgoals:
+            return sum(1 for hit in subgoals.values() if hit) / len(subgoals)
+        return 0.0
 
 
 @runtime_checkable
@@ -314,6 +351,14 @@ class Pack(ABC):
         prior's ``difficulty`` returns its default prior here, letting core step
         that difficulty up/down and re-admit a freshly-built world."""
         return None
+
+    def default_reward_adapter(self) -> RewardAdapter:
+        """The pack's natural ``EpisodeResult`` → reward mapping. Defaults to
+        the domain-agnostic subgoal-fraction shaping; a pack with a real reward
+        shape (cyber's exploit ladder, trading's P&L) overrides this so training
+        loops get a meaningful scalar without baking domain knowledge into the
+        trainer."""
+        return SubgoalFractionRewardAdapter()
 
 
 class NPC(ABC):

--- a/packages/openrange-pack-sdk/tests/test_reward.py
+++ b/packages/openrange-pack-sdk/tests/test_reward.py
@@ -1,0 +1,121 @@
+"""RewardAdapter seam: the ABC, the generic default, and the Pack hook.
+
+Real concrete subclasses + real ``EpisodeResult`` objects. No mocks, no
+patches, no test doubles.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from graphschema import Ontology, WorldGraph
+from openrange_pack_sdk import (
+    Backing,
+    Builder,
+    EpisodeReportLike,
+    EpisodeResult,
+    Manifest,
+    Pack,
+    PackPrior,
+    RewardAdapter,
+    RuntimeHandle,
+    SubgoalFractionRewardAdapter,
+    TaskFamily,
+)
+
+
+@dataclass(frozen=True)
+class _Report:
+    """A real ``EpisodeReportLike`` — the slice an adapter reads."""
+
+    passed: bool
+    episode_result: EpisodeResult
+    final_state: Mapping[str, Any] = field(default_factory=dict)
+
+
+def _report(*, success: bool, subgoals: Mapping[str, bool]) -> _Report:
+    return _Report(
+        passed=success,
+        episode_result=EpisodeResult(success=success, subgoals=dict(subgoals)),
+    )
+
+
+class _NoopBuilder(Builder):
+    def build(self, manifest: Manifest) -> Any:
+        del manifest
+        from openrange_pack_sdk import BuildResult
+
+        return BuildResult(WorldGraph(ontology="test@0"), [])
+
+
+class _MinimalPack(Pack):
+    id = "minimal"
+    version = "v0"
+
+    def ontology(self) -> Ontology:
+        return Ontology(id="test@0")
+
+    def make_builder(self, prior: PackPrior | None) -> Builder:
+        del prior
+        return _NoopBuilder()
+
+    def realize(self, graph: WorldGraph, backing: Backing) -> RuntimeHandle:
+        raise NotImplementedError
+
+    def task_families(self) -> list[TaskFamily]:
+        return []
+
+
+class _VectorAdapter(RewardAdapter):
+    def reward(self, report: EpisodeReportLike) -> Sequence[float]:
+        return [1.0 if hit else 0.0 for hit in report.episode_result.subgoals.values()]
+
+
+class TestSubgoalFractionRewardAdapter:
+    def test_solved_is_one(self) -> None:
+        adapter = SubgoalFractionRewardAdapter()
+        assert adapter.reward(_report(success=True, subgoals={"a": False})) == 1.0
+
+    def test_partial_credit_is_subgoal_fraction(self) -> None:
+        adapter = SubgoalFractionRewardAdapter()
+        reward = adapter.reward(
+            _report(success=False, subgoals={"a": True, "b": False, "c": False})
+        )
+        assert reward == 1 / 3
+
+    def test_unsolved_without_subgoals_is_zero(self) -> None:
+        adapter = SubgoalFractionRewardAdapter()
+        assert adapter.reward(_report(success=False, subgoals={})) == 0.0
+
+    def test_is_a_reward_adapter(self) -> None:
+        assert isinstance(SubgoalFractionRewardAdapter(), RewardAdapter)
+
+
+class TestPackDefaultRewardAdapter:
+    def test_default_is_subgoal_fraction(self) -> None:
+        adapter = _MinimalPack().default_reward_adapter()
+        assert isinstance(adapter, SubgoalFractionRewardAdapter)
+
+    def test_default_scores_like_the_generic_mapping(self) -> None:
+        adapter = _MinimalPack().default_reward_adapter()
+        assert (
+            adapter.reward(_report(success=False, subgoals={"a": True, "b": False}))
+            == 0.5
+        )
+
+
+class TestRewardAdapterVectorOutput:
+    def test_subclass_may_return_a_vector(self) -> None:
+        reward = _VectorAdapter().reward(
+            _report(success=False, subgoals={"a": True, "b": False})
+        )
+        assert list(reward) == [1.0, 0.0]
+
+
+class TestWidenedProtocol:
+    def test_report_satisfies_runtime_checkable_protocol(self) -> None:
+        report = _report(success=True, subgoals={"a": True})
+        assert isinstance(report, EpisodeReportLike)
+        assert report.episode_result.success is True

--- a/packs/cyber_webapp/cyber_webapp/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/__init__.py
@@ -9,6 +9,7 @@ from openrange_pack_sdk import (
     Builder,
     Pack,
     PackPrior,
+    RewardAdapter,
     RuntimeHandle,
     TaskFamily,
 )
@@ -34,6 +35,7 @@ from cyber_webapp.realize import (
     WebappRuntime,
     WebappRuntimeError,
 )
+from cyber_webapp.reward import CyberPentestRewardAdapter
 from cyber_webapp.sampling import _is_networked as _is_networked  # re-export
 
 
@@ -85,10 +87,14 @@ class WebappPack(Pack):
     def task_families(self) -> list[TaskFamily]:
         return [WebappBuild(), WebappPentest()]
 
+    def default_reward_adapter(self) -> RewardAdapter:
+        return CyberPentestRewardAdapter()
+
 
 __all__ = [
     "ONTOLOGY_ID",
     "ContainerWebappRuntime",
+    "CyberPentestRewardAdapter",
     "NetworkedContainerWebappRuntime",
     "WebappBuild",
     "WebappBuilder",

--- a/packs/cyber_webapp/cyber_webapp/reward.py
+++ b/packs/cyber_webapp/cyber_webapp/reward.py
@@ -1,0 +1,30 @@
+"""Reward shaping for ``webapp.pentest`` — the exploit-chain ladder."""
+
+from __future__ import annotations
+
+from openrange_pack_sdk import EpisodeReportLike, RewardAdapter
+
+
+class CyberPentestRewardAdapter(RewardAdapter):
+    """Monotone partial credit from the pentest subgoal chain.
+
+    A solved episode scores ``1.0``. An unsolved one scores the deepest rung it
+    reached along the natural exploit chain the grader emits — touching the
+    endpoint (``reached_endpoint`` → ``0.2``), pulling anything back out of it
+    (``extracted_anything`` → ``0.6``), then matching the flag
+    (``matched_flag`` → ``1.0``). Closer chains score higher, so a trainer sees
+    a gradient toward the exploit instead of a flat zero on every miss.
+    """
+
+    def reward(self, report: EpisodeReportLike) -> float:
+        if report.passed:
+            return 1.0
+        subgoals = report.episode_result.subgoals
+        rung = 0.0
+        if subgoals.get("reached_endpoint"):
+            rung = 0.2
+        if subgoals.get("extracted_anything"):
+            rung = 0.6
+        if subgoals.get("matched_flag"):
+            rung = 1.0
+        return rung

--- a/src/openrange/training.py
+++ b/src/openrange/training.py
@@ -34,6 +34,8 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
+from openrange_pack_sdk import RewardAdapter
+
 from openrange.core.episode import AgentTurn, EpisodeReport
 
 
@@ -95,15 +97,27 @@ class Trajectory:
         }
 
 
-def episode_reward(report: EpisodeReport) -> Reward:
+def episode_reward(
+    report: EpisodeReport,
+    adapter: RewardAdapter | None = None,
+) -> Reward:
     """Shape an ``EpisodeReport`` into a dense, trainer-agnostic ``Reward``.
 
     ``components`` maps each subgoal to ``1.0`` / ``0.0``. ``scalar`` is ``1.0``
     for a solved episode; otherwise the fraction of subgoals that passed (partial
     credit), or ``0.0`` when the pack reports no subgoals.
+
+    Pass a pack's ``adapter`` (e.g. ``pack.default_reward_adapter()``) to source
+    the ``scalar`` from the pack's own reward shape instead. A ``float`` adapter
+    output is the scalar directly, keeping the per-subgoal ``components``; a
+    ``Sequence[float]`` (a multi-objective vector) becomes an indexed
+    ``components`` map whose mean is the ``scalar``. With ``adapter=None`` the
+    result is byte-for-byte the historical harness default.
     """
     subgoals = report.episode_result.subgoals
     components = {str(k): (1.0 if v else 0.0) for k, v in subgoals.items()}
+    if adapter is not None:
+        return _adapter_reward(report, adapter, components)
     if report.passed:
         scalar = 1.0
     elif components:
@@ -113,16 +127,35 @@ def episode_reward(report: EpisodeReport) -> Reward:
     return Reward(scalar=scalar, components=components)
 
 
+def _adapter_reward(
+    report: EpisodeReport,
+    adapter: RewardAdapter,
+    subgoal_components: Mapping[str, float],
+) -> Reward:
+    value = adapter.reward(report)
+    if isinstance(value, Sequence):
+        vector = [float(v) for v in value]
+        scalar = sum(vector) / len(vector) if vector else 0.0
+        return Reward(
+            scalar=scalar,
+            components={str(i): v for i, v in enumerate(vector)},
+        )
+    return Reward(scalar=float(value), components=dict(subgoal_components))
+
+
 def episode_trajectory(
     report: EpisodeReport,
     turns: Sequence[AgentTurn] | None = None,
+    adapter: RewardAdapter | None = None,
 ) -> Trajectory:
     """Assemble a ``Trajectory`` from a report and the turns the harness recorded.
 
     ``EpisodeReport`` keeps only the last agent message (``agent_summary``), so
     the per-step record is rebuilt from ``turns`` — the same ``AgentTurn`` objects
     the harness passed to ``record_turn``. With no turns the trajectory still
-    carries the terminal reward + outcome (a degenerate zero-step episode).
+    carries the terminal reward + outcome (a degenerate zero-step episode). An
+    optional ``adapter`` is forwarded to :func:`episode_reward` so the trajectory
+    carries the pack's own reward shape.
     """
     steps = tuple(
         TrajectoryStep(
@@ -138,7 +171,7 @@ def episode_trajectory(
         snapshot_id=report.snapshot_id,
         task_id=report.task_id,
         steps=steps,
-        reward=episode_reward(report),
+        reward=episode_reward(report, adapter),
         success=report.passed,
         reason=report.episode_result.reason,
     )

--- a/tests/test_curriculum.py
+++ b/tests/test_curriculum.py
@@ -63,16 +63,19 @@ from openrange.core.episode import EpisodeService
 
 @dataclass(frozen=True)
 class _Report:
-    """Concrete `EpisodeReportLike` — `passed` + `final_state`.
+    """Concrete `EpisodeReportLike` — `passed`, `episode_result`, `final_state`.
 
     Tests use this so they don't depend on the runtime ``EpisodeReport``
     class. ``final_state`` defaults to ``{}`` because the curriculum
     policy under test only reads ``passed``; pack-side mutation heuristics
-    that interrogate final_state pass it explicitly.
+    that interrogate final_state pass it explicitly. ``episode_result``
+    defaults to an empty structured outcome — the protocol requires it, but
+    the curriculum policy never reads it.
     """
 
     passed: bool
     final_state: Mapping[str, object] = field(default_factory=dict)
+    episode_result: EpisodeResult = field(default_factory=lambda: EpisodeResult(False))
 
 
 def test_direction_none_when_no_reports() -> None:
@@ -111,6 +114,7 @@ def test_direction_treats_missing_passed_as_failure() -> None:
 
     class _MissingPassed:
         final_state: Mapping[str, object] = {}
+        episode_result: EpisodeResult = EpisodeResult(False)
 
         @property
         def passed(self) -> bool:

--- a/tests/test_cyber_auto_curriculum.py
+++ b/tests/test_cyber_auto_curriculum.py
@@ -21,7 +21,7 @@ from cyber_webapp.mutation import (
 from cyber_webapp.sampling import _INTERNAL_ONLY_KINDS
 from cyber_webapp.vulnerabilities import CATALOG as VULN_CATALOG
 from graphschema import GraphPatch, WorldGraph, apply_patch
-from openrange_pack_sdk import EpisodeReportLike, Mutation, Snapshot
+from openrange_pack_sdk import EpisodeReportLike, EpisodeResult, Mutation, Snapshot
 
 
 def _build_snapshot(seed: int = 0) -> Snapshot:
@@ -56,6 +56,7 @@ class _ReportShim:
 
     passed: bool
     final_state: Mapping[str, Any] = field(default_factory=dict)
+    episode_result: EpisodeResult = field(default_factory=lambda: EpisodeResult(False))
 
 
 def _report_with_paths(

--- a/tests/test_cyber_reward.py
+++ b/tests/test_cyber_reward.py
@@ -1,0 +1,90 @@
+"""Cyber pentest reward ladder: subgoal chain → monotone partial credit.
+
+Real ``EpisodeReport`` objects and the pack's own adapter. No mocks, no
+patches, no test doubles.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from cyber_webapp import CyberPentestRewardAdapter, WebappPack
+from openrange_pack_sdk import EpisodeResult, RewardAdapter
+
+from openrange.core.episode import EpisodeReport
+
+
+def _report(*, success: bool, subgoals: Mapping[str, bool]) -> EpisodeReport:
+    return EpisodeReport(
+        snapshot_id="sha256:world",
+        task_id="webapp.pentest.0",
+        episode_result=EpisodeResult(success=success, subgoals=dict(subgoals)),
+    )
+
+
+def _chain(
+    *, reached: bool, extracted: bool, matched: bool, success: bool
+) -> EpisodeReport:
+    return _report(
+        success=success,
+        subgoals={
+            "reached_endpoint": reached,
+            "extracted_anything": extracted,
+            "matched_flag": matched,
+        },
+    )
+
+
+class TestCyberPentestRewardAdapter:
+    def test_solved_is_one(self) -> None:
+        adapter = CyberPentestRewardAdapter()
+        report = _chain(reached=True, extracted=True, matched=True, success=True)
+        assert adapter.reward(report) == 1.0
+
+    def test_clean_miss_is_zero(self) -> None:
+        adapter = CyberPentestRewardAdapter()
+        report = _chain(reached=False, extracted=False, matched=False, success=False)
+        assert adapter.reward(report) == 0.0
+
+    def test_reached_endpoint_only(self) -> None:
+        adapter = CyberPentestRewardAdapter()
+        report = _chain(reached=True, extracted=False, matched=False, success=False)
+        assert adapter.reward(report) == 0.2
+
+    def test_extracted_anything(self) -> None:
+        adapter = CyberPentestRewardAdapter()
+        report = _chain(reached=True, extracted=True, matched=False, success=False)
+        assert adapter.reward(report) == 0.6
+
+    def test_matched_flag_without_success_reaches_top_rung(self) -> None:
+        # matched_flag is the deepest rung; a grader that flags it without the
+        # submission gate still earns the full ladder value.
+        adapter = CyberPentestRewardAdapter()
+        report = _chain(reached=True, extracted=True, matched=True, success=False)
+        assert adapter.reward(report) == 1.0
+
+    def test_ladder_is_monotone_non_decreasing(self) -> None:
+        adapter = CyberPentestRewardAdapter()
+        rungs = [
+            adapter.reward(
+                _chain(reached=False, extracted=False, matched=False, success=False)
+            ),
+            adapter.reward(
+                _chain(reached=True, extracted=False, matched=False, success=False)
+            ),
+            adapter.reward(
+                _chain(reached=True, extracted=True, matched=False, success=False)
+            ),
+            adapter.reward(
+                _chain(reached=True, extracted=True, matched=True, success=True)
+            ),
+        ]
+        assert rungs == sorted(rungs)
+        assert rungs == [0.0, 0.2, 0.6, 1.0]
+
+
+class TestWebappPackWiring:
+    def test_default_reward_adapter_is_the_cyber_ladder(self) -> None:
+        adapter = WebappPack().default_reward_adapter()
+        assert isinstance(adapter, CyberPentestRewardAdapter)
+        assert isinstance(adapter, RewardAdapter)

--- a/tests/test_dashboard_runs.py
+++ b/tests/test_dashboard_runs.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import cast
 
 from cyber_webapp import WebappPack
-from openrange_pack_sdk import Snapshot
+from openrange_pack_sdk import EpisodeResult, Snapshot
 
 from openrange.core.admit import admit
 from openrange.dashboard.events import DashboardEvent
@@ -377,6 +377,7 @@ def test_lineage_chain_grows_across_evolution() -> None:
 
     class _Report:
         passed = True
+        episode_result = EpisodeResult(True)
         final_state: dict[str, list[str]] = {"requests_made": []}
 
     pack = WebappPack()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -8,9 +8,9 @@ records, and the JSON / JSONL export a trainer consumes.
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 
-from openrange_pack_sdk import EpisodeResult
+from openrange_pack_sdk import EpisodeReportLike, EpisodeResult, RewardAdapter
 
 from openrange.core.episode import AgentTurn, EpisodeReport
 from openrange.training import (
@@ -136,6 +136,58 @@ class TestEpisodeRun:
         assert run.success is False
         assert run.reward.scalar == 0.0
         assert run.trajectory.steps == ()
+
+
+class _ConstantAdapter(RewardAdapter):
+    """Returns a fixed scalar regardless of the report."""
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    def reward(self, report: EpisodeReportLike) -> float:
+        del report
+        return self._value
+
+
+class _VectorAdapter(RewardAdapter):
+    """Returns a fixed multi-objective vector."""
+
+    def __init__(self, vector: Sequence[float]) -> None:
+        self._vector = list(vector)
+
+    def reward(self, report: EpisodeReportLike) -> Sequence[float]:
+        del report
+        return self._vector
+
+
+class TestRewardAdapterParam:
+    def test_scalar_adapter_sources_scalar_keeps_subgoal_components(self) -> None:
+        report = _report(success=False, subgoals={"t1": True, "t2": False})
+        reward = episode_reward(report, _ConstantAdapter(0.42))
+        assert reward.scalar == 0.42
+        # components stay the per-subgoal 1/0 vector, independent of the scalar.
+        assert reward.components == {"t1": 1.0, "t2": 0.0}
+
+    def test_none_adapter_preserves_default_behavior(self) -> None:
+        report = _report(success=False, subgoals={"t1": True, "t2": False})
+        assert episode_reward(report, None) == episode_reward(report)
+
+    def test_vector_adapter_means_scalar_and_indexes_components(self) -> None:
+        report = _report(success=True, subgoals={"t1": True})
+        reward = episode_reward(report, _VectorAdapter([0.2, 0.8]))
+        assert reward.scalar == 0.5
+        assert reward.components == {"0": 0.2, "1": 0.8}
+
+    def test_empty_vector_adapter_is_zero(self) -> None:
+        report = _report(success=True, subgoals={"t1": True})
+        reward = episode_reward(report, _VectorAdapter([]))
+        assert reward.scalar == 0.0
+        assert reward.components == {}
+
+    def test_trajectory_threads_adapter_into_reward(self) -> None:
+        report = _report(success=False, subgoals={"t1": False})
+        traj = episode_trajectory(report, None, _ConstantAdapter(0.9))
+        assert traj.reward.scalar == 0.9
 
 
 def test_to_jsonl_one_line_per_trajectory() -> None:

--- a/tests/test_v1_llm_generation.py
+++ b/tests/test_v1_llm_generation.py
@@ -20,6 +20,7 @@ from graphschema import (
 )
 from openrange_pack_sdk import (
     EpisodeReportLike,
+    EpisodeResult,
     LLMBackend,
     LLMError,
     LLMRequest,
@@ -385,6 +386,7 @@ def test_enrich_mutations_reads_request_log_from_reports() -> None:
 
     class _Report:
         passed = False
+        episode_result = EpisodeResult(False)
         final_state: Mapping[str, object] = {
             "requests": [
                 {


### PR DESCRIPTION
## Summary

Refs #199. Adds a `RewardAdapter` seam so each pack owns its `EpisodeResult -> reward` mapping and training loops stay domain-agnostic — replacing the hardcoded `success -> 1.0 / else 0.0` shaping. The point of this increment is **the seam**, not a perfect reward function.

- **SDK** (`openrange-pack-sdk`, `_protocols.py`): new `RewardAdapter` ABC — `reward(report: EpisodeReportLike) -> float | Sequence[float]` — consuming the SDK's `EpisodeReportLike`, never `openrange`. Adds a generic `SubgoalFractionRewardAdapter` that reproduces today's dense mapping exactly (`1.0` on success, else fraction of subgoals passed, else `0.0`), returned by a concrete `Pack.default_reward_adapter()` hook so **every existing pack keeps working** (trading/swe inherit it unchanged). `EpisodeReportLike` is widened with an `episode_result: EpisodeResult` property so adapters can read subgoals for partial credit; concrete `EpisodeReport` already satisfies it. Both new symbols exported from the SDK `__init__`.
- **Cyber** (`packs/cyber_webapp/.../reward.py`): `CyberPentestRewardAdapter` gives a monotone exploit-chain ladder from the subgoals the pentest grader already emits — `reached_endpoint (0.2) < extracted_anything (0.6) < matched_flag (1.0)`, `1.0` on success — wired via `WebappPack.default_reward_adapter()`.
- **Trainer** (`src/openrange/training.py`): `episode_reward` / `episode_trajectory` take an optional `adapter`. A `float` output is the scalar (keeping per-subgoal `components`); a `Sequence[float]` becomes an indexed `components` map whose mean is the scalar. **`adapter=None` preserves current behavior byte-for-byte.**
- **Example** (`examples/reward_adapter_demo.py`): builds miss / reached / extracted / solved reports by hand and prints the generic default vs the cyber ladder, then feeds `episode_trajectory(report, adapter=...)`. No LLM, no network.

The protocol widening required adding `episode_result` to a handful of existing `EpisodeReportLike` test shims (curriculum / mutation / dashboard tests); no core behavior changed.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `bash scripts/check_boundary.sh` — clean (cyber `reward.py` imports only the SDK)
- [x] `uv run mypy src tests examples main.py packages/openrange-trl/src packages/openrange-rllm/src` — Success, no issues (89 files)
- [x] `uv run mypy packages/openrange-pack-sdk/src packages/openrange-pack-sdk/tests/test_reward.py packs/cyber_webapp/cyber_webapp/reward.py` — clean
- [x] Impacted tests pass: `uv run pytest packages/openrange-pack-sdk/tests/test_reward.py tests/test_cyber_reward.py tests/test_training.py tests/test_curriculum.py tests/test_cyber_auto_curriculum.py tests/test_v1_llm_generation.py tests/test_dashboard_runs.py tests/test_import_boundaries.py packages/openrange-pack-sdk/tests/test_sdk.py` (220 passed)
- [x] 100% branch coverage on new/changed lines (`training.py` + cyber `reward.py` report complete; new `_protocols.py` lines all covered). Tests use real concrete subclasses + real `EpisodeReport`/`EpisodeResult` — no mocks/patches/fakes.
- [x] `uv run python -m examples.reward_adapter_demo` runs (no LLM/network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)