### PR TITLE
fix: a measurement must reflect what actually happened

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: uv run mypy src tests examples main.py packages/openrange-trl/src packages/openrange-rllm/src
 
       - name: Test with coverage
-        run: uv run coverage run -m pytest tests
+        run: uv run coverage run -m pytest
 
       - name: Enforce coverage
         run: uv run coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: bash scripts/check_boundary.sh
 
       - name: Typecheck
-        run: uv run mypy src tests examples main.py packages/openrange-trl/src packages/openrange-rllm/src
+        run: uv run mypy src tests examples main.py packages packs
 
       - name: Test with coverage
         run: uv run coverage run -m pytest

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -768,7 +768,17 @@ class EpisodeResult:
     success: bool
     subgoals: Mapping[str, bool] = field(default_factory=dict)
     reason: str = ""
+    baseline: Mapping[str, bool] = field(default_factory=dict)
 ```
+
+`baseline` is what each subgoal was worth **before the agent acted**, for
+the subgoals a family can say that about; its keys must be a subset of
+`subgoals`. A subgoal already `True` there is a precondition the agent
+inherited, not an achievement — shapers credit only the rest, and one that
+comes back `False` is a regression. A family that reports subgoals the world
+satisfies on its own (`swe.fix` grades `pass_to_pass`, which is green at
+base) must declare them here, or a policy that changes nothing collects
+their credit. Leaving it empty keeps uniform credit over `subgoals`.
 
 `final_state` is the dict `RuntimeHandle.collect()` returned at
 episode end. Its keys are a pack/family convention (the cyber pack

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Before opening a pull request, run the checks relevant to your change.
 
 ```bash
 uv run ruff check .
-uv run mypy src tests examples main.py
+uv run mypy src tests examples main.py packages packs
 uv run coverage run -m pytest
 uv run coverage report
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Before opening a pull request, run the checks relevant to your change.
 ```bash
 uv run ruff check .
 uv run mypy src tests examples main.py
-uv run coverage run -m pytest tests
+uv run coverage run -m pytest
 uv run coverage report
 ```
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -131,10 +131,16 @@ The rule is: lineage is provenance, not behavior. Anything core
 *branches on* must come from the ontology or the protocols, never
 from lineage.
 
-Second: the `Manifest` is also `Mapping[str, Any]`. Same rule —
-core never reads a manifest key. The episode layer reads two
-runtime-knob keys (`runtime.tick.mode`, `runtime.tick.rate_hz`); those
-are generic infrastructure knobs, not domain knowledge.
+Second: the `Manifest` is also `Mapping[str, Any]`. Same rule — core
+reads no *domain* key. It does read generic run knobs: `runtime.tick.*`
+and `runtime.backing` (`core/episode.py`, `runtime.py`), plus the `npc`
+roster it starts an episode with.
+
+That last one is the exception that proves the rule, and it is worth
+knowing about: `npc` is world content, not an infrastructure knob, and
+it lives outside the graph. Since `snapshot_id` is a hash of the graph
+alone, two worlds whose manifests differ only in a key core reads share
+one id — and one store filename, one pool member, one dataset row.
 
 ---
 

--- a/packages/openrange-pack-sdk/src/openrange_pack_sdk/_types.py
+++ b/packages/openrange-pack-sdk/src/openrange_pack_sdk/_types.py
@@ -115,11 +115,28 @@ class FeasibilityVerdict:
 @dataclass(frozen=True)
 class EpisodeResult:
     """Structured outcome — never a scalar reward. Harness-side
-    training adapters do the shaping."""
+    training adapters do the shaping.
+
+    ``baseline`` is what each subgoal was worth *before the agent acted*, for
+    the subgoals a pack can say that about. A subgoal that is already ``True``
+    there is a precondition the agent inherited, not an achievement: shapers
+    credit only the rest, and a precondition that comes back ``False`` is a
+    regression. Its keys must be a subset of ``subgoals`` — one this episode
+    does not report reads as regressed. Packs that leave it empty keep uniform
+    credit over ``subgoals``.
+
+    ``error`` marks an episode that produced no gradeable answer — the grader
+    crashed, the suite timed out, the world never came up. It is not a wrong
+    answer, and a curriculum that scores it as one learns that the world is
+    hard. Set it and the episode is a non-measurement: shapers still report
+    ``0.0``, but the pool excludes it rather than ranking on it.
+    """
 
     success: bool
     subgoals: Mapping[str, bool] = field(default_factory=dict)
     reason: str = ""
+    baseline: Mapping[str, bool] = field(default_factory=dict)
+    error: str | None = None
 
 
 @dataclass(frozen=True)

--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -478,7 +478,7 @@ def env_trajectory(env: EpisodeEnv) -> Trajectory:
     env._finalize()
     if env.report is None:
         raise RuntimeError("no completed episode to export; call reset() first")
-    return episode_trajectory(env.report, env.turns)
+    return episode_trajectory(env.report, env.turns, env.reward_fn(env.report))
 
 
 def make_grpo_rounds(

--- a/packages/openrange-trl/src/openrange_trl/__init__.py
+++ b/packages/openrange-trl/src/openrange_trl/__init__.py
@@ -395,12 +395,26 @@ def make_reward_func(
         **kwargs: object,
     ) -> list[float]:
         rewards: list[float] = []
+        graded: list[float] = []
+        ungraded: list[int] = []
         for env in environments or ():
             env._finalize()
             if collector is not None and env.report is not None:
                 key = (env.report.snapshot_id, env.report.task_id)
                 collector.setdefault(key, []).append(env.report)
-            rewards.append(float(env.reward))
+            value = float(env.reward)
+            if env.report is not None and env.report.episode_result.error is not None:
+                ungraded.append(len(rewards))
+            else:
+                graded.append(value)
+            rewards.append(value)
+        # GRPO reads the spread of a group, so a 0.0 from a crashed grader is a
+        # penalty for whatever the policy happened to do. The group mean carries
+        # zero advantage, which is what "this rollout measured nothing" deserves.
+        if ungraded and graded:
+            mean = sum(graded) / len(graded)
+            for index in ungraded:
+                rewards[index] = mean
         return rewards
 
     return reward_func

--- a/packs/cyber_webapp/cyber_webapp/builder.py
+++ b/packs/cyber_webapp/cyber_webapp/builder.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import random
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 
 from openrange_pack_sdk import (
     BuildResult,
@@ -43,7 +43,7 @@ def _as_int(value: object, ctx: str) -> int:
     return value
 
 
-def _validate_vuln_kinds(kinds: object) -> None:
+def _validate_vuln_kinds(kinds: Iterable[str]) -> None:
     for kind in kinds:
         if kind not in VULN_CATALOG:
             raise PackError(f"unknown vuln kind {kind!r}; not in the catalog")
@@ -56,9 +56,9 @@ def _validate_vuln_kinds(kinds: object) -> None:
 
 def _apply_vuln_knob(
     vuln: object,
-    topology: dict,
-    kind_weights: dict,
-    count_ranges: dict,
+    topology: dict[str, object],
+    kind_weights: dict[str, object],
+    count_ranges: dict[str, object],
 ) -> None:
     if not isinstance(vuln, Mapping):
         raise PackError("vuln must be a mapping with 'weights' or 'pin'")

--- a/packs/cyber_webapp/cyber_webapp/codegen/templates/app.py.j2
+++ b/packs/cyber_webapp/cyber_webapp/codegen/templates/app.py.j2
@@ -239,7 +239,8 @@ class Handler(BaseHTTPRequestHandler):
 
     def respond(self, status, headers, body):
         leaked = _scan_leaks(body, self.server.state.get("guarded", {}))
-        self.server.log_access(self.command, self.path, status, leaked)
+        actor = self.headers.get("X-OpenRange-Actor") or "agent"
+        self.server.log_access(self.command, self.path, status, leaked, actor)
         content_type = headers.get("Content-Type", "application/octet-stream")
         self.send_response(status)
         self.send_header("Content-Type", content_type)
@@ -261,8 +262,8 @@ class WebappServer(ThreadingHTTPServer):
         self.log_path = log_path
         self.state = state
 
-    def log_access(self, method, path, status, leaked=()):
-        row = {"method": method, "path": path, "status": status}
+    def log_access(self, method, path, status, leaked=(), actor="agent"):
+        row = {"method": method, "path": path, "status": status, "actor": actor}
         if leaked:
             row["leaked"] = list(leaked)
         with self.log_path.open("a", encoding="utf-8") as handle:

--- a/packs/cyber_webapp/cyber_webapp/npcs/__init__.py
+++ b/packs/cyber_webapp/cyber_webapp/npcs/__init__.py
@@ -26,6 +26,6 @@ class _HTTPCadenceNPC(NPC):
         if http_get is None:
             return
         try:
-            cast(Any, http_get)(self._next_path())
+            cast(Any, http_get)(self._next_path(), "npc")
         except Exception:  # noqa: BLE001 — NPC failures are silent
             return

--- a/packs/cyber_webapp/cyber_webapp/npcs/curious_employee.py
+++ b/packs/cyber_webapp/cyber_webapp/npcs/curious_employee.py
@@ -27,7 +27,7 @@ class CuriousEmployee(AgentNPC):
         if http_get is None:
             return ()
 
-        @tool
+        @tool  # type: ignore[untyped-decorator]
         def visit_url(path: str) -> str:
             """Visit a path on the company webapp and return a short snippet.
 

--- a/packs/cyber_webapp/cyber_webapp/sampling.py
+++ b/packs/cyber_webapp/cyber_webapp/sampling.py
@@ -749,7 +749,8 @@ def _sample_vulnerabilities(
     oracle_shapes: frozenset[str] = frozenset({"response_leak"}),
 ) -> None:
     count = _sample_int(rng, prior, "vuln_count")
-    vuln_pin = [str(k) for k in (prior.topology.get("vuln_pin") or [])]
+    pinned = prior.topology.get("vuln_pin") if prior is not None else None
+    vuln_pin = [str(k) for k in pinned or []]
     pool = vuln_pin or _weighted_pool(prior, "vuln_kinds", exclude=_INTERNAL_ONLY_KINDS)
     if not pool:
         return

--- a/packs/swe/swe/__init__.py
+++ b/packs/swe/swe/__init__.py
@@ -37,9 +37,6 @@ class SwePack(Pack):
         return [repo_has_base_files, suite_well_formed, solution_present]
 
     def make_builder(self, prior: PackPrior | None) -> Builder:
-        # Setup is where an unhonourable isolation request has to fail: late
-        # enough that it does not break discovery for every other pack, early
-        # enough that admission does not mistake it for an infeasible task.
         verify_backend_request()
         return SweBuilder(prior)
 

--- a/packs/swe/swe/__init__.py
+++ b/packs/swe/swe/__init__.py
@@ -18,6 +18,7 @@ from swe.families import SweBuild, SweFix
 from swe.invariants import repo_has_base_files, solution_present, suite_well_formed
 from swe.ontology import ONTOLOGY_ID, repo_ontology
 from swe.realize import SweRuntime
+from swe.sandbox import verify_backend_request
 
 
 class SwePack(Pack):
@@ -36,6 +37,10 @@ class SwePack(Pack):
         return [repo_has_base_files, suite_well_formed, solution_present]
 
     def make_builder(self, prior: PackPrior | None) -> Builder:
+        # Setup is where an unhonourable isolation request has to fail: late
+        # enough that it does not break discovery for every other pack, early
+        # enough that admission does not mistake it for an infeasible task.
+        verify_backend_request()
         return SweBuilder(prior)
 
     def realize(self, graph: WorldGraph, backing: Backing) -> RuntimeHandle:

--- a/packs/swe/swe/families/_target.py
+++ b/packs/swe/swe/families/_target.py
@@ -80,3 +80,21 @@ def str_list(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
     return [str(v) for v in value]
+
+
+def grading_tree(target: Target, workspace: Mapping[str, object]) -> dict[str, str]:
+    """The agent's edits to the files this world declared, and nothing else.
+
+    The grader runs pytest over what it is given, and pytest loads whatever it
+    finds: a ``conftest.py`` or ``pytest.ini`` the agent invented is collected
+    like any other file. That is a route to the grade that does not go through
+    the source — to a plugin hook that passes every test, or to a hang that
+    makes the run report nothing at all. Only declared paths are graded, so a
+    file the world never asked for cannot influence the result.
+    """
+    declared = str_map(target.repo.attrs.get("base_files"))
+    return {
+        str(path): str(content)
+        for path, content in workspace.items()
+        if str(path) in declared
+    }

--- a/packs/swe/swe/families/build.py
+++ b/packs/swe/swe/families/build.py
@@ -110,18 +110,22 @@ class SweBuild(TaskFamily):
                 f"{len(all_ids)} pass): {dict(gold_report.results)}",
             )
 
-        base_report = run_tests(base, test_files, integration)
+        base_report = run_tests(base, test_files, all_ids)
         # An unreported suite is all-False, which *satisfies* all_fail — the world
         # would admit with its gate never demonstrated. Admission fails closed.
         if base_report.error:
             return FeasibilityVerdict(
                 False, f"base suite never reported: {base_report.error}"
             )
-        if not base_report.all_fail(integration):
+        # Units as well as the integration gate: a skeleton that already greens
+        # a unit test hands the agent that subgoal for nothing, and unlike
+        # ``swe.fix``'s pass_to_pass there is no precondition worth preserving
+        # here — the whole project is meant to be unbuilt.
+        if not base_report.all_fail(all_ids):
             return FeasibilityVerdict(
                 False,
-                "skeleton already passes an integration test — the gate is not "
-                f"real or the project is pre-composed: {dict(base_report.results)}",
+                "skeleton already passes part of its own suite — the task would "
+                f"pay for work it did not do: {dict(base_report.results)}",
             )
         return FeasibilityVerdict(True)
 

--- a/packs/swe/swe/families/build.py
+++ b/packs/swe/swe/families/build.py
@@ -35,6 +35,7 @@ from openrange_pack_sdk import (
 
 from swe.families._target import (
     Target,
+    grading_tree,
     pick_target,
     resolve_target,
     str_list,
@@ -140,7 +141,7 @@ class SweBuild(TaskFamily):
             return EpisodeResult(
                 success=False, reason="agent produced no workspace files"
             )
-        tree = {str(k): str(v) for k, v in workspace.items()}
+        tree = grading_tree(target, workspace)
         units = str_list(target.suite.attrs.get("unit_tests"))
         integration = str_list(target.suite.attrs.get("integration_tests"))
         test_files = str_map(target.suite.attrs.get("test_files"))

--- a/packs/swe/swe/families/build.py
+++ b/packs/swe/swe/families/build.py
@@ -98,6 +98,10 @@ class SweBuild(TaskFamily):
         all_ids = [*units, *integration]
 
         gold_report = run_tests({**base, **gold}, test_files, all_ids)
+        if gold_report.error:
+            return FeasibilityVerdict(
+                False, f"gold suite never reported: {gold_report.error}"
+            )
         if not gold_report.all_pass(all_ids):
             return FeasibilityVerdict(
                 False,
@@ -106,6 +110,12 @@ class SweBuild(TaskFamily):
             )
 
         base_report = run_tests(base, test_files, integration)
+        # An unreported suite is all-False, which *satisfies* all_fail — the world
+        # would admit with its gate never demonstrated. Admission fails closed.
+        if base_report.error:
+            return FeasibilityVerdict(
+                False, f"base suite never reported: {base_report.error}"
+            )
         if not base_report.all_fail(integration):
             return FeasibilityVerdict(
                 False,
@@ -136,6 +146,8 @@ class SweBuild(TaskFamily):
         test_files = str_map(target.suite.attrs.get("test_files"))
         all_ids = [*units, *integration]
         report = run_tests(tree, test_files, all_ids)
+        if report.error:
+            return EpisodeResult(success=False, reason=report.error, error=report.error)
         # Integration GATES success; units + integration both SHAPE the subgoal
         # vector the training seam turns into dense partial credit.
         composed = report.all_pass(integration)

--- a/packs/swe/swe/families/fix.py
+++ b/packs/swe/swe/families/fix.py
@@ -84,6 +84,10 @@ class SweFix(TaskFamily):
         all_ids = [*f2p, *p2p]
 
         gold_report = run_tests({**base, **gold}, test_files, all_ids)
+        if gold_report.error:
+            return FeasibilityVerdict(
+                False, f"gold suite never reported: {gold_report.error}"
+            )
         if not gold_report.all_pass(all_ids):
             return FeasibilityVerdict(
                 False,
@@ -92,6 +96,12 @@ class SweFix(TaskFamily):
             )
 
         base_report = run_tests(base, test_files, all_ids)
+        # An unreported suite is all-False, which *satisfies* all_fail — the world
+        # would admit with its bug never demonstrated. Admission fails closed.
+        if base_report.error:
+            return FeasibilityVerdict(
+                False, f"base suite never reported: {base_report.error}"
+            )
         if not base_report.all_fail(f2p):
             return FeasibilityVerdict(
                 False,
@@ -133,6 +143,11 @@ class SweFix(TaskFamily):
         return EpisodeResult(
             success=resolved,
             subgoals={tid: report.results.get(tid, False) for tid in all_ids},
+            error=report.error,
+            # pass_to_pass is green before the agent edits anything —
+            # check_feasibility rejects the task otherwise — so it is a
+            # precondition to preserve, not partial credit to collect.
+            baseline=dict.fromkeys(p2p, True),
             reason=(
                 "all held-out tests pass"
                 if resolved

--- a/packs/swe/swe/families/fix.py
+++ b/packs/swe/swe/families/fix.py
@@ -26,6 +26,7 @@ from openrange_pack_sdk import (
 
 from swe.families._target import (
     Target,
+    grading_tree,
     pick_target,
     resolve_target,
     str_list,
@@ -133,7 +134,7 @@ class SweFix(TaskFamily):
             return EpisodeResult(
                 success=False, reason="agent produced no workspace files"
             )
-        tree = {str(k): str(v) for k, v in workspace.items()}
+        tree = grading_tree(target, workspace)
         f2p = str_list(target.suite.attrs.get("fail_to_pass"))
         p2p = str_list(target.suite.attrs.get("pass_to_pass"))
         test_files = str_map(target.suite.attrs.get("test_files"))

--- a/packs/swe/swe/grading.py
+++ b/packs/swe/swe/grading.py
@@ -42,9 +42,15 @@ _REPORT = "openrange_report.xml"
 
 @dataclass(frozen=True, slots=True)
 class TestReport:
-    """Per-test-id pass/fail from one suite run. ``True`` == the test passed."""
+    """Per-test-id pass/fail from one suite run. ``True`` == the test passed.
+
+    ``error`` is set when the suite never reported: a timeout, a missing or
+    unparseable report. Every id then reads as failed, which is right for a
+    gate and wrong as a grade — the caller separates the two.
+    """
 
     results: Mapping[str, bool]
+    error: str | None = None
 
     def all_pass(self, ids: Sequence[str]) -> bool:
         return bool(ids) and all(self.results.get(i, False) for i in ids)
@@ -95,27 +101,30 @@ def run_tests(
             root=root,
             timeout=timeout,
         )
-        results = _parse_report(report_path, test_ids, proc)
-    return TestReport(results=results)
+        results, error = _parse_report(report_path, test_ids, proc)
+    return TestReport(results=results, error=error)
 
 
 def _parse_report(
     report_path: Path,
     test_ids: Sequence[str],
     proc: SandboxResult,
-) -> dict[str, bool]:
+) -> tuple[dict[str, bool], str | None]:
     """Map each requested nodeid to pass/fail from the JUnit XML.
 
     A test passes iff it ran with no failure / error / skip. Ids missing from the
-    report (collection error, timeout, crash) are failures by construction.
+    report (collection error, timeout, crash) are failures by construction. The
+    second element names the reason the suite never reported at all.
     """
     outcomes: dict[str, bool] = dict.fromkeys(test_ids, False)
-    if proc.timed_out or not report_path.exists():
-        return outcomes
+    if proc.timed_out:
+        return outcomes, "suite timed out"
+    if not report_path.exists():
+        return outcomes, "suite produced no report"
     try:
         tree = ET.parse(report_path)
     except ET.ParseError:
-        return outcomes
+        return outcomes, "suite report is unparseable"
     by_id: dict[str, bool] = {}
     for case in tree.iter("testcase"):
         nodeid = _nodeid(case)
@@ -126,7 +135,7 @@ def _parse_report(
     for tid in test_ids:
         if tid in by_id:
             outcomes[tid] = by_id[tid]
-    return outcomes
+    return outcomes, None
 
 
 def _nodeid(case: ET.Element) -> str | None:

--- a/packs/swe/swe/sandbox.py
+++ b/packs/swe/swe/sandbox.py
@@ -113,9 +113,7 @@ def run_sandboxed(
     """
     inner = [sys.executable, *args]
     env = _child_env(root)
-    override = os.environ.get(_ENV_BACKEND, "auto").strip().lower()
-    backend = _select_backend(override, _bwrap_usable())
-    if backend == "bwrap":
+    if _use_bwrap():
         cmd = _bwrap_wrap(inner, root=root, network=network)
         isolation = "bwrap" if network else "bwrap+netns"
     else:
@@ -124,24 +122,18 @@ def run_sandboxed(
     return _exec(cmd, cwd=root, timeout=timeout, env=env, isolation=isolation)
 
 
-def _select_backend(override: str, usable: bool) -> str:
-    """Pick ``"bwrap"`` or ``"none"``. Pure and total, so both arms are drivable
-    in-process; an unhonourable request is refused once at import, below."""
-    if override in {"none", "subprocess"}:
-        return "none"
-    return "bwrap" if usable else "none"
+def _use_bwrap() -> bool:
+    if os.environ.get(_ENV_BACKEND, "auto").strip().lower() in {"none", "subprocess"}:
+        return False
+    return _bwrap_usable()
 
 
 def verify_backend_request() -> None:
     """Refuse if the operator asked for isolation this host cannot give.
 
-    Silently downgrading hands untrusted code weaker isolation than was asked
-    for and reports success. Where this is called from matters as much as the
-    check: from inside a feasibility check, admission correctly reads the raise
-    as "this task is infeasible" and a seeding pass yields an empty pool with
-    nothing logged; from module import, it fails the pack's entry point and
-    takes every *other* pack's discovery down with it. So the pack calls it from
-    ``make_builder`` — a setup call admission leaves bare on purpose.
+    Called from ``SwePack.make_builder``: raising from a feasibility check would
+    read to admission as an infeasible task, and raising at import would take
+    every other pack's discovery down with this one.
     """
     override = os.environ.get(_ENV_BACKEND, "auto").strip().lower()
     if override == "bwrap" and not _bwrap_usable():

--- a/packs/swe/swe/sandbox.py
+++ b/packs/swe/swe/sandbox.py
@@ -48,6 +48,20 @@ from pathlib import Path
 __all__ = ["SandboxResult", "run_sandboxed"]
 
 _ENV_BACKEND = "OPENRANGE_SWE_SANDBOX"
+
+# What a Python test run genuinely needs from the ambient environment. Anything
+# absent here — cloud credentials, API keys, CI tokens — never reaches the
+# repo's own test code.
+_PASSTHROUGH_ENV = (
+    "PATH",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TMPDIR",
+    "TZ",
+    "SYSTEMROOT",  # Windows: the interpreter will not start without it
+)
 _FSIZE_LIMIT = 2 * 1024 * 1024 * 1024  # 2 GiB — guard a test that fills the disk.
 _CPU_HEADROOM = 60  # CPU-seconds of slack over the wall-clock budget.
 _KILL_GRACE = 5.0
@@ -99,7 +113,8 @@ def run_sandboxed(
     """
     inner = [sys.executable, *args]
     env = _child_env(root)
-    backend = _select_backend(network)
+    override = os.environ.get(_ENV_BACKEND, "auto").strip().lower()
+    backend = _select_backend(override, _bwrap_usable())
     if backend == "bwrap":
         cmd = _bwrap_wrap(inner, root=root, network=network)
         isolation = "bwrap" if network else "bwrap+netns"
@@ -109,15 +124,29 @@ def run_sandboxed(
     return _exec(cmd, cwd=root, timeout=timeout, env=env, isolation=isolation)
 
 
-def _select_backend(network: bool) -> str:
-    """Pick ``"bwrap"`` or ``"none"`` from the env override and a live probe."""
-    override = os.environ.get(_ENV_BACKEND, "auto").strip().lower()
+def _select_backend(override: str, usable: bool) -> str:
+    """Pick ``"bwrap"`` or ``"none"``. Pure and total, so both arms are drivable
+    in-process; an unhonourable request is refused once at import, below."""
     if override in {"none", "subprocess"}:
         return "none"
-    if override == "bwrap":
-        return "bwrap" if _bwrap_usable() else "none"
-    # auto
-    return "bwrap" if _bwrap_usable() else "none"
+    return "bwrap" if usable else "none"
+
+
+def _verify_backend_request() -> None:
+    """Refuse at import if the operator asked for isolation we cannot give.
+
+    Silently downgrading hands untrusted code weaker isolation than was asked
+    for and reports success. The refusal belongs to *setup*: raised later from
+    inside a feasibility check, admission would correctly read it as "this task
+    is infeasible" and a seeding pass would yield an empty pool with nothing
+    logged — a worse failure than the one being prevented.
+    """
+    override = os.environ.get(_ENV_BACKEND, "auto").strip().lower()
+    if override == "bwrap" and not _bwrap_usable():
+        raise RuntimeError(
+            f"{_ENV_BACKEND}=bwrap was requested but bwrap is not usable here; "
+            "refusing to run untrusted code less isolated than asked"
+        )
 
 
 @lru_cache(maxsize=1)
@@ -188,7 +217,10 @@ def _child_env(root: Path) -> dict[str, str]:
     package layout and a ``src/`` layout importable *before* any editable
     install, so the no-build-file repos (the calc fixture) still resolve.
     """
-    env = dict(os.environ)
+    # The child runs repo-supplied test code, so it gets an allowlist rather
+    # than this process's environment: inheriting it hands whatever credentials
+    # the operator exported straight to the code under test.
+    env = {k: os.environ[k] for k in _PASSTHROUGH_ENV if k in os.environ}
     env["PYTHONDONTWRITEBYTECODE"] = "1"
     env["PYTHONUNBUFFERED"] = "1"
     parts = [str(root), str(root / "src")]
@@ -262,3 +294,6 @@ def _set_rlimits(timeout: float):  # type: ignore[no-untyped-def]
                 resource.setrlimit(getattr(resource, name), (limit, limit))
 
     return apply
+
+
+_verify_backend_request()

--- a/packs/swe/swe/sandbox.py
+++ b/packs/swe/swe/sandbox.py
@@ -109,8 +109,11 @@ def run_sandboxed(
     knob: the grading run leaves it ``False`` (isolated where possible); an
     editable install passes ``True``. The call never raises for a non-zero exit
     or a timeout — those are reported in the result, because a failed test run is
-    data, not an error.
+    data, not an error. It *does* raise if the operator demanded isolation this
+    host cannot give: this is the only place that knows what the child actually
+    got, so it is the only place that can keep the promise.
     """
+    verify_backend_request()
     inner = [sys.executable, *args]
     env = _child_env(root)
     if _use_bwrap():
@@ -131,9 +134,11 @@ def _use_bwrap() -> bool:
 def verify_backend_request() -> None:
     """Refuse if the operator asked for isolation this host cannot give.
 
-    Called from ``SwePack.make_builder``: raising from a feasibility check would
-    read to admission as an infeasible task, and raising at import would take
-    every other pack's discovery down with this one.
+    Enforced in ``run_sandboxed``, which is where the guarantee is either kept
+    or not. ``SwePack.make_builder`` calls it too, so the ordinary path fails at
+    setup with the right category rather than surfacing later as an infeasible
+    task; the check in ``run_sandboxed`` is what still holds when a world is
+    built in one process and graded in another.
     """
     override = os.environ.get(_ENV_BACKEND, "auto").strip().lower()
     if override == "bwrap" and not _bwrap_usable():

--- a/packs/swe/swe/sandbox.py
+++ b/packs/swe/swe/sandbox.py
@@ -45,7 +45,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 
-__all__ = ["SandboxResult", "run_sandboxed"]
+__all__ = ["SandboxResult", "run_sandboxed", "verify_backend_request"]
 
 _ENV_BACKEND = "OPENRANGE_SWE_SANDBOX"
 
@@ -132,14 +132,16 @@ def _select_backend(override: str, usable: bool) -> str:
     return "bwrap" if usable else "none"
 
 
-def _verify_backend_request() -> None:
-    """Refuse at import if the operator asked for isolation we cannot give.
+def verify_backend_request() -> None:
+    """Refuse if the operator asked for isolation this host cannot give.
 
     Silently downgrading hands untrusted code weaker isolation than was asked
-    for and reports success. The refusal belongs to *setup*: raised later from
-    inside a feasibility check, admission would correctly read it as "this task
-    is infeasible" and a seeding pass would yield an empty pool with nothing
-    logged — a worse failure than the one being prevented.
+    for and reports success. Where this is called from matters as much as the
+    check: from inside a feasibility check, admission correctly reads the raise
+    as "this task is infeasible" and a seeding pass yields an empty pool with
+    nothing logged; from module import, it fails the pack's entry point and
+    takes every *other* pack's discovery down with it. So the pack calls it from
+    ``make_builder`` — a setup call admission leaves bare on purpose.
     """
     override = os.environ.get(_ENV_BACKEND, "auto").strip().lower()
     if override == "bwrap" and not _bwrap_usable():
@@ -294,6 +296,3 @@ def _set_rlimits(timeout: float):  # type: ignore[no-untyped-def]
                 resource.setrlimit(getattr(resource, name), (limit, limit))
 
     return apply
-
-
-_verify_backend_request()

--- a/packs/trading/trading/families/pnl.py
+++ b/packs/trading/trading/families/pnl.py
@@ -131,6 +131,10 @@ class TradePnl(TaskFamily):
                 "return_target_met": report.return_met,
                 "drawdown_ok": report.drawdown_ok,
             },
+            # Never trading leaves equity flat, so max_drawdown is 0 and the
+            # limit is met: staying out of the market must not read as half a
+            # solved task.
+            baseline={"drawdown_ok": True},
             reason=report.reason,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,16 @@ testpaths = [
 
 [tool.coverage.run]
 branch = true
-source = ["openrange", "openrange_pack_sdk", "cyber_webapp", "openrange_trl"]
+source = [
+    "openrange",
+    "openrange_pack_sdk",
+    "graphschema",
+    "cyber_webapp",
+    "swe",
+    "trading",
+    "openrange_trl",
+    "openrange_rllm",
+]
 omit = [
     "src/openrange/__main__.py",
 ]

--- a/src/openrange/agent.py
+++ b/src/openrange/agent.py
@@ -113,7 +113,7 @@ class AgentRollout:
 
     @property
     def trajectory(self) -> Trajectory:
-        return episode_trajectory(self.report, self.turns)
+        return episode_trajectory(self.report, self.turns, self.reward)
 
 
 def agent_briefing(ctx: EpisodeContext) -> str:

--- a/src/openrange/agent.py
+++ b/src/openrange/agent.py
@@ -19,6 +19,7 @@ ships no per-verb tools.
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -35,6 +36,8 @@ from openrange.training import (
     episode_reward,
     episode_trajectory,
 )
+
+_LOG = logging.getLogger(__name__)
 
 
 class AgentError(RuntimeError):
@@ -200,12 +203,16 @@ async def arun_agent(
     rollouts — the caller closes it.
     """
     handle = service.start_episode(snapshot, task_id)
-    surface = service.surface(handle)
-    capability = await asyncio.to_thread(bind_run, surface)
+    capability: RunCapability | None = None
     steps: list[RolloutStep] = []
     turns: list[AgentTurn] = []
     terminal_reason = "max_turns"
     try:
+        # Inside the guard: binding the shell is the caller's code attaching to a
+        # live world — for a container that is the docker exec, the most
+        # failure-prone step here — and the episode is already registered.
+        surface = service.surface(handle)
+        capability = await asyncio.to_thread(bind_run, surface)
         task = next(t for t in snapshot.tasks if t.id == handle.task_id)
         bound = {**surface, "run": capability.run}
         prompt = agent_briefing(EpisodeContext(task=task, surface=bound))
@@ -249,7 +256,15 @@ async def arun_agent(
             terminal_reason=terminal_reason,
         )
     finally:
-        await asyncio.to_thread(capability.close)
+        # Cleanup must not mask the failure it is cleaning up after, nor let one
+        # failing step skip the next. `stop_episode` reaches pack code
+        # (`poolable()`) and the dashboard write, both of which can raise.
+        try:
+            service.stop_episode(handle)
+        except Exception:
+            _LOG.exception("stopping episode %s failed", handle.id)
+        if capability is not None:
+            await asyncio.to_thread(capability.close)
 
 
 def run_agent(
@@ -306,7 +321,16 @@ async def arun_rollouts(
                 **kwargs,
             )
 
-    return list(await asyncio.gather(*(_one(tid) for tid in ids)))
+    # Settle every rollout before surfacing a failure: a bare gather propagates
+    # the first exception out of the event loop, cancelling its siblings
+    # mid-episode so their worlds are never stopped and their grades are lost.
+    settled = await asyncio.gather(*(_one(tid) for tid in ids), return_exceptions=True)
+    rollouts: list[AgentRollout] = []
+    for outcome in settled:
+        if isinstance(outcome, BaseException):
+            raise outcome
+        rollouts.append(outcome)
+    return rollouts
 
 
 def run_rollouts(

--- a/src/openrange/agent.py
+++ b/src/openrange/agent.py
@@ -146,11 +146,14 @@ def parse_action(text: str) -> AgentAction:
     tool token it only ever sees in our prompt and routinely forgets. The *last*
     recognized block wins, so an illustrative snippet earlier in the reply is not
     executed in place of the action the model actually settled on. A reply with
-    no recognized block becomes a ``finish`` carrying the whole text, so a model
-    that ignores the protocol terminates rather than loops."""
+    no recognized block still terminates the episode, so a model that ignores
+    the protocol does not loop — but it is reported as ``no_action`` rather than
+    ``finish``, because "never produced an action" and "chose to stop" are
+    different outcomes and a trainer that cannot tell them apart learns from the
+    difference as if it were signal."""
     matches = list(_ACTION_BLOCK.finditer(text))
     if not matches:
-        return AgentAction(tool="finish", command=text.strip())
+        return AgentAction(tool="no_action", command=text.strip())
     match = matches[-1]
     lang = match.group(1).lower()
     tool = "finish" if lang == "finish" else "run_shell"
@@ -211,17 +214,17 @@ async def arun_agent(
                 sampler.complete, prompt, system=system_prompt
             )
             action = parse_action(sample.text)
-            if action.tool == "finish":
+            if action.tool in {"finish", "no_action"}:
                 turn = AgentTurn(
                     message=action.command or sample.text,
                     tool_calls=(
-                        {"tool": "finish", "args": {"answer": action.command}},
+                        {"tool": action.tool, "args": {"answer": action.command}},
                     ),
                 )
                 service.record_turn(handle, turn)
                 turns.append(turn)
                 steps.append(RolloutStep(prompt, sample, None, None))
-                terminal_reason = "finished"
+                terminal_reason = "finished" if action.tool == "finish" else "no_action"
                 break
             output = await asyncio.to_thread(run_shell, bound, action.command)
             turn = AgentTurn(

--- a/src/openrange/core/admit.py
+++ b/src/openrange/core/admit.py
@@ -110,8 +110,10 @@ def admit(
 
     errors: list[Issue] = []
     infeasible: list[str] = []
+    attempted = 0
 
     for attempt in range(max_repairs + 1):
+        attempted = attempt + 1
         issues = validate(result.graph, ontology, pack.invariants())
         issues += validate_task_bindings(result.graph, result.tasks)
         errors = [i for i in issues if i.severity == "error"]
@@ -124,7 +126,7 @@ def admit(
             )
         )
 
-        infeasible = _run_feasibility(families, result.graph, result.tasks)
+        infeasible, crashed = _run_feasibility(families, result.graph, result.tasks)
         history.append(
             BuildEvent(
                 len(history),
@@ -133,6 +135,15 @@ def admit(
                 tuple(infeasible),
             )
         )
+        if crashed:
+            history.append(
+                BuildEvent(
+                    len(history),
+                    "feasibility",
+                    "; ".join(f"{task_id}: {why}" for task_id, why in crashed),
+                    tuple(task_id for task_id, _ in crashed),
+                )
+            )
 
         if not errors and not infeasible:
             history.append(
@@ -160,7 +171,21 @@ def admit(
         if attempt == max_repairs:
             break
 
-        result = builder.repair(result, errors, infeasible)
+        try:
+            result = builder.repair(result, errors, infeasible)
+        except Exception as exc:  # noqa: BLE001 — pack-supplied code is untrusted
+            # Not overriding repair() is the SDK's sanctioned opt-out, so the
+            # raise it answers with is a capability signal, not a crash: the
+            # candidate simply gets no retries and fails admission normally.
+            history.append(
+                BuildEvent(
+                    len(history),
+                    "repair",
+                    f"builder did not repair ({type(exc).__name__}); "
+                    f"admission stops after attempt {attempt + 1}",
+                )
+            )
+            break
         history.append(
             BuildEvent(
                 len(history),
@@ -172,7 +197,7 @@ def admit(
     return AdmissionFailure(
         issues=errors,
         infeasible_tasks=infeasible,
-        attempts=max_repairs + 1,
+        attempts=attempted,
         history=tuple(history),
     )
 
@@ -181,8 +206,10 @@ def _run_feasibility(
     families: Mapping[str, TaskFamily],
     graph: WorldGraph,
     tasks: list[TaskSpec],
-) -> list[str]:
+) -> tuple[list[str], list[tuple[str, str]]]:
+    """Infeasible task ids, plus (id, why) for the checks that raised."""
     infeasible: list[str] = []
+    crashed: list[tuple[str, str]] = []
     for t in tasks:
         # An empty-entrypoint task is structurally rejected upstream
         # (``validate_task_bindings``); skipping feasibility here keeps
@@ -195,10 +222,17 @@ def _run_feasibility(
         if family is None:
             infeasible.append(t.id)
             continue
-        verdict: FeasibilityVerdict = family.check_feasibility(graph, t)
+        try:
+            verdict: FeasibilityVerdict = family.check_feasibility(graph, t)
+        except Exception as exc:  # noqa: BLE001 — pack-supplied code is untrusted
+            # A check that cannot answer has not shown the task solvable, and
+            # admission is the gate: reject the task rather than the build.
+            infeasible.append(t.id)
+            crashed.append((t.id, f"{type(exc).__name__}: {exc}"))
+            continue
         if not verdict.feasible:
             infeasible.append(t.id)
-    return infeasible
+    return infeasible, crashed
 
 
 def snapshot_to_dict(snap: Snapshot) -> dict[str, Any]:

--- a/src/openrange/core/admit.py
+++ b/src/openrange/core/admit.py
@@ -174,15 +174,19 @@ def admit(
         try:
             result = builder.repair(result, errors, infeasible)
         except Exception as exc:  # noqa: BLE001 — pack-supplied code is untrusted
-            # Not overriding repair() is the SDK's sanctioned opt-out, so the
-            # raise it answers with is a capability signal, not a crash: the
-            # candidate simply gets no retries and fails admission normally.
+            # Not overriding repair() is the SDK's sanctioned opt-out; anything
+            # else is a crash, and calling it the opt-out discards the only
+            # record of it.
+            reason = (
+                "builder did not implement repair()"
+                if isinstance(exc, NotImplementedError)
+                else f"repair raised {type(exc).__name__}: {exc}"
+            )
             history.append(
                 BuildEvent(
                     len(history),
                     "repair",
-                    f"builder did not repair ({type(exc).__name__}); "
-                    f"admission stops after attempt {attempt + 1}",
+                    f"{reason}; admission stops after attempt {attempt + 1}",
                 )
             )
             break

--- a/src/openrange/core/curriculum.py
+++ b/src/openrange/core/curriculum.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -33,6 +34,8 @@ from openrange.core.episode import EpisodeService
 
 if TYPE_CHECKING:
     from openrange_pack_sdk import Snapshot
+
+_LOG = logging.getLogger(__name__)
 
 
 Direction = Literal["harden", "soften", "diversify"]
@@ -150,7 +153,12 @@ def auto_evolve(
     for chosen in _patch_candidates(pack, snapshot, reports, direction, llm=llm):
         try:
             evolved = _evolve_snapshot(snapshot, pack, chosen, max_repairs=max_repairs)
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001 — pack-supplied code is untrusted
+            _LOG.warning(
+                "evolving %s failed; the frontier does not move for it",
+                snapshot.snapshot_id,
+                exc_info=True,
+            )
             continue
         if evolved is None or evolved.snapshot_id == snapshot.snapshot_id:
             continue
@@ -158,7 +166,13 @@ def auto_evolve(
             try:
                 if not gate(evolved, chosen):
                     continue
-            except Exception:  # noqa: BLE001
+            except Exception:  # noqa: BLE001 — caller-supplied gate
+                _LOG.warning(
+                    "evolution gate raised on a candidate from %s; treating it "
+                    "as rejected",
+                    snapshot.snapshot_id,
+                    exc_info=True,
+                )
                 continue
         return evolved
 
@@ -167,6 +181,11 @@ def auto_evolve(
     try:
         return _grow_snapshot(snapshot, pack, direction, max_repairs=max_repairs)
     except Exception:  # noqa: BLE001 — pack-supplied code is untrusted
+        _LOG.warning(
+            "growing %s failed; the frontier stays where it is",
+            snapshot.snapshot_id,
+            exc_info=True,
+        )
         return None
 
 

--- a/src/openrange/core/episode.py
+++ b/src/openrange/core/episode.py
@@ -134,7 +134,9 @@ class EpisodeReport:
             "episode_result": {
                 "success": self.episode_result.success,
                 "subgoals": dict(self.episode_result.subgoals),
+                "baseline": dict(self.episode_result.baseline),
                 "reason": self.episode_result.reason,
+                "error": self.episode_result.error,
             },
             "final_state": dict(self.final_state),
             "agent_summary": self.agent_summary,
@@ -343,12 +345,15 @@ class EpisodeService:
             running.final_state = final_state
             episode_result = self._check_success(running, final_state)
         except Exception as exc:  # noqa: BLE001
-            # A grader/collect crash becomes a failed grade, not a propagated error.
+            # A grader/collect crash must not abort the batch, but it is the
+            # harness failing, not the agent answering wrongly — ``error`` is
+            # what keeps the curriculum from ranking the world on it.
             running.final_state = final_state
             episode_result = EpisodeResult(
                 success=False,
                 subgoals={},
                 reason=f"grading failed: {exc!r}",
+                error=f"{type(exc).__name__}: {exc}",
             )
             self._record_system(
                 running,
@@ -569,6 +574,7 @@ class EpisodeService:
                     f"pack {self.pack.id!r} has no TaskFamily "
                     f"{running.task.success_check!r}"
                 ),
+                error=f"unresolved success_check {running.task.success_check!r}",
             )
         return family.check_success(running.snapshot.graph, running.task, final_state)
 

--- a/src/openrange/core/episode.py
+++ b/src/openrange/core/episode.py
@@ -351,9 +351,8 @@ class EpisodeService:
             running.final_state = final_state
             episode_result = self._check_success(running, final_state)
         except Exception as exc:  # noqa: BLE001
-            # A grader/collect crash must not abort the batch, but it is the
-            # harness failing, not the agent answering wrongly — ``error`` is
-            # what keeps the curriculum from ranking the world on it.
+            # A grader/collect crash becomes a failed grade, not a propagated
+            # error — and `error` marks it a non-measurement.
             running.final_state = final_state
             episode_result = EpisodeResult(
                 success=False,

--- a/src/openrange/core/episode.py
+++ b/src/openrange/core/episode.py
@@ -308,8 +308,14 @@ class EpisodeService:
         if not _is_poolable(running.runtime):
             return False
         snapshot_id = running.snapshot.snapshot_id
+        # Overwrite would drop whatever is already parked under this key without
+        # stopping it — and since the dict does not grow, the eviction below
+        # never fires to reclaim it either.
+        displaced = self._warm.pop(snapshot_id, None)
+        if displaced is not None:
+            with contextlib.suppress(Exception):
+                displaced.stop()
         self._warm[snapshot_id] = running.runtime
-        self._warm.move_to_end(snapshot_id)
         while len(self._warm) > self._warm_capacity:
             _, evicted = self._warm.popitem(last=False)
             with contextlib.suppress(Exception):

--- a/src/openrange/core/pack.py
+++ b/src/openrange/core/pack.py
@@ -46,7 +46,6 @@ class PackRegistry:
             return
         if self._discovered and not force:
             return
-        self._discovered = True
         from openrange.core._registry import iter_entry_points
 
         for name, value in iter_entry_points(
@@ -66,6 +65,10 @@ class PackRegistry:
                     f"entry point name {name!r} does not match pack.id {pack.id!r}",
                 )
             self._packs[pack.id] = pack
+        # Only once the sweep completed. Marking it before the loop makes a
+        # single malformed entry point raise once and then return a partial
+        # registry, silently, for the rest of the process.
+        self._discovered = True
 
 
 PACKS = PackRegistry(autodiscover=True)

--- a/src/openrange/core/store.py
+++ b/src/openrange/core/store.py
@@ -31,8 +31,8 @@ class SnapshotStore:
         return path
 
     def load(self, snapshot_id: str) -> Snapshot:
-        """Raises `StoreError` if the file is missing, malformed, or its
-        stored `snapshot_id` does not match `<root>/<snapshot_id>.json`."""
+        """Raises `StoreError` if the file is missing, malformed, or its graph
+        does not hash to `snapshot_id`."""
         path = self.root / f"{snapshot_id}.json"
         try:
             raw = path.read_text(encoding="utf-8")
@@ -49,6 +49,11 @@ class SnapshotStore:
             raise StoreError(
                 f"snapshot id mismatch: file {snapshot_id!r} carries id "
                 f"{snap.snapshot_id!r}"
+            )
+        if snap.graph.content_hash() != snapshot_id:
+            raise StoreError(
+                f"snapshot {snapshot_id!r} does not hash to its id; the stored "
+                "graph was modified after it was written"
             )
         return snap
 

--- a/src/openrange/llm.py
+++ b/src/openrange/llm.py
@@ -396,6 +396,14 @@ def _openai_compatible_result(raw: str, request: LLMRequest) -> LLMResult:
     content = message.get("content")
     if not isinstance(content, str):
         raise LLMBackendError("OpenAI-compatible message content was not text")
+    if not content:
+        # A refusal or a content filter answers 200 with empty text. Passing it
+        # on makes the caller grade "the provider returned nothing" as
+        # "the model said nothing worth acting on".
+        raise LLMBackendError(
+            "OpenAI-compatible message content was empty "
+            f"(finish_reason={first.get('finish_reason')!r})"
+        )
 
     if request.json_schema is None:
         return LLMResult(content)

--- a/src/openrange/npc.py
+++ b/src/openrange/npc.py
@@ -56,7 +56,6 @@ class NPCRegistry:
             return
         if self._discovered and not force:
             return
-        self._discovered = True
         from openrange.core._registry import iter_entry_points
 
         for name, value in iter_entry_points(
@@ -71,6 +70,8 @@ class NPCRegistry:
                     f"entry point {name!r} did not yield a callable",
                 )
             self._factories[name] = value
+        # Only once the sweep completed — see PackRegistry._ensure_discovered.
+        self._discovered = True
 
 
 NPCS = NPCRegistry(autodiscover=True)

--- a/src/openrange/pool.py
+++ b/src/openrange/pool.py
@@ -125,6 +125,12 @@ def _gated_members(
     for manifest in manifests:
         result = admit(pack, dict(manifest), max_repairs=max_repairs)
         if isinstance(result, AdmissionFailure):
+            _LOG.warning(
+                "manifest rejected after %d attempt(s): %s",
+                result.attempts,
+                "; ".join([i.message for i in result.issues] + result.infeasible_tasks)
+                or "no issue reported",
+            )
             continue
         if seed_gate is not None and not seed_gate(result):
             _LOG.warning(

--- a/src/openrange/pool.py
+++ b/src/openrange/pool.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from openrange_pack_sdk import Mutation, Pack, Snapshot
 
@@ -39,6 +39,32 @@ GateFactory = Callable[[Snapshot], EvolutionGate]
 
 _STALENESS_STEP = 0.1
 _MAX_PRIORITY = 2.0
+_HISTORY_LIMIT = 64
+
+
+@dataclass(frozen=True, slots=True)
+class RoundOutcome:
+    """What one round measured for one world in the pool.
+
+    Kept per member (the most recent :data:`_HISTORY_LIMIT` rounds) so a caller
+    can regress ``difficulty`` against observed solve rate instead of trusting
+    it, and so a scorer can read a world's trend rather than only the priority
+    that overwrote it.
+    """
+
+    round_index: int
+    difficulty: float
+    priority: float
+    rewards: tuple[float, ...]
+    passed: int
+
+    @property
+    def solve_rate(self) -> float:
+        return self.passed / len(self.rewards) if self.rewards else 0.0
+
+    @property
+    def mean_reward(self) -> float:
+        return sum(self.rewards) / len(self.rewards) if self.rewards else 0.0
 
 
 @dataclass
@@ -49,6 +75,7 @@ class _Member:
     family: str
     difficulty: float
     priority: float = 1.0
+    history: list[RoundOutcome] = field(default_factory=list)
 
     @property
     def key(self) -> tuple[str, str]:
@@ -136,18 +163,16 @@ def _mean_pass_rate(report_groups: Iterable[Sequence[EpisodeReport]]) -> float:
     return sum(rates) / len(rates) if rates else 0.0
 
 
-def _member_priority(
-    reports: Sequence[EpisodeReport], reward_fn: RewardFn = episode_reward
-) -> float:
-    scalars = [reward_fn(r).scalar for r in reports]
-    mean = sum(scalars) / len(scalars)
+def _member_priority(rewards: Sequence[Reward]) -> float:
+    mean = sum(r.scalar for r in rewards) / len(rewards)
     learnability = 1.0 - abs(2.0 * mean - 1.0)
-    gaps = []
-    for report in reports:
-        subgoals = report.episode_result.subgoals
-        if subgoals:
-            achieved = sum(1 for hit in subgoals.values() if hit)
-            gaps.append(1.0 - achieved / len(subgoals))
+    # Regret reads the shaped components, so a subgoal the world granted for free
+    # cannot masquerade as headroom the agent failed to reach.
+    gaps = [
+        1.0 - sum(r.components.values()) / len(r.components)
+        for r in rewards
+        if r.components
+    ]
     regret = sum(gaps) / len(gaps) if gaps else 0.0
     return learnability + regret
 
@@ -182,6 +207,7 @@ class WorldPool:
         self._max_size = max_size
         self._mix_floor = mix_floor
         self._last_difficulty_gain: float | None = None
+        self._round = 0
 
     @classmethod
     def seed(
@@ -216,6 +242,18 @@ class WorldPool:
 
     def snapshots(self) -> list[Snapshot]:
         return _snapshots_of(self._members.values())
+
+    def history(self) -> dict[tuple[str, str], tuple[RoundOutcome, ...]]:
+        """Per-member measured rounds, oldest first, for members that have run.
+
+        The join a caller needs to check ``difficulty`` against what agents
+        actually did with these worlds; the pool itself never reads it.
+        """
+        return {
+            key: tuple(member.history)
+            for key, member in self._members.items()
+            if member.history
+        }
 
     def round_rows(self, *, groups: int, num_generations: int) -> list[PromptRow]:
         return _rows_for(self._select(groups), num_generations)
@@ -259,14 +297,49 @@ class WorldPool:
         max_repairs: int = 2,
         reward_fn: RewardFn = episode_reward,
     ) -> bool:
+        self._round += 1
+        graded: dict[tuple[str, str], Sequence[EpisodeReport]] = {}
         for member in self._members.values():
-            ran = reports.get(member.key)
+            # An errored episode graded nothing, so it is not evidence about the
+            # world; a round of only those leaves the member unmeasured.
+            attempted = reports.get(member.key) or ()
+            ran = [
+                report for report in attempted if report.episode_result.error is None
+            ]
             if ran:
-                member.priority = _member_priority(ran, reward_fn)
+                graded[member.key] = ran
+                # One pass: reward_fn is caller-supplied and may be expensive.
+                rewards = [reward_fn(report) for report in ran]
+                member.priority = _member_priority(rewards)
+                member.history.append(
+                    RoundOutcome(
+                        round_index=self._round,
+                        difficulty=member.difficulty,
+                        priority=member.priority,
+                        rewards=tuple(reward.scalar for reward in rewards),
+                        passed=sum(1 for report in ran if report.passed),
+                    )
+                )
+                del member.history[:-_HISTORY_LIMIT]
+            elif attempted:
+                # Ran and graded nothing, so it taught nothing: sort it to the
+                # back. Holding priority steady is not neutral — priority is
+                # comparative, and the staleness arm below would still march a
+                # world nobody can grade to the front one skipped round at a
+                # time. Staleness is also how it recovers if the failure was
+                # transient.
+                member.priority = 0.0
+                _LOG.warning(
+                    "pool: %s graded nothing this round (%d errored episode(s))",
+                    member.key,
+                    len(attempted),
+                )
             else:
                 member.priority = min(member.priority + _STALENESS_STEP, _MAX_PRIORITY)
+        # Evolution reads the same graded subset: an ungraded round must not
+        # steer the frontier either.
         grown, capped, gain = self._grow(
-            reports, pack, policy, gate, gate_factory, evolve_top, max_repairs
+            graded, pack, policy, gate, gate_factory, evolve_top, max_repairs
         )
         self._last_difficulty_gain = gain
         self._bound(grown)

--- a/src/openrange/pool.py
+++ b/src/openrange/pool.py
@@ -276,6 +276,13 @@ class WorldPool:
         max_repairs: int = 2,
         reward_fn: RewardFn = episode_reward,
     ) -> bool:
+        """Re-price the pool from a round's reports and evolve its frontier.
+
+        ``reports`` must carry a key for every member ``round_rows`` offered,
+        even when all of its episodes errored: a missing key is indistinguishable
+        from "never selected" and takes the staleness bump meant for a world
+        still waiting its turn.
+        """
         graded: dict[tuple[str, str], Sequence[EpisodeReport]] = {}
         for member in self._members.values():
             # An errored episode graded nothing, so it is not evidence about the

--- a/src/openrange/pool.py
+++ b/src/openrange/pool.py
@@ -158,9 +158,22 @@ def _snapshots_of(members: Iterable[_Member]) -> list[Snapshot]:
     return list(by_id.values())
 
 
-def _mean_pass_rate(report_groups: Iterable[Sequence[EpisodeReport]]) -> float:
-    rates = [sum(1 for r in g if r.passed) / len(g) for g in report_groups if g]
-    return sum(rates) / len(rates) if rates else 0.0
+def _mean_pass_rate(
+    report_groups: Iterable[Sequence[EpisodeReport]],
+) -> tuple[float, int]:
+    """Mean solve rate over the episodes that graded, and how many groups did.
+
+    An errored episode measured nothing. Leaving it in the denominator deflates
+    the only number a trainer reads by however much the infrastructure flaked,
+    and the count is what separates "solved none of them" from "graded none of
+    them" — which are the same ``0.0`` otherwise.
+    """
+    rates: list[float] = []
+    for group in report_groups:
+        graded = [r for r in group if r.episode_result.error is None]
+        if graded:
+            rates.append(sum(1 for r in graded if r.passed) / len(graded))
+    return (sum(rates) / len(rates) if rates else 0.0), len(rates)
 
 
 def _member_priority(rewards: Sequence[Reward]) -> float:
@@ -409,6 +422,12 @@ class RoundMetrics:
     held_out_solve_rate: float | None = None
     frontier_capped: bool = False
     difficulty_gain: float | None = None
+    graded_members: int = 0
+    """How many pool members actually produced a grade this round.
+
+    ``train_solve_rate`` is a mean over these; at zero the round measured
+    nothing and the rate is not evidence of anything.
+    """
 
     @property
     def generalization_gap(self) -> float | None:
@@ -460,9 +479,10 @@ class EvalPool:
         return _rows_for(self._members, num_generations)
 
     def solve_rate(self, reports: RoundReports) -> float:
-        return _mean_pass_rate(
+        rate, _graded = _mean_pass_rate(
             reports[m.key] for m in self._members if m.key in reports
         )
+        return rate
 
 
 def run_pool_curriculum(
@@ -515,9 +535,11 @@ def run_pool_curriculum(
             evolve_top=evolve_top,
             reward_fn=reward_fn,
         )
+        train_rate, graded = _mean_pass_rate(reports.values())
         metrics.append(
             RoundMetrics(
-                train_solve_rate=_mean_pass_rate(reports.values()),
+                train_solve_rate=train_rate,
+                graded_members=graded,
                 held_out_solve_rate=held_out,
                 frontier_capped=capped,
                 difficulty_gain=pool._last_difficulty_gain,

--- a/src/openrange/pool.py
+++ b/src/openrange/pool.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from openrange_pack_sdk import Mutation, Pack, Snapshot
 
@@ -39,32 +39,6 @@ GateFactory = Callable[[Snapshot], EvolutionGate]
 
 _STALENESS_STEP = 0.1
 _MAX_PRIORITY = 2.0
-_HISTORY_LIMIT = 64
-
-
-@dataclass(frozen=True, slots=True)
-class RoundOutcome:
-    """What one round measured for one world in the pool.
-
-    Kept per member (the most recent :data:`_HISTORY_LIMIT` rounds) so a caller
-    can regress ``difficulty`` against observed solve rate instead of trusting
-    it, and so a scorer can read a world's trend rather than only the priority
-    that overwrote it.
-    """
-
-    round_index: int
-    difficulty: float
-    priority: float
-    rewards: tuple[float, ...]
-    passed: int
-
-    @property
-    def solve_rate(self) -> float:
-        return self.passed / len(self.rewards) if self.rewards else 0.0
-
-    @property
-    def mean_reward(self) -> float:
-        return sum(self.rewards) / len(self.rewards) if self.rewards else 0.0
 
 
 @dataclass
@@ -75,7 +49,6 @@ class _Member:
     family: str
     difficulty: float
     priority: float = 1.0
-    history: list[RoundOutcome] = field(default_factory=list)
 
     @property
     def key(self) -> tuple[str, str]:
@@ -125,11 +98,15 @@ def _gated_members(
     for manifest in manifests:
         result = admit(pack, dict(manifest), max_repairs=max_repairs)
         if isinstance(result, AdmissionFailure):
+            # The build history, not just the issues: a check that *raised*
+            # produces no Issue, and its exception text is recorded only there.
             _LOG.warning(
                 "manifest rejected after %d attempt(s): %s",
                 result.attempts,
-                "; ".join([i.message for i in result.issues] + result.infeasible_tasks)
-                or "no issue reported",
+                "; ".join(
+                    [i.message for i in result.issues]
+                    + [event.detail for event in result.history]
+                ),
             )
             continue
         if seed_gate is not None and not seed_gate(result):
@@ -166,20 +143,16 @@ def _snapshots_of(members: Iterable[_Member]) -> list[Snapshot]:
 
 def _mean_pass_rate(
     report_groups: Iterable[Sequence[EpisodeReport]],
-) -> tuple[float, int]:
-    """Mean solve rate over the episodes that graded, and how many groups did.
-
-    An errored episode measured nothing. Leaving it in the denominator deflates
-    the only number a trainer reads by however much the infrastructure flaked,
-    and the count is what separates "solved none of them" from "graded none of
-    them" — which are the same ``0.0`` otherwise.
-    """
+) -> float:
+    # An errored episode measured nothing; leaving it in the denominator
+    # deflates the only number a trainer reads by however much the
+    # infrastructure flaked.
     rates: list[float] = []
     for group in report_groups:
         graded = [r for r in group if r.episode_result.error is None]
         if graded:
             rates.append(sum(1 for r in graded if r.passed) / len(graded))
-    return (sum(rates) / len(rates) if rates else 0.0), len(rates)
+    return sum(rates) / len(rates) if rates else 0.0
 
 
 def _member_priority(rewards: Sequence[Reward]) -> float:
@@ -226,7 +199,6 @@ class WorldPool:
         self._max_size = max_size
         self._mix_floor = mix_floor
         self._last_difficulty_gain: float | None = None
-        self._round = 0
 
     @classmethod
     def seed(
@@ -261,18 +233,6 @@ class WorldPool:
 
     def snapshots(self) -> list[Snapshot]:
         return _snapshots_of(self._members.values())
-
-    def history(self) -> dict[tuple[str, str], tuple[RoundOutcome, ...]]:
-        """Per-member measured rounds, oldest first, for members that have run.
-
-        The join a caller needs to check ``difficulty`` against what agents
-        actually did with these worlds; the pool itself never reads it.
-        """
-        return {
-            key: tuple(member.history)
-            for key, member in self._members.items()
-            if member.history
-        }
 
     def round_rows(self, *, groups: int, num_generations: int) -> list[PromptRow]:
         return _rows_for(self._select(groups), num_generations)
@@ -316,7 +276,6 @@ class WorldPool:
         max_repairs: int = 2,
         reward_fn: RewardFn = episode_reward,
     ) -> bool:
-        self._round += 1
         graded: dict[tuple[str, str], Sequence[EpisodeReport]] = {}
         for member in self._members.values():
             # An errored episode graded nothing, so it is not evidence about the
@@ -328,18 +287,9 @@ class WorldPool:
             if ran:
                 graded[member.key] = ran
                 # One pass: reward_fn is caller-supplied and may be expensive.
-                rewards = [reward_fn(report) for report in ran]
-                member.priority = _member_priority(rewards)
-                member.history.append(
-                    RoundOutcome(
-                        round_index=self._round,
-                        difficulty=member.difficulty,
-                        priority=member.priority,
-                        rewards=tuple(reward.scalar for reward in rewards),
-                        passed=sum(1 for report in ran if report.passed),
-                    )
+                member.priority = _member_priority(
+                    [reward_fn(report) for report in ran]
                 )
-                del member.history[:-_HISTORY_LIMIT]
             elif attempted:
                 # Ran and graded nothing, so it taught nothing: sort it to the
                 # back. Holding priority steady is not neutral — priority is
@@ -428,12 +378,6 @@ class RoundMetrics:
     held_out_solve_rate: float | None = None
     frontier_capped: bool = False
     difficulty_gain: float | None = None
-    graded_members: int = 0
-    """How many pool members actually produced a grade this round.
-
-    ``train_solve_rate`` is a mean over these; at zero the round measured
-    nothing and the rate is not evidence of anything.
-    """
 
     @property
     def generalization_gap(self) -> float | None:
@@ -485,10 +429,9 @@ class EvalPool:
         return _rows_for(self._members, num_generations)
 
     def solve_rate(self, reports: RoundReports) -> float:
-        rate, _graded = _mean_pass_rate(
+        return _mean_pass_rate(
             reports[m.key] for m in self._members if m.key in reports
         )
-        return rate
 
 
 def run_pool_curriculum(
@@ -541,11 +484,9 @@ def run_pool_curriculum(
             evolve_top=evolve_top,
             reward_fn=reward_fn,
         )
-        train_rate, graded = _mean_pass_rate(reports.values())
         metrics.append(
             RoundMetrics(
-                train_solve_rate=train_rate,
-                graded_members=graded,
+                train_solve_rate=_mean_pass_rate(reports.values()),
                 held_out_solve_rate=held_out,
                 frontier_capped=capped,
                 difficulty_gain=pool._last_difficulty_gain,

--- a/src/openrange/runtime.py
+++ b/src/openrange/runtime.py
@@ -18,7 +18,12 @@ from openrange_pack_sdk import (
 )
 
 from openrange.core.admit import AdmissionFailure, admit
-from openrange.core.episode import AgentTurn, EpisodeError, EpisodeService
+from openrange.core.episode import (
+    AgentTurn,
+    EpisodeError,
+    EpisodeReport,
+    EpisodeService,
+)
 from openrange.core.errors import EpisodeRuntimeError as EpisodeRuntimeError
 from openrange.core.pack import PACKS
 from openrange.dashboard import (
@@ -26,7 +31,7 @@ from openrange.dashboard import (
     DashboardHTTPServer,
     DashboardView,
 )
-from openrange.training import EpisodeRun
+from openrange.training import EpisodeRun, Reward, episode_reward
 
 
 @dataclass(frozen=True, slots=True)
@@ -193,6 +198,7 @@ class OpenRangeRun:
         solver: Solver,
         *,
         task_id: str | None = None,
+        reward_fn: Callable[[EpisodeReport], Reward] = episode_reward,
     ) -> EpisodeRun:
         """Run one episode end to end and return the graded result.
 
@@ -219,7 +225,7 @@ class OpenRangeRun:
             report = svc.stop_episode(handle)
         finally:
             svc.close()
-        return EpisodeRun(report=report, turns=tuple(turns))
+        return EpisodeRun(report=report, reward=reward_fn(report), turns=tuple(turns))
 
     def serve_dashboard(
         self,

--- a/src/openrange/training.py
+++ b/src/openrange/training.py
@@ -15,9 +15,11 @@ This is the reference half of the training-integration standard
 is the first consumer. Three choices keep it trainer-agnostic:
 
 - **Dense by default.** ``episode_reward`` gives a solved episode ``1.0`` and an
-  unsolved one the *fraction* of its subgoals that passed — partial credit a
-  trainer can learn from — with no per-domain knowledge. A pack that wants
-  bespoke shaping writes its own function returning a ``Reward``.
+  unsolved one the *fraction* of its still-in-play subgoals that passed — those
+  the result's ``baseline`` did not already grant — and ``0.0`` when a
+  precondition regressed. Partial credit a trainer can learn from, with no
+  per-domain knowledge. A pack that wants bespoke shaping writes its own
+  function returning a ``Reward``.
 - **The curriculum dimension rides along.** Each ``Trajectory`` is tagged with
   the ``snapshot_id`` it ran against, so trajectories logged across an
   ``evolve(...)`` curriculum stay attributable to the exact (hardened) world
@@ -41,7 +43,9 @@ from openrange.core.episode import AgentTurn, EpisodeReport
 class Reward:
     """A shaped reward. ``scalar`` (in ``[0, 1]``) is what a scalar-reward
     trainer reads; ``components`` is the per-subgoal vector for trainers that
-    consume structured signals."""
+    consume structured signals, each also in ``[0, 1]`` and covering the
+    subgoals that were still in play. A shaper that leaves it empty gives the
+    curriculum no regret signal — priority then reads learnability alone."""
 
     scalar: float
     components: Mapping[str, float] = field(default_factory=dict)
@@ -98,18 +102,30 @@ class Trajectory:
 def episode_reward(report: EpisodeReport) -> Reward:
     """Shape an ``EpisodeReport`` into a dense, trainer-agnostic ``Reward``.
 
-    ``components`` maps each subgoal to ``1.0`` / ``0.0``. ``scalar`` is ``1.0``
-    for a solved episode; otherwise the fraction of subgoals that passed (partial
-    credit), or ``0.0`` when the pack reports no subgoals.
+    ``components`` holds the subgoals still in play — every one the result's
+    ``baseline`` did not already grant, plus any precondition that regressed —
+    each ``1.0`` / ``0.0``. ``scalar`` is ``1.0`` for a solved episode, otherwise
+    the fraction of those earned, and ``0.0`` when nothing was in play or a
+    precondition regressed.
     """
-    subgoals = report.episode_result.subgoals
-    components = {str(k): (1.0 if v else 0.0) for k, v in subgoals.items()}
+    result = report.episode_result
+    baseline = result.baseline
+    # A precondition stays out of the vector only while it holds: drop it when
+    # it regressed and the loss becomes invisible to everything downstream.
+    components = {
+        str(k): (1.0 if v else 0.0)
+        for k, v in result.subgoals.items()
+        if not (baseline.get(k, False) and v)
+    }
     if report.passed:
-        scalar = 1.0
-    elif components:
-        scalar = sum(components.values()) / len(components)
-    else:
-        scalar = 0.0
+        return Reward(scalar=1.0, components=components)
+    regressed = any(
+        was_met and not result.subgoals.get(name, False)
+        for name, was_met in baseline.items()
+    )
+    if regressed or not components:
+        return Reward(scalar=0.0, components=components)
+    scalar = sum(components.values()) / len(components)
     return Reward(scalar=scalar, components=components)
 
 

--- a/src/openrange/training.py
+++ b/src/openrange/training.py
@@ -132,6 +132,7 @@ def episode_reward(report: EpisodeReport) -> Reward:
 def episode_trajectory(
     report: EpisodeReport,
     turns: Sequence[AgentTurn] | None = None,
+    reward: Reward | None = None,
 ) -> Trajectory:
     """Assemble a ``Trajectory`` from a report and the turns the harness recorded.
 
@@ -139,6 +140,10 @@ def episode_trajectory(
     the per-step record is rebuilt from ``turns`` — the same ``AgentTurn`` objects
     the harness passed to ``record_turn``. With no turns the trajectory still
     carries the terminal reward + outcome (a degenerate zero-step episode).
+
+    ``reward`` is the already-graded scalar. A caller running its own objective
+    must pass it: the exported trajectory is what a trainer consumes, so leaving
+    it to default here writes a number the caller is not optimizing.
     """
     steps = tuple(
         TrajectoryStep(
@@ -154,7 +159,7 @@ def episode_trajectory(
         snapshot_id=report.snapshot_id,
         task_id=report.task_id,
         steps=steps,
-        reward=episode_reward(report),
+        reward=episode_reward(report) if reward is None else reward,
         success=report.passed,
         reason=report.episode_result.reason,
     )

--- a/src/openrange/training.py
+++ b/src/openrange/training.py
@@ -174,15 +174,12 @@ class EpisodeRun:
     """
 
     report: EpisodeReport
+    reward: Reward
     turns: tuple[AgentTurn, ...] = ()
 
     @property
     def trajectory(self) -> Trajectory:
-        return episode_trajectory(self.report, self.turns)
-
-    @property
-    def reward(self) -> Reward:
-        return self.trajectory.reward
+        return episode_trajectory(self.report, self.turns, self.reward)
 
     @property
     def success(self) -> bool:

--- a/tests/test_admit.py
+++ b/tests/test_admit.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-import pytest
 from graphschema import (
     AttrSpec,
     AttrType,
@@ -512,15 +511,43 @@ def test_admit_repair_exhausts_budget() -> None:
     assert builder.repair_calls == 2
 
 
-def test_admit_default_repair_raises_when_called() -> None:
+def test_a_builder_that_does_not_repair_fails_admission_normally() -> None:
+    # Not overriding repair() is the SDK's sanctioned opt-out, so a pack that
+    # takes it must still get the documented AdmissionFailure — otherwise that
+    # failure is unreachable for it at the shipped max_repairs, and every
+    # caller of admit() has to guard a NotImplementedError instead.
     class _Bare(Builder):
         def build(self, manifest: Manifest) -> BuildResult:
             del manifest
             return _bad_build_result()
 
     pack = _TestPack(_Bare(), families=[_PentestFamily()])
-    with pytest.raises(NotImplementedError):
-        admit(pack, manifest={}, max_repairs=1)
+    out = admit(pack, manifest={}, max_repairs=1)
+    assert isinstance(out, AdmissionFailure)
+    assert out.attempts == 1  # the one attempt it actually made, not the budget
+    assert any(
+        e.phase == "repair" and "did not repair" in e.detail for e in out.history
+    )
+
+
+def test_a_raising_feasibility_check_rejects_only_its_task() -> None:
+    # A check that cannot answer has not shown the task solvable. Rejecting the
+    # task keeps admission fail-closed; letting the exception out would abort a
+    # whole seeding pass over one bad family.
+    class _Raising(_PentestFamily):
+        def check_feasibility(
+            self, graph: WorldGraph, task: TaskSpec
+        ) -> FeasibilityVerdict:
+            del graph, task
+            raise RuntimeError("feasibility boom")
+
+    pack = _TestPack(
+        _StaticBuilder(_good_build_result("test.pentest")), families=[_Raising()]
+    )
+    out = admit(pack, manifest={}, max_repairs=0)
+    assert isinstance(out, AdmissionFailure)
+    assert out.infeasible_tasks
+    assert any("feasibility boom" in e.detail for e in out.history)
 
 
 def test_validate_task_bindings_returns_empty_for_clean_tasks() -> None:

--- a/tests/test_admit.py
+++ b/tests/test_admit.py
@@ -526,8 +526,37 @@ def test_a_builder_that_does_not_repair_fails_admission_normally() -> None:
     assert isinstance(out, AdmissionFailure)
     assert out.attempts == 1  # the one attempt it actually made, not the budget
     assert any(
-        e.phase == "repair" and "did not repair" in e.detail for e in out.history
+        e.phase == "repair" and "did not implement repair()" in e.detail
+        for e in out.history
     )
+
+
+def test_a_repair_that_crashes_is_not_recorded_as_the_opt_out() -> None:
+    # A builder that implements repair() and blows up inside it has told us
+    # nothing about its capabilities. Filing that under the opt-out throws away
+    # the only trace of the crash, and `ProceduralBuilder.repair` — the one
+    # every procedural pack inherits — is `self.build(...)`, so this is the
+    # ordinary path, not an exotic one.
+    class _CrashingRepair(Builder):
+        def build(self, manifest: Manifest) -> BuildResult:
+            del manifest
+            return _bad_build_result()
+
+        def repair(
+            self,
+            result: BuildResult,
+            errors: list[Issue],
+            infeasible: list[tuple[str, str]],
+        ) -> BuildResult:
+            del result, errors, infeasible
+            raise KeyError("chain_target")
+
+    pack = _TestPack(_CrashingRepair(), families=[_PentestFamily()])
+    out = admit(pack, manifest={}, max_repairs=1)
+    assert isinstance(out, AdmissionFailure)
+    (event,) = [e for e in out.history if e.phase == "repair"]
+    assert "repair raised KeyError" in event.detail
+    assert "chain_target" in event.detail
 
 
 def test_a_raising_feasibility_check_rejects_only_its_task() -> None:

--- a/tests/test_admit.py
+++ b/tests/test_admit.py
@@ -546,7 +546,7 @@ def test_a_repair_that_crashes_is_not_recorded_as_the_opt_out() -> None:
             self,
             result: BuildResult,
             errors: list[Issue],
-            infeasible: list[tuple[str, str]],
+            infeasible: list[str],
         ) -> BuildResult:
             del result, errors, infeasible
             raise KeyError("chain_target")

--- a/tests/test_agent_harness.py
+++ b/tests/test_agent_harness.py
@@ -249,15 +249,17 @@ def test_arun_rollouts_overlaps_concurrent_episodes(tmp_path: Path) -> None:
     assert all(r.terminal_reason == "finished" for r in rollouts)
 
 
-def test_parse_action_reads_blocks_and_falls_back_to_finish() -> None:
+def test_parse_action_reads_blocks_and_terminates_on_an_unrecognized_reply() -> None:
     shell = parse_action("intro\n```bash\ncurl -s http://x/\n```\noutro")
     assert shell.tool == "run_shell"
     assert shell.command == "curl -s http://x/"
     done = parse_action("```finish\nthe answer\n```")
     assert done.tool == "finish"
     assert done.command == "the answer"
+    # Still terminates — a model ignoring the protocol must not loop — but it is
+    # not the same outcome as choosing to stop, and the caller can tell.
     bare = parse_action("just prose, no block")
-    assert bare.tool == "finish"
+    assert bare.tool == "no_action"
     assert bare.command == "just prose, no block"
 
 

--- a/tests/test_curriculum.py
+++ b/tests/test_curriculum.py
@@ -819,6 +819,14 @@ def test_an_unresolvable_success_check_is_an_error_not_a_grade(
         svc.close()
 
 
+def _pool_warnings(caplog: pytest.LogCaptureFixture) -> str:
+    # caplog.text spans every logger, so it can go green on text the pool never
+    # emitted — which is the exact failure these two tests exist to catch.
+    records = [r for r in caplog.records if r.name == "openrange.pool"]
+    assert records, "the pool logged nothing at all"
+    return "\n".join(r.getMessage() for r in records)
+
+
 def test_seeding_says_why_a_manifest_was_rejected(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -835,7 +843,7 @@ def test_seeding_says_why_a_manifest_was_rejected(
         )
 
     assert not pool.keys()
-    assert "entrypoint" in caplog.text, caplog.text
+    assert "entrypoint" in _pool_warnings(caplog)
 
 
 def test_seeding_reports_a_check_that_raised(
@@ -858,7 +866,7 @@ def test_seeding_reports_a_check_that_raised(
     with caplog.at_level(logging.WARNING, logger="openrange.pool"):
         WorldPool.seed(pack, [{"seed": 0}], difficulty_fn=lambda _s: 1.0, max_size=4)
 
-    assert "cannot honour the isolation" in caplog.text, caplog.text
+    assert "cannot honour the isolation" in _pool_warnings(caplog)
 
 
 class TestPoolPricesOnlyWhatGraded:

--- a/tests/test_curriculum.py
+++ b/tests/test_curriculum.py
@@ -60,7 +60,7 @@ from openrange.core.curriculum import (
     direction_from_reports,
 )
 from openrange.core.episode import EpisodeReport, EpisodeService
-from openrange.pool import _HISTORY_LIMIT, WorldPool
+from openrange.pool import WorldPool
 
 
 @dataclass(frozen=True)
@@ -838,12 +838,31 @@ def test_seeding_says_why_a_manifest_was_rejected(
     assert "entrypoint" in caplog.text, caplog.text
 
 
-class TestPoolHistory:
-    """A round's measurement outlives the priority that summarised it.
+def test_seeding_reports_a_check_that_raised(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A raising check produces no Issue — admission records the exception text
+    # in the build history and nowhere else, so reading only `issues` names the
+    # task that failed and never says why.
+    class _Raising(_StubFamily):
+        def check_feasibility(
+            self, graph: WorldGraph, task: TaskSpec
+        ) -> FeasibilityVerdict:
+            raise RuntimeError("cannot honour the isolation this host was asked for")
 
-    ``WorldPool.update`` used to collapse a round to one float, so nothing could
-    afterwards check ``difficulty`` against what agents did with the world.
-    """
+    pack = _StubPack(_Raising())
+    pack.attach_build_result(
+        BuildResult(graph=_build_stub_world(), tasks=[_stub_task()])
+    )
+
+    with caplog.at_level(logging.WARNING, logger="openrange.pool"):
+        WorldPool.seed(pack, [{"seed": 0}], difficulty_fn=lambda _s: 1.0, max_size=4)
+
+    assert "cannot honour the isolation" in caplog.text, caplog.text
+
+
+class TestPoolPricesOnlyWhatGraded:
+    """An errored episode is not evidence about the world it ran in."""
 
     @staticmethod
     def _pool() -> tuple[WorldPool, _StubPack, tuple[str, str]]:
@@ -888,7 +907,6 @@ class TestPoolHistory:
         pool, pack, key = self._pool()
         for _ in range(5):
             pool.update({key: self._errored(key)}, pack=pack)
-        assert pool.history() == {}
         assert pool._members[key].priority == 0.0
 
     def test_a_member_nobody_ran_still_ages(self) -> None:
@@ -898,43 +916,13 @@ class TestPoolHistory:
         pool.update({}, pack=pack)
         assert pool._members[key].priority > before
 
-    def test_a_round_keeps_the_episodes_that_did_grade(self) -> None:
+    def test_a_mixed_round_is_priced_on_the_episodes_that_graded(self) -> None:
         pool, pack, key = self._pool()
         pool.update({key: [*self._errored(key), *self._reports(key, True)]}, pack=pack)
-        (outcome,) = pool.history()[key]
-        assert outcome.rewards == (1.0,)
-        assert outcome.solve_rate == 1.0
-
-    def test_a_measured_round_is_retained(self) -> None:
-        pool, pack, key = self._pool()
-        pool.update({key: self._reports(key, True, False)}, pack=pack)
-        (outcome,) = pool.history()[key]
-        assert outcome.round_index == 1
-        assert outcome.difficulty == 7.0
-        assert outcome.solve_rate == 0.5
-        assert outcome.rewards == (1.0, 0.0)
-        assert outcome.mean_reward == 0.5
-
-    def test_a_member_that_did_not_run_records_nothing(self) -> None:
-        pool, pack, _ = self._pool()
-        pool.update({}, pack=pack)
-        assert pool.history() == {}
-
-    def test_rounds_accumulate_in_order(self) -> None:
-        pool, pack, key = self._pool()
-        pool.update({key: self._reports(key, False)}, pack=pack)
-        pool.update({key: self._reports(key, True)}, pack=pack)
-        assert [o.round_index for o in pool.history()[key]] == [1, 2]
-        assert [o.solve_rate for o in pool.history()[key]] == [0.0, 1.0]
-
-    def test_history_is_bounded(self) -> None:
-        pool, pack, key = self._pool()
-        for _ in range(_HISTORY_LIMIT + 3):
-            pool.update({key: self._reports(key, False)}, pack=pack)
-        retained = pool.history()[key]
-        assert len(retained) == _HISTORY_LIMIT
-        # The oldest rounds are the ones dropped.
-        assert retained[-1].round_index == _HISTORY_LIMIT + 3
+        # The one solve alone: fully learnable-out (0.0) plus its unmet subgoal
+        # (0.5). Counting the errored episode as a loss would read as a half-solved
+        # world and price it 1.5 — the most attractive thing in the pool.
+        assert pool._members[key].priority == 0.5
 
 
 # Lint shim — keep imported types from being flagged as unused. They

--- a/tests/test_curriculum.py
+++ b/tests/test_curriculum.py
@@ -15,6 +15,7 @@ Three layers:
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -816,6 +817,25 @@ def test_an_unresolvable_success_check_is_an_error_not_a_grade(
         assert report.episode_result.error == "unresolved success_check 'stub.missing'"
     finally:
         svc.close()
+
+
+def test_seeding_says_why_a_manifest_was_rejected(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # An empty pool is the same object whether nothing was offered or
+    # everything was refused, so a silent skip leaves an operator with a
+    # seeding run that produced nothing and no way to find out why.
+    pack = _StubPack(_StubFamily())
+    task = replace(_stub_task(), entrypoints=())  # unbindable, so admission refuses
+    pack.attach_build_result(BuildResult(graph=_build_stub_world(), tasks=[task]))
+
+    with caplog.at_level(logging.WARNING, logger="openrange.pool"):
+        pool = WorldPool.seed(
+            pack, [{"seed": 0}], difficulty_fn=lambda _s: 1.0, max_size=4
+        )
+
+    assert not pool.keys()
+    assert "entrypoint" in caplog.text, caplog.text
 
 
 class TestPoolHistory:

--- a/tests/test_curriculum.py
+++ b/tests/test_curriculum.py
@@ -16,7 +16,7 @@ Three layers:
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -58,7 +58,8 @@ from openrange.core.curriculum import (
     auto_evolve,
     direction_from_reports,
 )
-from openrange.core.episode import EpisodeService
+from openrange.core.episode import EpisodeReport, EpisodeService
+from openrange.pool import _HISTORY_LIMIT, WorldPool
 
 
 @dataclass(frozen=True)
@@ -781,6 +782,9 @@ def test_stop_episode_records_a_failed_grade_when_the_grader_raises(
         report = svc.stop_episode(handle)
         assert report.passed is False
         assert "grader boom" in report.episode_result.reason
+        # The harness failed, not the agent: without this the curriculum reads
+        # a crashed grader as a world the agent could not solve.
+        assert report.episode_result.error == "RuntimeError: grader boom"
         # collect() ran before the grader raised, so its state survives in the report.
         assert dict(report.final_state) == collected
         assert handle.id not in svc._episodes
@@ -790,6 +794,127 @@ def test_stop_episode_records_a_failed_grade_when_the_grader_raises(
         )
     finally:
         svc.close()
+
+
+def test_an_unresolvable_success_check_is_an_error_not_a_grade(
+    tmp_path: Path,
+) -> None:
+    # admit() resolves feasibility_check but never success_check, so a task can
+    # be admitted and only fail at grading. That is the harness misconfigured,
+    # not the agent answering wrongly.
+    family = _StubFamily()
+    pack = _StubPack(family)
+    task = replace(_stub_task(), success_check="stub.missing")
+    pack.attach_build_result(BuildResult(graph=_build_stub_world(), tasks=[task]))
+    snap = admit(pack, manifest={"seed": 0, "runtime": {"tick": {"mode": "off"}}})
+    assert isinstance(snap, Snapshot), snap
+
+    svc = EpisodeService(pack, tmp_path)
+    try:
+        report = svc.stop_episode(svc.start_episode(snap, snap.tasks[0].id))
+        assert report.passed is False
+        assert report.episode_result.error == "unresolved success_check 'stub.missing'"
+    finally:
+        svc.close()
+
+
+class TestPoolHistory:
+    """A round's measurement outlives the priority that summarised it.
+
+    ``WorldPool.update`` used to collapse a round to one float, so nothing could
+    afterwards check ``difficulty`` against what agents did with the world.
+    """
+
+    @staticmethod
+    def _pool() -> tuple[WorldPool, _StubPack, tuple[str, str]]:
+        family = _StubFamily()
+        _, pack = _build_stub_snapshot(family)
+        pool = WorldPool.seed(
+            pack, [{"seed": 0}], difficulty_fn=lambda _s: 7.0, max_size=4
+        )
+        (key,) = pool.keys()
+        return pool, pack, key
+
+    @staticmethod
+    def _reports(key: tuple[str, str], *outcomes: bool) -> list[EpisodeReport]:
+        return [
+            EpisodeReport(
+                snapshot_id=key[0],
+                task_id=key[1],
+                episode_result=EpisodeResult(
+                    success=ok, subgoals={"a": ok, "b": False}
+                ),
+            )
+            for ok in outcomes
+        ]
+
+    @staticmethod
+    def _errored(key: tuple[str, str]) -> list[EpisodeReport]:
+        return [
+            EpisodeReport(
+                snapshot_id=key[0],
+                task_id=key[1],
+                episode_result=EpisodeResult(
+                    success=False, reason="grading failed", error="TimeoutExpired"
+                ),
+            )
+        ]
+
+    def test_an_errored_round_is_not_a_measurement(self) -> None:
+        # Grading crashed, so the round is not evidence: nothing is recorded.
+        # The world also sorts to the back — priority is comparative, so merely
+        # holding it steady while every other member moves would march a world
+        # nobody can grade to the front of the pool.
+        pool, pack, key = self._pool()
+        for _ in range(5):
+            pool.update({key: self._errored(key)}, pack=pack)
+        assert pool.history() == {}
+        assert pool._members[key].priority == 0.0
+
+    def test_a_member_nobody_ran_still_ages(self) -> None:
+        # The staleness bump is for waiting its turn, not for failing to grade.
+        pool, pack, key = self._pool()
+        before = pool._members[key].priority
+        pool.update({}, pack=pack)
+        assert pool._members[key].priority > before
+
+    def test_a_round_keeps_the_episodes_that_did_grade(self) -> None:
+        pool, pack, key = self._pool()
+        pool.update({key: [*self._errored(key), *self._reports(key, True)]}, pack=pack)
+        (outcome,) = pool.history()[key]
+        assert outcome.rewards == (1.0,)
+        assert outcome.solve_rate == 1.0
+
+    def test_a_measured_round_is_retained(self) -> None:
+        pool, pack, key = self._pool()
+        pool.update({key: self._reports(key, True, False)}, pack=pack)
+        (outcome,) = pool.history()[key]
+        assert outcome.round_index == 1
+        assert outcome.difficulty == 7.0
+        assert outcome.solve_rate == 0.5
+        assert outcome.rewards == (1.0, 0.0)
+        assert outcome.mean_reward == 0.5
+
+    def test_a_member_that_did_not_run_records_nothing(self) -> None:
+        pool, pack, _ = self._pool()
+        pool.update({}, pack=pack)
+        assert pool.history() == {}
+
+    def test_rounds_accumulate_in_order(self) -> None:
+        pool, pack, key = self._pool()
+        pool.update({key: self._reports(key, False)}, pack=pack)
+        pool.update({key: self._reports(key, True)}, pack=pack)
+        assert [o.round_index for o in pool.history()[key]] == [1, 2]
+        assert [o.solve_rate for o in pool.history()[key]] == [0.0, 1.0]
+
+    def test_history_is_bounded(self) -> None:
+        pool, pack, key = self._pool()
+        for _ in range(_HISTORY_LIMIT + 3):
+            pool.update({key: self._reports(key, False)}, pack=pack)
+        retained = pool.history()[key]
+        assert len(retained) == _HISTORY_LIMIT
+        # The oldest rounds are the ones dropped.
+        assert retained[-1].round_index == _HISTORY_LIMIT + 3
 
 
 # Lint shim — keep imported types from being flagged as unused. They

--- a/tests/test_cyber_npcs.py
+++ b/tests/test_cyber_npcs.py
@@ -2,7 +2,9 @@
 
 The NPCs receive an ``interface`` mapping matching the shape produced
 by ``WebappRuntime.surface()``:
-``{base_url, http_get, http_get_json, solver_root}``. Tests use a fake
+``{base_url, http_get, http_get_json, solver_root}``, where ``http_get`` takes
+the caller's actor so the world can tell its own traffic from the agent's.
+Tests use a fake
 interface that records GET calls so we can assert on cadence,
 rotation, and graceful error handling — no real subprocess needed.
 """
@@ -31,9 +33,11 @@ class _RuntimeSurface(dict[str, Any]):
     def __init__(self) -> None:
         super().__init__()
         self.calls: list[str] = []
+        self.actors: list[str] = []
 
-        def http_get(path: object) -> bytes:
+        def http_get(path: object, actor: str = "agent") -> bytes:
             self.calls.append(str(path))
+            self.actors.append(actor)
             return b""
 
         def http_get_json(path: object) -> object:
@@ -407,3 +411,17 @@ def test_office_chatter_registered_via_entry_point() -> None:
     from openrange.npc import NPCS
 
     assert "cyber.office_chatter" in NPCS.ids()
+
+
+def test_every_shipped_npc_identifies_its_traffic_as_the_world() -> None:
+    # The pentest grade reads the request log to decide whether the agent
+    # reached the endpoint. An NPC that does not say who it is gets counted as
+    # the agent, and a policy that did nothing is paid for turning up.
+    for npc in (
+        BrowsingUser(cadence_ticks=1, paths=("/a",)),
+        AdminAudit(cadence_ticks=1),
+    ):
+        iface = _RuntimeSurface()
+        npc.step(iface)
+        assert iface.calls, f"{type(npc).__name__} made no request"
+        assert iface.actors == ["npc"] * len(iface.calls), type(npc).__name__

--- a/tests/test_cyber_procedural_builder.py
+++ b/tests/test_cyber_procedural_builder.py
@@ -15,9 +15,12 @@ Covers:
 
 from __future__ import annotations
 
+import random
+
 import pytest
 from cyber_webapp import WebappBuilder, WebappPack
 from cyber_webapp.priors import default_prior
+from cyber_webapp.sampling import sample_graph
 from openrange_pack_sdk import BuildResult, PackError, PackPrior, Snapshot
 
 from openrange.core.admit import admit
@@ -270,3 +273,12 @@ def test_admission_snapshot_id_is_deterministic() -> None:
     assert isinstance(snap_a, Snapshot)
     assert isinstance(snap_b, Snapshot)
     assert snap_a.snapshot_id == snap_b.snapshot_id
+
+
+def test_sample_graph_honours_its_optional_prior() -> None:
+    # `sample_graph` advertises `prior: PackPrior | None = None` and every
+    # helper it calls guards for None — except the vuln-pin read, which made
+    # the advertised default an AttributeError. No in-tree caller passes None
+    # (WebappBuilder always injects default_prior()), so nothing caught it.
+    graph = sample_graph(random.Random(0))
+    assert graph.nodes

--- a/tests/test_cyber_webapp_v2.py
+++ b/tests/test_cyber_webapp_v2.py
@@ -16,9 +16,12 @@ entrypoint kinds — "one pack, many TaskFamilies" applied to this pack.
 
 from __future__ import annotations
 
+import time
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 
+from cyber_webapp import WebappPack
 from cyber_webapp.families.build import WebappBuild
 from cyber_webapp.families.pentest import WebappPentest
 from cyber_webapp.invariants import (
@@ -52,6 +55,7 @@ from openrange_pack_sdk import (
 )
 
 from openrange.core.admit import admit
+from openrange.core.episode import EpisodeService
 
 
 def _build_cyber_world() -> WorldGraph:
@@ -864,3 +868,33 @@ def test_sampler_never_places_sqli_on_non_db_backed_service() -> None:
                     f"seed={seed}: SQLi vuln {vuln.id} targets {target.id} "
                     f"on service {svc_id} which has no backed_by data_store"
                 )
+
+
+def test_npc_traffic_is_not_credited_to_the_agent(tmp_path: Path) -> None:
+    # NPCs browse the app while the episode runs. Counting their requests pays
+    # `reached_endpoint` to a policy that turned up and did nothing, which is
+    # the same free-subgoal defect the reward shaper exists to remove.
+    pack = WebappPack()
+    snapshot = admit(
+        pack,
+        {
+            "world": {"goal": "npc credit"},
+            "pack": {"id": "webapp"},
+            "runtime": {"tick": {"mode": "auto", "rate_hz": 20}},
+            "npc": [{"type": "cyber.browsing_user", "count": 1}],
+        },
+        max_repairs=2,
+    )
+    assert isinstance(snapshot, Snapshot), snapshot
+    task = next(t for t in snapshot.tasks if t.meta.get("family") == "webapp.pentest")
+
+    service = EpisodeService(pack, tmp_path)
+    try:
+        handle = service.start_episode(snapshot, task.id)
+        time.sleep(2.0)  # long enough for the NPC's cadence to fire
+        report = service.stop_episode(handle)
+    finally:
+        service.close()
+
+    assert report.episode_result.subgoals["reached_endpoint"] is False
+    assert report.final_state["requests_made"] == []

--- a/tests/test_openai_compatible_backend.py
+++ b/tests/test_openai_compatible_backend.py
@@ -311,3 +311,30 @@ def test_openai_compatible_backend_omits_sampling_knobs_by_default() -> None:
     payload = cast(dict[str, Any], requests[0]["payload"])
     assert "temperature" not in payload
     assert "max_tokens" not in payload
+
+
+def test_an_empty_completion_is_an_error_not_an_empty_answer() -> None:
+    # A refusal or content filter answers 200 with empty text. Handing that back
+    # as a valid completion makes the caller grade "the provider returned
+    # nothing" as "the model said nothing worth acting on".
+    def handler(
+        _payload: Mapping[str, object],
+        _headers: Mapping[str, str],
+        _path: str,
+    ) -> ServerResponse:
+        body = {
+            "id": "cmpl-empty",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": ""},
+                    "finish_reason": "content_filter",
+                }
+            ],
+        }
+        return 200, body, 0
+
+    with running_openai_server(handler) as (base_url, _requests):
+        backend = OR.OpenAICompatibleBackend(model="m", base_url=f"{base_url}/v1")
+        with pytest.raises(LLMBackendError, match="content_filter"):
+            backend.complete(LLMRequest("hello"))

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from openrange_pack_sdk import EpisodeResult
 
 from openrange.core.episode import EpisodeReport
-from openrange.pool import _member_priority
+from openrange.pool import _mean_pass_rate, _member_priority
 from openrange.training import Reward, episode_reward
 
 
@@ -56,6 +56,31 @@ def test_a_world_the_agent_almost_solved_outranks_a_solved_one() -> None:
     idle = episode_reward(_report(False, {"f2p": False, "p2p": True}, {"p2p": True}))
     assert _member_priority([solved]) < _member_priority([trap])
     assert _member_priority([trap]) < _member_priority([idle])
+
+
+def test_solve_rate_excludes_the_episodes_that_never_graded() -> None:
+    # Counting an infra failure as a miss deflates the only number a trainer
+    # reads by however much the grader flaked.
+    graded = [_report(True, {"a": True}), _report(False, {"a": False})]
+    errored = EpisodeReport(
+        snapshot_id="s",
+        task_id="t",
+        episode_result=EpisodeResult(success=False, error="TimeoutExpired"),
+    )
+    rate, members = _mean_pass_rate([[*graded, errored, errored]])
+    assert rate == 0.5
+    assert members == 1
+
+
+def test_a_round_that_graded_nothing_is_not_a_round_that_solved_nothing() -> None:
+    errored = EpisodeReport(
+        snapshot_id="s",
+        task_id="t",
+        episode_result=EpisodeResult(success=False, error="TimeoutExpired"),
+    )
+    rate, members = _mean_pass_rate([[errored]])
+    assert rate == 0.0
+    assert members == 0  # the count is what tells the two apart
 
 
 def test_priority_without_components_is_learnability_only() -> None:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,7 +1,8 @@
 """The pool ranks worlds by the reward the trainer optimizes, not always the default.
 
-``reward_fn`` threads into world priority (``_member_priority``); a custom reward
-must change the ranking, or the pool evolves on a different objective than GRPO.
+``_member_priority`` reads shaped ``Reward``s, so the ``reward_fn`` handed to
+``WorldPool.update`` is the objective the ranking follows, and a subgoal the world
+granted for free cannot inflate the regret term into headroom that is not there.
 The threading through ``WorldPool.update`` / ``run_pool_curriculum`` is covered as
 an integration test in ``test_curriculum`` (against a real admitted world).
 """
@@ -15,20 +16,49 @@ from openrange.pool import _member_priority
 from openrange.training import Reward, episode_reward
 
 
-def _report(success: bool, subgoals: dict[str, bool]) -> EpisodeReport:
+def _report(
+    success: bool,
+    subgoals: dict[str, bool],
+    baseline: dict[str, bool] | None = None,
+) -> EpisodeReport:
     return EpisodeReport(
         snapshot_id="s",
         task_id="t",
-        episode_result=EpisodeResult(success=success, subgoals=subgoals),
+        episode_result=EpisodeResult(
+            success=success, subgoals=subgoals, baseline=baseline or {}
+        ),
     )
 
 
-def test_member_priority_defaults_to_episode_reward() -> None:
+def test_priority_follows_the_shaped_reward() -> None:
     reports = [_report(False, {"a": True, "b": False, "c": False})]
-    assert _member_priority(reports) == _member_priority(reports, episode_reward)
+    shaped = _member_priority([episode_reward(r) for r in reports])
+    flat = _member_priority([Reward(scalar=0.5) for _ in reports])
+    assert shaped != flat
 
 
-def test_member_priority_uses_a_custom_reward_fn() -> None:
-    reports = [_report(False, {"a": True, "b": False, "c": False})]
-    custom = _member_priority(reports, lambda _r: Reward(scalar=0.5))
-    assert custom != _member_priority(reports)
+def test_regret_ignores_subgoals_the_world_granted() -> None:
+    # Identical observed subgoals; the second world handed "a" over unearned, so
+    # it offers one third less to learn and must not rank as if it offered more.
+    earned = episode_reward(_report(False, {"a": True, "b": False, "c": False}))
+    granted = episode_reward(
+        _report(False, {"a": True, "b": False, "c": False}, {"a": True})
+    )
+    assert _member_priority([earned]) > _member_priority([granted])
+
+
+def test_a_world_the_agent_almost_solved_outranks_a_solved_one() -> None:
+    # The instructive world: everything earnable won, one precondition broken.
+    # It must not sort with the solved world, or the pool evicts exactly the
+    # world with the most left to learn.
+    trap = episode_reward(_report(False, {"f2p": True, "p2p": False}, {"p2p": True}))
+    solved = episode_reward(_report(True, {"f2p": True, "p2p": True}, {"p2p": True}))
+    idle = episode_reward(_report(False, {"f2p": False, "p2p": True}, {"p2p": True}))
+    assert _member_priority([solved]) < _member_priority([trap])
+    assert _member_priority([trap]) < _member_priority([idle])
+
+
+def test_priority_without_components_is_learnability_only() -> None:
+    # No subgoals at all: regret has nothing to read, so priority is the
+    # learnability term alone rather than an accidental zero.
+    assert _member_priority([episode_reward(_report(True, {}))]) == 0.0

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -67,20 +67,18 @@ def test_solve_rate_excludes_the_episodes_that_never_graded() -> None:
         task_id="t",
         episode_result=EpisodeResult(success=False, error="TimeoutExpired"),
     )
-    rate, members = _mean_pass_rate([[*graded, errored, errored]])
-    assert rate == 0.5
-    assert members == 1
+    assert _mean_pass_rate([[*graded, errored, errored]]) == 0.5
 
 
-def test_a_round_that_graded_nothing_is_not_a_round_that_solved_nothing() -> None:
+def test_a_group_that_graded_nothing_leaves_the_mean_alone() -> None:
+    # Not just excluded from its own group's denominator — a group where every
+    # episode errored is not a zero to average against the groups that ran.
     errored = EpisodeReport(
         snapshot_id="s",
         task_id="t",
         episode_result=EpisodeResult(success=False, error="TimeoutExpired"),
     )
-    rate, members = _mean_pass_rate([[errored]])
-    assert rate == 0.0
-    assert members == 0  # the count is what tells the two apart
+    assert _mean_pass_rate([[_report(True, {"a": True})], [errored]]) == 1.0
 
 
 def test_priority_without_components_is_learnability_only() -> None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -22,6 +22,7 @@ from openrange_pack_sdk import Backing, Snapshot, TaskSpec
 from openrange.core.episode import AgentTurn, EpisodeError
 from openrange.core.errors import EpisodeRuntimeError
 from openrange.runtime import EpisodeContext, OpenRangeRun, RunConfig
+from openrange.training import Reward
 
 MANIFEST = {
     "world": {"goal": "run_episode end to end"},
@@ -121,6 +122,28 @@ class TestRunEpisode:
         assert ep.success is False
         assert ep.reward.scalar == 0.0
         assert ep.trajectory.steps == ()
+
+    def test_a_custom_objective_reaches_the_exported_trajectory(
+        self, snapshot: Snapshot, tmp_path: Path
+    ) -> None:
+        # `run_episode` is the documented one-call API and `.trajectory` is what
+        # `to_jsonl` writes, so a caller's own objective has to survive the trip
+        # or the trainer reads a number nobody is optimizing.
+        run = OpenRangeRun(RunConfig(tmp_path, dashboard=False))
+
+        def solve(ctx: EpisodeContext) -> AgentTurn:
+            _write_reference(ctx)
+            return AgentTurn(message="submitted reference handler")
+
+        ep = run.run_episode(
+            snapshot,
+            solve,
+            task_id=_build_task_id(snapshot),
+            reward_fn=lambda report: Reward(scalar=0.25),
+        )
+        assert ep.success is True, ep.report.episode_result.reason
+        assert ep.reward.scalar == 0.25  # the default would score this solve 1.0
+        assert ep.trajectory.reward.scalar == 0.25
 
     def test_multi_turn_solver_records_each_turn(
         self, snapshot: Snapshot, tmp_path: Path

--- a/tests/test_snapshot_store.py
+++ b/tests/test_snapshot_store.py
@@ -383,11 +383,34 @@ def test_store_load_non_mapping_raises_store_error(tmp_path: Path) -> None:
         store.load("sha256:listy")
 
 
+def test_store_load_rejects_a_graph_edited_under_its_own_id(tmp_path: Path) -> None:
+    # A snapshot id is a content hash, so it is only worth anything if loading
+    # recomputes it. Edit a node attribute and leave both the filename and the
+    # stored id field alone: every name still agrees, and only the content has
+    # moved.
+    snap = _admit_one()
+    store = SnapshotStore(tmp_path)
+    path = store.save(snap)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    node = next(n for n in payload["graph"]["nodes"] if n["id"] == "repo.a")
+    node["attrs"]["name"] = "tampered"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+    # The tampered file is well-formed and still self-consistent by name, so a
+    # rejection below can only have come from rehashing the graph.
+    edited = snapshot_from_dict(payload)
+    assert edited.snapshot_id == snap.snapshot_id
+    assert edited.graph.nodes["repo.a"].attrs["name"] == "tampered"
+
+    with pytest.raises(StoreError, match="does not hash to its id"):
+        store.load(snap.snapshot_id)
+
+
 def test_store_load_mismatched_id_raises_store_error(tmp_path: Path) -> None:
     """A file whose stored snapshot_id != its filename is rejected.
 
-    Catches accidental rename / tampering — the content hash must agree
-    with the storage key.
+    Catches an accidental rename; content edits are caught by the rehash.
     """
     snap = _admit_one()
     store = SnapshotStore(tmp_path)

--- a/tests/test_stranded_state.py
+++ b/tests/test_stranded_state.py
@@ -1,0 +1,353 @@
+"""A failure must not strand what it touched.
+
+Three places left state behind when something went wrong: the warm pool dropped
+the runtime it displaced, the agent loop abandoned a live episode when the
+sampler raised, and a registry that failed to sweep reported itself swept. The
+oracle in each case is an absence — a handle that was never stopped, an episode
+still registered, a pack that vanished — so every test asserts the absence
+directly rather than trusting a return value.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from graphschema import (
+    AttrSpec,
+    AttrType,
+    Node,
+    NodeKind,
+    Ontology,
+    WorldGraph,
+)
+from openrange_pack_sdk import (
+    Backing,
+    Builder,
+    BuildResult,
+    EpisodeResult,
+    FeasibilityVerdict,
+    Manifest,
+    Pack,
+    PackPrior,
+    RuntimeHandle,
+    Snapshot,
+    TaskFamily,
+    TaskSpec,
+)
+
+from openrange.agent import SampleResult, arun_rollouts
+from openrange.core.admit import admit
+from openrange.core.episode import EpisodeService
+from openrange.core.pack import PackRegistry
+
+_ONTOLOGY = Ontology(
+    id="lifetime@1",
+    node_kinds={"box": NodeKind("box", attrs={"n": AttrSpec(AttrType.STRING)})},
+    edge_kinds={},
+)
+
+
+class _PoolableHandle:
+    """A ``PoolableRuntime`` that records whether anyone stopped it."""
+
+    def __init__(self) -> None:
+        self.stopped = False
+
+    def reset(self) -> None: ...
+
+    def surface(self) -> Mapping[str, Any]:
+        return {"solver_root": "/tmp"}
+
+    def poll_events(self) -> tuple[Mapping[str, Any], ...]:
+        return ()
+
+    def terminal(self) -> tuple[bool, str | None]:
+        return False, None
+
+    def checkpoint(self) -> Any:
+        return None
+
+    def restore(self, state: Any) -> None:
+        del state
+
+    def collect(self) -> Mapping[str, Any]:
+        return {}
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def poolable(self) -> bool:
+        return True
+
+    def reset_episode(self) -> None: ...
+
+
+class _Family(TaskFamily):
+    id = "lifetime.family"
+    pack_id = "lifetime"
+
+    def generate(
+        self, graph: WorldGraph, manifest: Manifest, prior: PackPrior | None
+    ) -> list[TaskSpec]:
+        del graph, manifest, prior
+        return [
+            TaskSpec(
+                id="lifetime.t.0",
+                instruction="do the thing",
+                entrypoints=("box.a",),
+                goal_nodes=("box.a",),
+                feasibility_check="lifetime.family",
+                success_check="lifetime.family",
+            )
+        ]
+
+    def check_feasibility(
+        self, graph: WorldGraph, task: TaskSpec
+    ) -> FeasibilityVerdict:
+        del graph, task
+        return FeasibilityVerdict(True)
+
+    def check_success(
+        self, graph: WorldGraph, task: TaskSpec, final_state: Mapping[str, Any]
+    ) -> EpisodeResult:
+        del graph, task, final_state
+        return EpisodeResult(success=True)
+
+
+class _Builder(Builder):
+    def build(self, manifest: Manifest) -> BuildResult:
+        del manifest
+        graph = WorldGraph(ontology="lifetime@1")
+        graph.add_node(Node("box.a", "box", attrs={"n": "a"}))
+        return BuildResult(graph=graph, tasks=_Family().generate(graph, {}, None))
+
+
+class _Pack(Pack):
+    id = "lifetime"
+    version = "0.1.0"
+
+    def __init__(self) -> None:
+        self.handles: list[_PoolableHandle] = []
+
+    def ontology(self) -> Ontology:
+        return _ONTOLOGY
+
+    def invariants(self) -> list[Any]:
+        return []
+
+    def make_builder(self, prior: PackPrior | None) -> Builder:
+        del prior
+        return _Builder()
+
+    def realize(self, graph: WorldGraph, backing: Backing) -> RuntimeHandle:
+        del graph, backing
+        handle = _PoolableHandle()
+        self.handles.append(handle)
+        return handle
+
+    def task_families(self) -> list[TaskFamily]:
+        return [_Family()]
+
+
+def _snapshot(pack: _Pack) -> Snapshot:
+    snap = admit(pack, manifest={"seed": 0, "runtime": {"tick": {"mode": "off"}}})
+    assert isinstance(snap, Snapshot), snap
+    return snap
+
+
+def test_the_warm_pool_stops_the_runtime_it_displaces(tmp_path: Path) -> None:
+    # Two *overlapping* episodes of one snapshot — the group shape a trainer
+    # runs. Neither can reuse the other's warm slot, so both realize a runtime
+    # and both park under the same key on the way out. Overwriting silently
+    # drops the first, and because the dict never grows the eviction loop cannot
+    # reclaim it either, so nothing would ever stop it.
+    pack = _Pack()
+    snap = _snapshot(pack)
+    service = EpisodeService(pack, tmp_path)
+    try:
+        first_episode = service.start_episode(snap, snap.tasks[0].id)
+        second_episode = service.start_episode(snap, snap.tasks[0].id)
+        first, second = pack.handles[0], pack.handles[1]
+        assert first is not second
+
+        service.stop_episode(first_episode)
+        parked_alive = not first.stopped  # warm, not stopped — the precondition
+
+        service.stop_episode(second_episode)
+        assert parked_alive, "the first runtime was stopped instead of parked"
+        assert first.stopped, "the displaced runtime was never stopped"
+        assert not second.stopped, "the survivor should still be warm"
+    finally:
+        service.close()
+
+
+class _RaisingSampler:
+    def complete(self, prompt: str, *, system: str | None = None) -> SampleResult:
+        del prompt, system
+        raise RuntimeError("gateway 503")
+
+
+def _capability(surface: Mapping[str, Any]) -> Any:
+    class _Cap:
+        def run(self, command: str) -> str:
+            del command
+            return ""
+
+        def close(self) -> None: ...
+
+    del surface
+    return _Cap()
+
+
+def test_a_raising_sampler_does_not_strand_the_episode(tmp_path: Path) -> None:
+    pack = _Pack()
+    snap = _snapshot(pack)
+    service = EpisodeService(pack, tmp_path)
+    try:
+        with pytest.raises(RuntimeError, match="gateway 503"):
+            asyncio.run(
+                arun_rollouts(
+                    service,
+                    snap,
+                    _RaisingSampler(),
+                    bind_run=_capability,
+                    task_ids=[snap.tasks[0].id],
+                )
+            )
+        assert not service._episodes, "the episode outlived the failure"
+    finally:
+        service.close()
+
+
+def test_a_raising_bind_run_does_not_strand_the_episode(tmp_path: Path) -> None:
+    # Binding the shell is the caller attaching to an already-realized world —
+    # for a container, the docker exec. It is the most failure-prone step in the
+    # loop and the episode is registered before it runs.
+    pack = _Pack()
+    snap = _snapshot(pack)
+    service = EpisodeService(pack, tmp_path)
+
+    def _explode(surface: Mapping[str, Any]) -> Any:
+        del surface
+        raise RuntimeError("docker exec setup failed")
+
+    try:
+        with pytest.raises(RuntimeError, match="docker exec setup failed"):
+            asyncio.run(
+                arun_rollouts(
+                    service,
+                    snap,
+                    _RaisingSampler(),
+                    bind_run=_explode,
+                    task_ids=[snap.tasks[0].id],
+                )
+            )
+        assert not service._episodes, "the episode outlived the bind failure"
+    finally:
+        service.close()
+
+
+def test_a_raising_stop_does_not_mask_the_real_failure(tmp_path: Path) -> None:
+    # stop_episode reaches pack code (`poolable()`) and the dashboard write,
+    # neither of which it guards. A cleanup step that raises must not demote the
+    # error it was cleaning up after.
+    class _HostileHandle(_PoolableHandle):
+        def poolable(self) -> bool:
+            raise RuntimeError("poolable blew up")
+
+    class _HostilePack(_Pack):
+        def realize(self, graph: WorldGraph, backing: Backing) -> RuntimeHandle:
+            del graph, backing
+            handle = _HostileHandle()
+            self.handles.append(handle)
+            return handle
+
+    pack = _HostilePack()
+    snap = _snapshot(pack)
+    service = EpisodeService(pack, tmp_path)
+    try:
+        with pytest.raises(RuntimeError, match="gateway 503"):
+            asyncio.run(
+                arun_rollouts(
+                    service,
+                    snap,
+                    _RaisingSampler(),
+                    bind_run=_capability,
+                    task_ids=[snap.tasks[0].id],
+                )
+            )
+    finally:
+        service.close()
+
+
+def test_one_failure_does_not_cancel_its_siblings(tmp_path: Path) -> None:
+    # A bare gather propagates the first exception out of the loop, cancelling
+    # every sibling mid-episode so none of them is ever stopped.
+    pack = _Pack()
+    snap = _snapshot(pack)
+    service = EpisodeService(pack, tmp_path)
+    task_id = snap.tasks[0].id
+
+    class _OneBadSampler:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def complete(self, prompt: str, *, system: str | None = None) -> SampleResult:
+            del prompt, system
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("gateway 503")
+            return SampleResult(text="```bash\nfinish done\n```")
+
+    try:
+        with pytest.raises(RuntimeError, match="gateway 503"):
+            asyncio.run(
+                arun_rollouts(
+                    service,
+                    snap,
+                    _OneBadSampler(),
+                    bind_run=_capability,
+                    task_ids=[task_id] * 4,
+                    max_concurrency=4,
+                )
+            )
+        assert not service._episodes, "siblings were cancelled before stopping"
+    finally:
+        service.close()
+
+
+def _install_broken_entry_point(root: Path, group: str, name: str) -> None:
+    """Put a real distribution on ``sys.path`` whose entry point cannot load."""
+    dist = root / "brokenpack-1.0.dist-info"
+    dist.mkdir(parents=True)
+    (dist / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: brokenpack\nVersion: 1.0\n", encoding="utf-8"
+    )
+    (dist / "entry_points.txt").write_text(
+        f"[{group}]\n{name} = no_such_module_at_all:factory\n", encoding="utf-8"
+    )
+
+
+def test_a_malformed_pack_does_not_mark_the_registry_swept(tmp_path: Path) -> None:
+    # Marking the sweep done before it runs makes the first call raise and every
+    # call after it return a partial registry, silently, for the whole process.
+    import importlib
+
+    _install_broken_entry_point(tmp_path, "openrange.packs", "zzz.broken")
+    sys.path.insert(0, str(tmp_path))
+    importlib.invalidate_caches()
+    try:
+        registry = PackRegistry(autodiscover=True)
+        with pytest.raises(Exception, match="zzz.broken"):
+            registry.ids()
+        # The second call must not pretend the sweep succeeded.
+        with pytest.raises(Exception, match="zzz.broken"):
+            registry.ids()
+    finally:
+        sys.path.remove(str(tmp_path))
+        importlib.invalidate_caches()

--- a/tests/test_stranded_state.py
+++ b/tests/test_stranded_state.py
@@ -321,6 +321,18 @@ def test_one_failure_does_not_cancel_its_siblings(tmp_path: Path) -> None:
         service.close()
 
 
+def test_the_shipped_packs_all_resolve() -> None:
+    # A pack that refuses to import takes the whole sweep down with it, and the
+    # sweep is correctly never marked complete — so one pack's setup failure
+    # would make every *other* pack permanently unreachable in this process.
+    # PACKS is a module singleton; nothing recovers without a restart.
+    from openrange.core.pack import PACKS
+
+    ids = PACKS.ids()
+    assert {"swe", "trading", "webapp"} <= set(ids), ids
+    assert PACKS.ids() == ids  # and again — discovery is not one-shot-poisoned
+
+
 def _install_broken_entry_point(root: Path, group: str, name: str) -> None:
     """Put a real distribution on ``sys.path`` whose entry point cannot load."""
     dist = root / "brokenpack-1.0.dist-info"

--- a/tests/test_stranded_state.py
+++ b/tests/test_stranded_state.py
@@ -127,9 +127,21 @@ class _Builder(Builder):
         return BuildResult(graph=graph, tasks=_Family().generate(graph, {}, None))
 
 
+class _DisposableHandle(_PoolableHandle):
+    """A runtime that cannot be reused, so ending its episode must stop it.
+
+    The strand tests use this so the oracle is a public observable: with a
+    poolable runtime, correct cleanup parks it warm and ``stopped`` stays False.
+    """
+
+    def poolable(self) -> bool:
+        return False
+
+
 class _Pack(Pack):
     id = "lifetime"
     version = "0.1.0"
+    handle_cls: type[_PoolableHandle] = _PoolableHandle
 
     def __init__(self) -> None:
         self.handles: list[_PoolableHandle] = []
@@ -146,12 +158,16 @@ class _Pack(Pack):
 
     def realize(self, graph: WorldGraph, backing: Backing) -> RuntimeHandle:
         del graph, backing
-        handle = _PoolableHandle()
+        handle = self.handle_cls()
         self.handles.append(handle)
         return handle
 
     def task_families(self) -> list[TaskFamily]:
         return [_Family()]
+
+
+class _Disposable(_Pack):
+    handle_cls = _DisposableHandle
 
 
 def _snapshot(pack: _Pack) -> Snapshot:
@@ -205,7 +221,7 @@ def _capability(surface: Mapping[str, Any]) -> Any:
 
 
 def test_a_raising_sampler_does_not_strand_the_episode(tmp_path: Path) -> None:
-    pack = _Pack()
+    pack = _Disposable()
     snap = _snapshot(pack)
     service = EpisodeService(pack, tmp_path)
     try:
@@ -219,7 +235,8 @@ def test_a_raising_sampler_does_not_strand_the_episode(tmp_path: Path) -> None:
                     task_ids=[snap.tasks[0].id],
                 )
             )
-        assert not service._episodes, "the episode outlived the failure"
+        assert pack.handles, "the episode never started, so nothing was proved"
+        assert all(h.stopped for h in pack.handles), "a runtime outlived the failure"
     finally:
         service.close()
 
@@ -228,7 +245,7 @@ def test_a_raising_bind_run_does_not_strand_the_episode(tmp_path: Path) -> None:
     # Binding the shell is the caller attaching to an already-realized world —
     # for a container, the docker exec. It is the most failure-prone step in the
     # loop and the episode is registered before it runs.
-    pack = _Pack()
+    pack = _Disposable()
     snap = _snapshot(pack)
     service = EpisodeService(pack, tmp_path)
 
@@ -247,7 +264,8 @@ def test_a_raising_bind_run_does_not_strand_the_episode(tmp_path: Path) -> None:
                     task_ids=[snap.tasks[0].id],
                 )
             )
-        assert not service._episodes, "the episode outlived the bind failure"
+        assert pack.handles, "the world was never realized, so nothing was proved"
+        assert all(h.stopped for h in pack.handles), "a runtime outlived the failure"
     finally:
         service.close()
 
@@ -288,7 +306,7 @@ def test_a_raising_stop_does_not_mask_the_real_failure(tmp_path: Path) -> None:
 def test_one_failure_does_not_cancel_its_siblings(tmp_path: Path) -> None:
     # A bare gather propagates the first exception out of the loop, cancelling
     # every sibling mid-episode so none of them is ever stopped.
-    pack = _Pack()
+    pack = _Disposable()
     snap = _snapshot(pack)
     service = EpisodeService(pack, tmp_path)
     task_id = snap.tasks[0].id
@@ -316,7 +334,10 @@ def test_one_failure_does_not_cancel_its_siblings(tmp_path: Path) -> None:
                     max_concurrency=4,
                 )
             )
-        assert not service._episodes, "siblings were cancelled before stopping"
+        assert len(pack.handles) == 4, pack.handles
+        assert all(h.stopped for h in pack.handles), (
+            "a sibling was cancelled mid-episode"
+        )
     finally:
         service.close()
 

--- a/tests/test_swe_build.py
+++ b/tests/test_swe_build.py
@@ -163,7 +163,7 @@ class TestFeasibility:
         task = SweBuild().generate(graph, {}, None)[0]
         verdict = SweBuild().check_feasibility(graph, task)
         assert not verdict.feasible
-        assert "skeleton already passes an integration test" in verdict.reason
+        assert "skeleton already passes part of its own suite" in verdict.reason
 
     def test_non_composing_gold_is_infeasible(self) -> None:
         # A gold overlay that passes units but fails integration doesn't prove

--- a/tests/test_swe_pack.py
+++ b/tests/test_swe_pack.py
@@ -207,6 +207,34 @@ class TestGradingCredit:
         assert result.subgoals["test_calc.py::test_subtract"] is False
         assert reward.scalar == 0.0
 
+    def test_a_plugin_the_world_never_declared_is_not_graded(self) -> None:
+        # pytest collects whatever it finds, so a conftest.py or pytest.ini the
+        # agent invents is a route to the grade that never touches the source:
+        # a tryfirst hook greens every test, and a sleep makes the run report
+        # nothing at all — which reads as an ungraded episode and is excluded
+        # from the solve rate rather than counted as the failure it is.
+        instance = load_instance(_INSTANCE)
+        greened, _ = self._reward(
+            {
+                **instance.base_files,
+                "pytest.ini": "[pytest]\naddopts = -p pwn\n",
+                "pwn.py": (
+                    "import pytest\n\n\n"
+                    "@pytest.hookimpl(tryfirst=True)\n"
+                    "def pytest_pyfunc_call(pyfuncitem):\n"
+                    "    return True\n"
+                ),
+            }
+        )
+        assert greened.success is False
+        assert greened.subgoals["test_calc.py::test_add"] is False
+
+        hung, _ = self._reward(
+            {**instance.base_files, "conftest.py": "import os\n\nos._exit(0)\n"}
+        )
+        assert hung.error is None, "the agent must not be able to author an error"
+        assert hung.success is False
+
     def test_the_gold_tree_still_scores_one(self) -> None:
         instance = load_instance(_INSTANCE)
         result, reward = self._reward({**instance.base_files, **instance.gold_files})

--- a/tests/test_swe_pack.py
+++ b/tests/test_swe_pack.py
@@ -34,8 +34,8 @@ from swe.sandbox import (
     _bwrap_usable,
     _bwrap_wrap,
     _select_backend,
-    _verify_backend_request,
     run_sandboxed,
+    verify_backend_request,
 )
 from swe.swebench import instance_from_row
 
@@ -440,13 +440,13 @@ class TestSandbox:
         if _bwrap_usable():
             pytest.skip("bwrap is usable here, so the request is honourable")
         with pytest.raises(RuntimeError, match="not usable"):
-            _verify_backend_request()
+            verify_backend_request()
 
     def test_the_default_request_is_always_honourable(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("OPENRANGE_SWE_SANDBOX", raising=False)
-        _verify_backend_request()  # must not raise on any host
+        verify_backend_request()  # must not raise on any host
 
     def test_bwrap_argv_isolates_net_only_when_disabled(self) -> None:
         with_net = _bwrap_wrap(["x"], root=Path("/w"), network=True)

--- a/tests/test_swe_pack.py
+++ b/tests/test_swe_pack.py
@@ -18,7 +18,13 @@ from pathlib import Path
 
 import pytest
 from graphschema import Visibility, WorldGraph, validate
-from openrange_pack_sdk import Backing, BuildResult, TaskSpec, write_tree
+from openrange_pack_sdk import (
+    Backing,
+    BuildResult,
+    EpisodeResult,
+    TaskSpec,
+    write_tree,
+)
 from swe import SweFix, SwePack, repo_ontology
 from swe.builder import SweBuilder
 from swe.grading import _nodeid
@@ -26,6 +32,9 @@ from swe.instances import SweInstance, load_instance, to_graph
 from swe.realize import SweRuntime
 from swe.sandbox import _bwrap_wrap, run_sandboxed
 from swe.swebench import instance_from_row
+
+from openrange.core.episode import EpisodeReport
+from openrange.training import Reward, episode_reward
 
 _INSTANCE = "calc_sum"
 _MULTI = "shapes_area"
@@ -154,6 +163,51 @@ class TestGrading:
         result = SweFix().check_success(graph, task, {"result": {"done": True}})
         assert not result.success
         assert "no workspace" in result.reason
+
+
+class TestGradingCredit:
+    """``pass_to_pass`` is green at base, so it is not partial credit.
+
+    Uniform credit over the subgoal vector pays an agent that edits nothing —
+    here half the task, and on a real instance, where ``pass_to_pass``
+    outnumbers ``fail_to_pass``, very nearly all of it.
+    """
+
+    @staticmethod
+    def _reward(tree: dict[str, str]) -> tuple[EpisodeResult, Reward]:
+        graph, task = _graph_and_task()
+        result = SweFix().check_success(
+            graph, task, {"workspace_files": tree, "result": {"done": True}}
+        )
+        report = EpisodeReport(
+            snapshot_id="sha256:swe", task_id=task.id, episode_result=result
+        )
+        return result, episode_reward(report)
+
+    def test_an_untouched_tree_earns_nothing(self) -> None:
+        result, reward = self._reward(dict(load_instance(_INSTANCE).base_files))
+        assert result.subgoals["test_calc.py::test_subtract"] is True
+        assert reward.scalar == 0.0
+        assert reward.components == {"test_calc.py::test_add": 0.0}
+
+    def test_breaking_a_passing_test_forfeits_the_fix(self) -> None:
+        instance = load_instance(_INSTANCE)
+        tree = {
+            **instance.base_files,
+            "calc/core.py": "def add(a, b):\n    return a + b\n\n\n"
+            "def subtract(a, b):\n    return a + b\n",
+        }
+        result, reward = self._reward(tree)
+        assert result.subgoals["test_calc.py::test_add"] is True
+        assert result.subgoals["test_calc.py::test_subtract"] is False
+        assert reward.scalar == 0.0
+
+    def test_the_gold_tree_still_scores_one(self) -> None:
+        instance = load_instance(_INSTANCE)
+        result, reward = self._reward({**instance.base_files, **instance.gold_files})
+        assert result.success
+        assert reward.scalar == 1.0
+        assert reward.components == {"test_calc.py::test_add": 1.0}
 
 
 class TestRealizer:

--- a/tests/test_swe_pack.py
+++ b/tests/test_swe_pack.py
@@ -30,7 +30,13 @@ from swe.builder import SweBuilder
 from swe.grading import _nodeid
 from swe.instances import SweInstance, load_instance, to_graph
 from swe.realize import SweRuntime
-from swe.sandbox import _bwrap_wrap, run_sandboxed
+from swe.sandbox import (
+    _bwrap_usable,
+    _bwrap_wrap,
+    _select_backend,
+    _verify_backend_request,
+    run_sandboxed,
+)
 from swe.swebench import instance_from_row
 
 from openrange.core.episode import EpisodeReport
@@ -393,6 +399,54 @@ class TestSandbox:
             ["-c", "import time; time.sleep(10)"], root=tmp_path, timeout=2
         )
         assert res.timed_out
+
+    def test_a_secret_in_the_environment_does_not_reach_the_child(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The child runs repo-supplied test code. A canary standing in for the
+        # API keys and CI tokens a real operator has exported must not be
+        # readable from it.
+        monkeypatch.setenv("OPENRANGE_CANARY_TOKEN", "sk-do-not-leak")
+        read_canary = (
+            "import os; print(os.environ.get('OPENRANGE_CANARY_TOKEN', 'ABSENT'))"
+        )
+        res = run_sandboxed(["-c", read_canary], root=tmp_path, timeout=10)
+        assert res.ok
+        assert "sk-do-not-leak" not in res.stdout
+        assert "ABSENT" in res.stdout
+
+    def test_the_child_keeps_what_a_test_run_needs(self, tmp_path: Path) -> None:
+        res = run_sandboxed(
+            ["-c", "import os; print(bool(os.environ.get('PATH')))"],
+            root=tmp_path,
+            timeout=10,
+        )
+        assert "True" in res.stdout
+
+    def test_backend_selection_is_pure_and_total(self) -> None:
+        assert _select_backend("bwrap", usable=True) == "bwrap"
+        assert _select_backend("auto", usable=True) == "bwrap"
+        assert _select_backend("auto", usable=False) == "none"
+        assert _select_backend("none", usable=True) == "none"
+
+    def test_an_unhonourable_isolation_request_is_refused_at_setup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Silently downgrading reports success while running untrusted code less
+        # isolated than asked. The refusal has to happen at setup: raised from
+        # inside a feasibility check it reads as "this task is infeasible", and a
+        # seeding pass then yields an empty pool with nothing logged.
+        monkeypatch.setenv("OPENRANGE_SWE_SANDBOX", "bwrap")
+        if _bwrap_usable():
+            pytest.skip("bwrap is usable here, so the request is honourable")
+        with pytest.raises(RuntimeError, match="not usable"):
+            _verify_backend_request()
+
+    def test_the_default_request_is_always_honourable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENRANGE_SWE_SANDBOX", raising=False)
+        _verify_backend_request()  # must not raise on any host
 
     def test_bwrap_argv_isolates_net_only_when_disabled(self) -> None:
         with_net = _bwrap_wrap(["x"], root=Path("/w"), network=True)

--- a/tests/test_swe_pack.py
+++ b/tests/test_swe_pack.py
@@ -33,7 +33,6 @@ from swe.realize import SweRuntime
 from swe.sandbox import (
     _bwrap_usable,
     _bwrap_wrap,
-    _select_backend,
     run_sandboxed,
     verify_backend_request,
 )
@@ -422,12 +421,6 @@ class TestSandbox:
             timeout=10,
         )
         assert "True" in res.stdout
-
-    def test_backend_selection_is_pure_and_total(self) -> None:
-        assert _select_backend("bwrap", usable=True) == "bwrap"
-        assert _select_backend("auto", usable=True) == "bwrap"
-        assert _select_backend("auto", usable=False) == "none"
-        assert _select_backend("none", usable=True) == "none"
 
     def test_an_unhonourable_isolation_request_is_refused_at_setup(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_trading_pack.py
+++ b/tests/test_trading_pack.py
@@ -23,6 +23,9 @@ from trading.families.backtest import perfect_foresight_return, run_backtest
 from trading.invariants import account_can_trade, bars_contiguous, ohlc_sane
 from trading.sampling import _select_window
 
+from openrange.core.episode import EpisodeReport
+from openrange.training import episode_reward
+
 _DEFAULT_SEED = 7
 _DEFAULT_WINDOW_DAYS = 180
 _DEFAULT_PRODUCT = "BTC-USD"
@@ -309,6 +312,25 @@ class TestBacktestGrader:
         assert not outcome.success
         assert "pnl=" in outcome.reason
         assert set(outcome.subgoals) == {"return_target_met", "drawdown_ok"}
+
+    def test_staying_out_of_the_market_earns_nothing(self, tmp_path: Path) -> None:
+        # Flat equity draws down nothing, so uniform credit over the subgoal
+        # vector would pay an all-cash strategy half of this task.
+        result = _build(tmp_path)
+        task = result.tasks[0]
+        outcome = TradePnl().check_success(
+            result.graph,
+            task,
+            {"result": {"strategy": "def decide(history):\n    return 0.0\n"}},
+        )
+        reward = episode_reward(
+            EpisodeReport(
+                snapshot_id="sha256:trading", task_id=task.id, episode_result=outcome
+            )
+        )
+        assert outcome.subgoals["drawdown_ok"] is True
+        assert reward.scalar == 0.0
+        assert reward.components == {"return_target_met": 0.0}
 
     def test_missing_strategy_field_fails_cleanly(self, tmp_path: Path) -> None:
         result = _build(tmp_path)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -235,13 +235,18 @@ class TestTrajectory:
 class TestEpisodeRun:
     def test_bundles_report_turns_and_shapes_trajectory(self) -> None:
         report = _report(success=True, subgoals={"t1": True}, reason="green")
-        run = EpisodeRun(report=report, turns=(AgentTurn(message="done"),))
+        run = EpisodeRun(
+            report=report,
+            reward=episode_reward(report),
+            turns=(AgentTurn(message="done"),),
+        )
         assert run.success is True
         assert run.reward.scalar == 1.0
         assert [s.message for s in run.trajectory.steps] == ["done"]
 
     def test_defaults_to_zero_step_trajectory(self) -> None:
-        run = EpisodeRun(report=_report(success=False, subgoals={"t1": False}))
+        report = _report(success=False, subgoals={"t1": False})
+        run = EpisodeRun(report=report, reward=episode_reward(report))
         assert run.success is False
         assert run.reward.scalar == 0.0
         assert run.trajectory.steps == ()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -7,6 +7,7 @@ records, and the JSON / JSONL export a trainer consumes.
 
 from __future__ import annotations
 
+import itertools
 import json
 from collections.abc import Mapping
 
@@ -77,17 +78,6 @@ class TestRewardBaseline:
     anything, so uniform credit pays an agent that changes nothing.
     """
 
-    def test_preconditions_are_not_credited(self) -> None:
-        reward = episode_reward(
-            _report(
-                success=False,
-                subgoals={"f2p": False, "p2p_a": True, "p2p_b": True},
-                baseline={"p2p_a": True, "p2p_b": True},
-            )
-        )
-        assert reward.scalar == 0.0
-        assert reward.components == {"f2p": 0.0}
-
     def test_partial_credit_is_over_the_earnable_subgoals(self) -> None:
         reward = episode_reward(
             _report(
@@ -135,25 +125,45 @@ class TestRewardBaseline:
         assert reward.components == {"f2p": 1.0}
 
 
-class TestRewardError:
-    """An episode that graded nothing still shapes to 0.0.
+class TestRewardInvariants:
+    """The two properties the shaper exists to hold, over every small shape.
 
-    ``error`` does not change the scalar — a trainer reading a batch needs a
-    number for every rollout. It marks the episode as a non-measurement so the
-    consumers that *can* exclude it (the pool, a metrics pass) know to.
+    Enumerated rather than sampled: the space is finite and tiny, so this is an
+    exhaustive proof rather than a search. Both are inexpressible before
+    ``baseline`` existed — they specify the fix instead of recording it.
     """
 
-    def test_an_errored_episode_still_scores_zero(self) -> None:
-        report = _report(success=False, subgoals={})
-        errored = EpisodeReport(
-            snapshot_id=report.snapshot_id,
-            task_id=report.task_id,
-            episode_result=EpisodeResult(
-                success=False, reason="grading failed", error="TimeoutExpired"
-            ),
-        )
-        assert episode_reward(errored).scalar == 0.0
-        assert episode_reward(errored).components == {}
+    @staticmethod
+    def _earned(bits: tuple[bool, ...]) -> dict[str, bool]:
+        return {f"f{i}": bit for i, bit in enumerate(bits)}
+
+    def test_a_free_subgoal_never_moves_the_score(self) -> None:
+        for bits in itertools.product([True, False], repeat=3):
+            earned = self._earned(bits)
+            alone = episode_reward(_report(success=False, subgoals=earned))
+            with_free = episode_reward(
+                _report(
+                    success=False,
+                    subgoals={**earned, "free": True},
+                    baseline={"free": True},
+                )
+            )
+            assert alone.scalar == with_free.scalar, bits
+
+    def test_breaking_a_precondition_forfeits_the_attempt(self) -> None:
+        # Not merely "scores lower" — that is true of any uniform mean, so it
+        # would pass against the shaper this replaces. Handing back a world
+        # more broken than it arrived is worth nothing, whatever else was
+        # earned alongside it.
+        for bits in itertools.product([True, False], repeat=3):
+            broke = episode_reward(
+                _report(
+                    success=False,
+                    subgoals={**self._earned(bits), "p": False},
+                    baseline={"p": True},
+                )
+            )
+            assert broke.scalar == 0.0, bits
 
 
 class TestTrajectory:

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -12,9 +12,11 @@ from collections.abc import Mapping
 
 from openrange_pack_sdk import EpisodeResult
 
+from openrange.agent import AgentRollout
 from openrange.core.episode import AgentTurn, EpisodeReport
 from openrange.training import (
     EpisodeRun,
+    Reward,
     episode_reward,
     episode_trajectory,
     to_jsonl,
@@ -191,6 +193,23 @@ class TestTrajectory:
         assert traj.steps == ()
         assert traj.reward.scalar == 0.0
         assert traj.success is False
+
+    def test_a_rollout_exports_the_reward_it_was_graded_with(self) -> None:
+        # The trajectory is what a trainer consumes, so it has to carry the
+        # objective the caller actually ran, not the built-in one.
+        report = _report(success=False, subgoals={"free": True, "earned": False})
+        only_earned = Reward(scalar=0.0, components={"earned": 0.0})
+        rollout = AgentRollout(
+            snapshot_id=report.snapshot_id,
+            task_id=report.task_id,
+            steps=(),
+            turns=(),
+            report=report,
+            reward=only_earned,
+            terminal_reason="done",
+        )
+        assert episode_reward(report).scalar == 0.5  # what the default would say
+        assert rollout.reward == rollout.trajectory.reward
 
     def test_as_dict_is_json_serializable(self) -> None:
         report = _report(

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -28,12 +28,16 @@ def _report(
     reason: str = "",
     snapshot_id: str = "sha256:world",
     task_id: str = "swe.fix.calc",
+    baseline: Mapping[str, bool] | None = None,
 ) -> EpisodeReport:
     return EpisodeReport(
         snapshot_id=snapshot_id,
         task_id=task_id,
         episode_result=EpisodeResult(
-            success=success, subgoals=dict(subgoals), reason=reason
+            success=success,
+            subgoals=dict(subgoals),
+            reason=reason,
+            baseline=dict(baseline or {}),
         ),
     )
 
@@ -62,6 +66,92 @@ class TestReward:
         # success is the gate: a pack may green an episode with no subgoals.
         reward = episode_reward(_report(success=True, subgoals={}))
         assert reward.scalar == 1.0
+
+
+class TestRewardBaseline:
+    """A subgoal the world hands over is not partial credit.
+
+    The shape is ``swe.fix``: ``pass_to_pass`` is green before the agent edits
+    anything, so uniform credit pays an agent that changes nothing.
+    """
+
+    def test_preconditions_are_not_credited(self) -> None:
+        reward = episode_reward(
+            _report(
+                success=False,
+                subgoals={"f2p": False, "p2p_a": True, "p2p_b": True},
+                baseline={"p2p_a": True, "p2p_b": True},
+            )
+        )
+        assert reward.scalar == 0.0
+        assert reward.components == {"f2p": 0.0}
+
+    def test_partial_credit_is_over_the_earnable_subgoals(self) -> None:
+        reward = episode_reward(
+            _report(
+                success=False,
+                subgoals={"f2p_a": True, "f2p_b": False, "p2p": True},
+                baseline={"p2p": True},
+            )
+        )
+        assert reward.scalar == 0.5
+        assert reward.components == {"f2p_a": 1.0, "f2p_b": 0.0}
+
+    def test_a_regressed_precondition_is_worth_nothing(self) -> None:
+        reward = episode_reward(
+            _report(
+                success=False,
+                subgoals={"f2p": True, "p2p": False},
+                baseline={"p2p": True},
+            )
+        )
+        assert reward.scalar == 0.0
+        # The broken precondition is back in the vector: dropped, the loss is
+        # invisible to every consumer that reads components rather than scalar.
+        assert reward.components == {"f2p": 1.0, "p2p": 0.0}
+
+    def test_nothing_earnable_is_zero(self) -> None:
+        reward = episode_reward(
+            _report(
+                success=False,
+                subgoals={"p2p": True},
+                baseline={"p2p": True},
+            )
+        )
+        assert reward.scalar == 0.0
+        assert reward.components == {}
+
+    def test_solved_still_scores_one_over_the_earnable_set(self) -> None:
+        reward = episode_reward(
+            _report(
+                success=True,
+                subgoals={"f2p": True, "p2p": True},
+                baseline={"p2p": True},
+            )
+        )
+        assert reward.scalar == 1.0
+        assert reward.components == {"f2p": 1.0}
+
+
+class TestRewardError:
+    """An episode that graded nothing still shapes to 0.0.
+
+    ``error`` does not change the scalar — a trainer reading a batch needs a
+    number for every rollout. It marks the episode as a non-measurement so the
+    consumers that *can* exclude it (the pool, a metrics pass) know to.
+    """
+
+    def test_an_errored_episode_still_scores_zero(self) -> None:
+        report = _report(success=False, subgoals={})
+        errored = EpisodeReport(
+            snapshot_id=report.snapshot_id,
+            task_id=report.task_id,
+            episode_result=EpisodeResult(
+                success=False, reason="grading failed", error="TimeoutExpired"
+            ),
+        )
+        assert episode_reward(errored).scalar == 0.0
+        assert episode_reward(errored).components == {}
 
 
 class TestTrajectory:

--- a/tests/test_trl_adapter.py
+++ b/tests/test_trl_adapter.py
@@ -502,6 +502,25 @@ class TestTrajectoryExport:
         with pytest.raises(RuntimeError, match="no completed episode"):
             env_trajectory(env)
 
+    def test_export_carries_the_envs_own_objective(self, tmp_path: Path) -> None:
+        # The env grades with `reward_fn`; the exported trajectory is what a
+        # trainer reads back. Disagreement means the JSONL teaches a different
+        # objective than the one being optimized.
+        snapshot = _admit("calc_sum")
+        service = EpisodeService(SwePack(), tmp_path / "objective")
+        try:
+            env = EpisodeEnv(
+                service=service,
+                snapshots={snapshot.snapshot_id: snapshot},
+                tools=FILE_TOOLS,
+                reward_fn=lambda report: Reward(scalar=0.25),
+            )
+            env.reset(snapshot_id=snapshot.snapshot_id)
+            _solve(env, "calc_sum")  # a solve the default would score 1.0
+            assert env_trajectory(env).reward.scalar == 0.25
+        finally:
+            service.close()
+
 
 class TestEnvFactory:
     def test_factory_isolates_concurrent_envs(self, tmp_path: Path) -> None:

--- a/tests/test_trl_adapter.py
+++ b/tests/test_trl_adapter.py
@@ -14,6 +14,7 @@ the same path the SWE pack's own tests take.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Mapping
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -437,6 +438,37 @@ class TestRewardFunc:
         # its PASS_TO_PASS test was green before it started — distinct, and in
         # env order.
         assert reward_func(environments=[solved, unsolved]) == [1.0, 0.0]
+
+    def test_an_ungraded_rollout_takes_the_group_mean(self, tmp_path: Path) -> None:
+        # GRPO learns from the spread within a group, so a crashed grader's 0.0
+        # is a penalty for whatever the policy happened to do. The group mean
+        # carries zero advantage, which is what "measured nothing" deserves.
+        snapshot = _admit("calc_sum")
+        broken = replace(
+            snapshot,
+            tasks=(replace(snapshot.tasks[0], success_check="swe.no_such_family"),),
+        )
+        service = EpisodeService(SwePack(), tmp_path / "grp")
+        try:
+            solved = EpisodeEnv(
+                service=service,
+                snapshots={snapshot.snapshot_id: snapshot},
+                tools=FILE_TOOLS,
+            )
+            solved.reset(snapshot_id=snapshot.snapshot_id)
+            _solve(solved, "calc_sum")
+            ungraded = EpisodeEnv(
+                service=service, snapshots={broken.snapshot_id: broken}
+            )
+            ungraded.reset(snapshot_id=broken.snapshot_id)
+
+            rewards = make_reward_func()(environments=[solved, ungraded])
+            assert ungraded.report is not None
+            assert ungraded.report.episode_result.error is not None
+            # Only the solved rollout graded, so the mean is its own reward.
+            assert rewards == [1.0, 1.0]
+        finally:
+            service.close()
 
     def test_reward_func_is_idempotent(self, make_env: EnvMaker) -> None:
         env, snap = make_env("calc_sum")

--- a/tests/test_trl_adapter.py
+++ b/tests/test_trl_adapter.py
@@ -274,10 +274,10 @@ class TestEnvLifecycle:
         env._finalize()
         assert env.report is not None
         assert not env.report.passed
-        # The bug (FAIL_TO_PASS) stays red, but the trivially-passing
-        # PASS_TO_PASS test floors the dense reward at 0.5 — not zero, and
-        # strictly below the gold's 1.0, so the group still has spread.
-        assert env.reward == 0.5
+        # The bug (FAIL_TO_PASS) stays red. PASS_TO_PASS is green before the
+        # agent touches anything, so it is a precondition, not partial credit:
+        # an untouched workspace earns nothing.
+        assert env.reward == 0.0
 
     def test_build_partial_credit_is_dense(self, make_env: EnvMaker) -> None:
         # notes_app (swe.build): the bare skeleton fails every tier -> 0.0, but
@@ -362,10 +362,13 @@ class TestRewardSpread:
     ``apply_patch`` tool to each distinct grade ``calc_sum`` admits — proving the
     spread is real and, just as importantly, mapping the trap a weak policy falls
     into: ``return a - b`` appears in *both* ``add`` and ``subtract``, so the
-    naive replace-all fixes ``add`` but breaks ``subtract`` and nets right back to
-    the 0.5 floor. Only the *targeted* edit reaches 1.0, so "learn to target the
-    add block" is exactly the climb the gradient rewards. This is the
-    deterministic floor under the live signal the notebook demonstrates at scale.
+    naive replace-all fixes ``add`` but breaks ``subtract`` — a regression, worth
+    nothing, exactly like touching nothing at all. Only the *targeted* edit
+    reaches 1.0, so "learn to target the add block" is exactly the climb the
+    gradient rewards. ``calc_sum`` declares one ``fail_to_pass`` test, so its
+    earned signal is binary by construction; the dense case is ``notes_app``
+    above, whose tiers are all earnable. This is the deterministic floor under
+    the live signal the notebook demonstrates at scale.
     """
 
     def _reward_after(
@@ -400,9 +403,10 @@ class TestRewardSpread:
             snapshot,
             lambda e: e.apply_patch("calc/core.py", "return a - b", "return a + b"),
         )
-        # FAIL_TO_PASS test_add now greens, but PASS_TO_PASS test_subtract reds:
-        # one subgoal each way -> the same 0.5 an untouched workspace earns.
-        assert reward == 0.5
+        # FAIL_TO_PASS test_add now greens, but PASS_TO_PASS test_subtract reds.
+        # Regressing a precondition forfeits the fix, so the trap earns exactly
+        # what touching nothing earns — and strictly less than the targeted edit.
+        assert reward == 0.0
 
     def test_breaking_pass_to_pass_sinks_below_the_floor(
         self, make_env: EnvMaker
@@ -417,7 +421,7 @@ class TestRewardSpread:
                 "def subtract(a, b):\n    return a * b",
             ),
         )
-        # Both tests red now -> below the floor, the bottom of the spread.
+        # Both tests red: the bug unfixed and a precondition regressed.
         assert reward == 0.0
 
 
@@ -429,9 +433,10 @@ class TestRewardFunc:
         unsolved, snap2 = make_env("calc_sum")
         unsolved.reset(snapshot_id=snap2.snapshot_id)
         reward_func = make_reward_func()
-        # Solved earns the full 1.0; the untouched base floors at 0.5 (its
-        # PASS_TO_PASS test passes for free) — distinct, and in env order.
-        assert reward_func(environments=[solved, unsolved]) == [1.0, 0.5]
+        # Solved earns the full 1.0; the untouched base earns nothing, because
+        # its PASS_TO_PASS test was green before it started — distinct, and in
+        # env order.
+        assert reward_func(environments=[solved, unsolved]) == [1.0, 0.0]
 
     def test_reward_func_is_idempotent(self, make_env: EnvMaker) -> None:
         env, snap = make_env("calc_sum")


### PR DESCRIPTION
## The number this starts from

`episode_reward` averaged `EpisodeResult.subgoals` uniformly. But packs report subgoals the world
already satisfies before the agent is handed it, so **a policy that does nothing was paid for them.**

**`swe.fix`** — `check_feasibility` rejects a task unless every `pass_to_pass` test is green in the
base tree (`packs/swe/swe/families/fix.py`), and `check_success` reports `fail_to_pass +
pass_to_pass` as the subgoal set. A policy that never edits a file therefore scores exactly

```
|p2p| / (|f2p| + |p2p|)
```

0.4 on the shipped `shapes_area` fixture, 0.5 on `calc_sum`, and **above 0.9** on an imported
instance whose `pass_to_pass` set is the repository's existing suite — the shape
`swe.swebench.instance_from_row` exists to load.

**`trading.pnl`** — the subgoals are `return_target_met` and `drawdown_ok`. Flat equity draws down
nothing, so **holding cash scores 0.5**.

`WorldPool` ranks worlds on that number, and every trainer optimizes it.

The suite had encoded this as intended behaviour. On `main`,
`tests/test_trl_adapter.py::TestEnvLifecycle::test_untouched_base_does_not_resolve` asserts
`env.reward == 0.5` and explains it in a comment: *"the trivially-passing PASS_TO_PASS test floors
the dense reward at 0.5"*.

## What this is

One defect with several expressions: **OpenRange reported outcomes it had not established.**

A reward credited work the agent never did. An infrastructure failure was recorded as an agent
failure. An isolation guarantee was reported as obtained after being silently downgraded. A
content-addressed id was trusted as identity without ever being checked against its content. A
builder crash was filed as a capability the builder had declined. And CI reported a pass over a
suite it never ran and a typecheck over half the files.

They are one PR rather than several because they are one bug — and because two of them, each
correct in isolation, were wrong in combination. Twice. See *Composition*.

## What changes

| Area | Before | After |
|---|---|---|
| **Reward** | uniform credit over all subgoals | `EpisodeResult.baseline` records what each subgoal was worth before the agent acted; only the remainder is credited, and a regressed precondition forfeits the attempt |
| **Ungraded episodes** | a crashed grader or a timed-out suite graded `0.0`, indistinguishable from a wrong answer | `EpisodeResult.error` marks it; the pool prices a world only on the episodes that graded, `solve_rate` drops the rest from the denominator, and GRPO gets the group mean — zero advantage — instead of a penalty |
| **Admission** | an unreported test suite is all-`False`, which *satisfies* `all_fail`, so a world could admit with its bug never demonstrated | admission fails closed on an errored suite |
| **Pack trust** | `Builder.repair`'s SDK default raises and `admit()` called it bare at the shipped `max_repairs=2`, so `AdmissionFailure` was unreachable for any pack taking the documented opt-out; a raising `check_feasibility` aborted the whole build; and *every* exception from `repair()` was recorded as "builder did not repair" | the opt-out yields the documented `AdmissionFailure`; a check that cannot answer rejects its own task and the build continues; a crash inside a `repair()` that *is* implemented is recorded as a crash, with its message |
| **Seeding diagnostics** | `_gated_members` dropped every `AdmissionFailure` with a bare `continue` — 200 rejected manifests produced an empty pool, no exception and no log | the rejection is logged with the build history, which is where a *raising* check's exception text lives (there is no `Issue` for it) |
| **Resource lifetime** | the warm pool dropped the runtime it displaced; a raise between `start_episode` and grading stranded the episode and its realized world; one failed rollout cancelled its siblings mid-episode | each is guarded, and the batch settles before the failure is surfaced |
| **Registries** | a single malformed entry point returned a partial registry — silently, for the process lifetime, since `PACKS` is a module singleton | the sweep is marked done only once it completes |
| **Isolation** | `OPENRANGE_SWE_SANDBOX=bwrap` on a host without a usable bwrap ran a bare subprocess and reported success; the graded child inherited the operator's full environment | the request is refused at pack setup; the child gets an allowlist |
| **Snapshot integrity** | `SnapshotStore.load` compared the stored `snapshot_id` field to the filename — both are names, neither is the content, so a graph edited under its own id loaded clean | `load` rehashes the reconstructed graph (1.6 ms on the largest shipped pack, 184 nodes; one caller, loading once) |
| **Exported reward** | `episode_trajectory` always called `episode_reward`, so a caller running its own objective exported a different number than it optimized — inside one `AgentRollout`, `.reward` and `.trajectory.reward` disagreed | the graded reward is passed through to the trajectory a trainer consumes |
| **Reply classification** | a reply with no recognized block was reported as `finish`, so "never produced an action" and "chose to stop with this answer" reached the trainer as the same outcome; an empty `content` from a provider was accepted as text | `terminal_reason="no_action"`; an empty completion is an `LLMBackendError` naming the `finish_reason` |
| **CI** | a positional argument to `pytest` overrode the declared `testpaths`, so 176 tests never ran; mypy covered 88 of 164 files | CI runs the declared suite, counts all eight distributions for coverage, and typechecks the packs and SDK — which surfaced a live crash (below) |

## Why this is worth landing

Every item above is load-bearing for something the repository already claims.

- **README:** *"Solvable by construction. Every task is admission-checked against the realized world
  before an episode starts."* That is false while an unreported suite satisfies `all_fail` — a world
  could admit with its bug never demonstrated.
- **A curriculum is only as good as its input signal.** Ranking worlds on a reward that pays for
  inherited state, and on a solve rate deflated by infrastructure flake, optimizes noise.
- **A guarantee that is reported but not obtained is worse than none**, because it gets relied on.
  The old `_select_backend`'s explicit-`bwrap` arm was byte-identical to the auto fallthrough.
- **A content hash that is never recomputed is a label**, and the store, the pool member key,
  curriculum lineage and the dataset rows all read it as identity.
- **176 tests that never ran** include `graphschema`'s
  `test_content_hash_deterministic_for_identical_graphs`, which is what `snapshot_id` rests on. The
  76 files mypy never read include `sample_graph`, whose documented `prior=None` default raised
  `AttributeError: 'NoneType' object has no attribute 'topology'`.

## Composition

This is the argument for one PR rather than a dozen. None of the following was visible in any single
branch; each appeared only when the merged tree was run against an adversary.

**0. The error channel handed the agent a way to erase a failure.** `EpisodeResult.error` marks an
episode that graded nothing, and the pool drops it from the denominator. Both correct — until you
notice the agent writes files into the tree the grader runs. A two-line `conftest.py`
(`import time; time.sleep(600)`) makes the suite report nothing:

```
4 rollouts, 1 real solve + 3 real failures
  honest   -> _mean_pass_rate 0.2500     (true rate 0.25)
  farming  -> _mean_pass_rate 1.0000
```

and GRPO paid that rollout the group mean — `+0.3333` against `0.0000` for failing honestly, so
failing loudly strictly dominated failing honestly. On `main` both read `0.25`. This PR introduced it
and this PR closes it: the grader now runs only the paths the world declared, so `error` stays
something the harness sets and the agent cannot. The same filter closes a preexisting hole where a
`pytest.ini` plus a tryfirst plugin scored **1.0 on all three shipped fixtures** without editing a
line of source.

**1. Two correct fixes produced a silently empty world pool.** The isolation refusal was originally
raised from inside `check_feasibility`. Admission — correctly — reads any exception there as *"this
task is infeasible"*, and `_gated_members` skipped an `AdmissionFailure` with a bare `continue`.
Composed, an unhonourable isolation request yielded **a world pool with zero members, no exception
and no log line** — strictly worse than the silent downgrade it replaced.

**2. Fixing that broke pack discovery for every pack.** Moving the refusal to module import made
`import swe.sandbox` raise, so loading the `swe` entry point raised, so the registry sweep raised —
and the registry fix above deliberately declines to mark an incomplete sweep as done. Composed,
`PACKS.ids()` raised on every call for the life of the process:

```
OPENRANGE_SWE_SANDBOX=bwrap, PACKS.ids() called three times in one process
  main       ('swe', 'trading', 'webapp')  x3
  composed   PackError: failed to load pack entry point 'swe'   x3
```

`trading` and `webapp` never touch the swe sandbox and became unreachable. Where the check runs is
as much the fix as the check itself: it now lives in `SwePack.make_builder` — a setup call admission
leaves bare on purpose, reached by every use of that pack and by no use of any other.

Both failures shared one root cause, which is why the seeding-diagnostics row above is in this PR:
admission failing closed was **completely silent**, so neither had a symptom to read.

## Verification

The CI fix is a scope change, and the scope is the claim: `pytest`'s positional argument overrode
the declared `testpaths`, so **the `graphschema` and `openrange-pack-sdk` suites never ran on a pull
request** — including `test_content_hash_deterministic_for_identical_graphs`, which is what
`snapshot_id` rests on. Both now run, and coverage counts all eight distributions rather than four.
Typecheck goes from 88 files to 164.

Every test that had stopped running passes unchanged. Exact counts are left to the checks below
rather than quoted here, since they move with every commit.

Every fix is red-green isolated: reverting the source change on its own fails exactly its own tests
and no others. Lint, format, boundary scan, `mypy` over all 164 files, the full declared suite and
coverage all run in the checks below.

## Notes for review

- **Existing tests asserted the defective behaviour and are rewritten, not deleted.**
  `test_admit_default_repair_raises_when_called` asserted the crash — the SDK documents *not*
  overriding `repair` as the sanctioned opt-out, so the crash was never the contract — and two in
  `TestRewardSpread` pinned the inflated reward, one of them explaining in a comment that the
  `PASS_TO_PASS` test "passes for free". Each is re-derived from the stated contract rather than
  from a run.
- **A deliberate consequence:** on a task with a single `fail_to_pass` test the reward is now
  binary. The previous density came from counting a free subgoal. Real density needs several
  *earnable* subgoals — `notes_app` / `swe.build` remains the dense fixture.
- **`_member_priority` changed signature** to take `Sequence[Reward]`. It is private, and the change
  means a caller-supplied `reward_fn` — which may be expensive — runs once per report, not twice.
- **Deliberately not decided here:** whether a completion truncated at `max_tokens` should be
  excluded from training. Unlike a crashed grader, running out of tokens is inside the policy's
  control and is arguably signal. It is now visible (`terminal_reason="no_action"`) rather than
  silently classified.
- **Deliberately not fixed here:** `snapshot_id` is a hash of the graph alone, but core reads four
  manifest keys at run time (`runtime.backing`, `runtime.tick.*`, `npc[]`). Two worlds differing
  only in one of those share an id, a store filename and a pool member — last writer wins. Changing
  what a snapshot id covers is a contract change (it touches `CONTRACTS.md`'s published field, needs
  a public SDK helper, and invalidates every stored id), and it is a different subject from this
  PR. `DESIGN.md` claimed core reads two manifest keys; that sentence is corrected here, and now
  names the aliasing as a known constraint rather than leaving it undocumented.
- **`WorldPool.update` gained a documented precondition** rather than defensive bookkeeping: a
  member that `round_rows` offered must come back with a key even when every episode errored.
  Reconstructing that inside the pool would mean an attribute plus a hidden ordering between two
  public methods, to recover what the caller already knows.

## The same defect, found in three more places

An adversarial pass over the merged tree turned up the same shape — *a score that measures
something other than what the agent did* — in three places this PR had not reached. All are fixed
here, because leaving any of them makes the PR's own claim untrue:

- **`webapp.pentest` credited NPC traffic to the agent.** `reached_endpoint` read the server request
  log, which recorded no origin, so a policy that did nothing for five seconds scored **0.3333**
  under the manifest `examples/strands_eval.py` ships (`npc: []` scored `0.0`). The log now records
  who asked; only agent-origin rows count. A single agent request still sets it, so the reward
  spread `test_trl_cyber` pins is unchanged.
- **`swe.build` admitted partly-built skeletons.** Feasibility ran the base tree over the
  integration gate only, so a skeleton already greening a unit test admitted and paid that unit to
  an agent that did nothing. It now runs the base tree over the whole suite — the same invocation
  with more ids, so it costs nothing — and refuses such a world. A build task's project is meant to
  be unbuilt, so the gate is the honest fix and no `baseline` is needed.
- **The isolation refusal was in the wrong place.** It sat on `SwePack.make_builder`, so a world
  built in one process and graded in another never passed it. `run_sandboxed` is the only seam that
  knows what the child actually got, so it refuses there now; the setup call stays so the ordinary
  path still fails with the right category.

Also: three pack/caller failures inside `auto_evolve` — a raising evolve, a raising gate, a failing
regrow — each returned `None` with nothing logged at any level, leaving a frozen frontier
indistinguishable from a curriculum with nothing left to propose. Each now logs with the parent
snapshot id and a traceback.
